### PR TITLE
Rename containers plugin

### DIFF
--- a/plugins/containers-plugin/package.json
+++ b/plugins/containers-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "containers-plugin",
+  "name": "@eclipse-che/theia-containers-plugin",
   "publisher": "theia",
   "keywords": [
     "theia-plugin"


### PR DESCRIPTION
Change name of Pontainers Plugin to `@eclipse-che/theia-containers-plugin`

Signed-off-by: Vitaliy Guliy <vgulyy@redhat.com>