### PR TITLE
Add Theia remote plugin runner with Java 8 runtime

### DIFF
--- a/dockerfiles/remote-plugin-runner-java/Dockerfile
+++ b/dockerfiles/remote-plugin-runner-java/Dockerfile
@@ -1,0 +1,4 @@
+FROM wsskeleton/theia-endpoint-runtime
+RUN apk --no-cache add openjdk8
+ENV JAVA_HOME /usr/lib/jvm/default-jvm/
+WORKDIR /projects

--- a/dockerfiles/remote-plugin-runner-java/Dockerfile
+++ b/dockerfiles/remote-plugin-runner-java/Dockerfile
@@ -1,4 +1,0 @@
-FROM wsskeleton/theia-endpoint-runtime
-RUN apk --no-cache add openjdk8
-ENV JAVA_HOME /usr/lib/jvm/default-jvm/
-WORKDIR /projects

--- a/dockerfiles/remote-plugin-runner-java8/Dockerfile
+++ b/dockerfiles/remote-plugin-runner-java8/Dockerfile
@@ -1,0 +1,14 @@
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+FROM wsskeleton/theia-endpoint-runtime
+RUN apk --no-cache add openjdk8
+ENV JAVA_HOME /usr/lib/jvm/default-jvm/
+WORKDIR /projects


### PR DESCRIPTION
Add Dockerfile for an image that can run Theia plugin runner sidecar that depends on Java 8