### PR TITLE
Build che-theia plugins from che-theia-dev builder container rather than getting it from released travis built

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -82,6 +82,46 @@ RUN che:theia production
 # change permissions
 RUN find production -exec sh -c "chgrp 0 {}; chmod g+rwX {}" \; 2>log.txt
 
+
+###
+# Plugin Builder Image
+#
+FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-dev:${BUILD_TAG} as plugins-builder
+WORKDIR ${HOME}
+
+# define in env variable GITHUB_TOKEN only if it is defined
+# else check if github rate limit is enough, else will abort requiring to set GITHUB_TOKEN value
+ARG GITHUB_TOKEN
+
+# Define che-theia branch to use for plugins
+ARG CHE_THEIA_PLUGIN_BRANCH=master
+
+# Check github limit
+RUN if [ ! -z "${GITHUB_TOKEN-}" ]; then \
+      export GITHUB_TOKEN=$GITHUB_TOKEN; \
+      echo "Setting GITHUB_TOKEN value as provided"; \
+    else \
+      export GITHUB_LIMIT=$(curl -s 'https://api.github.com/rate_limit' | jq '.rate .remaining'); \
+      echo "Current API rate limit https://api.github.com is ${GITHUB_LIMIT}"; \
+      if [ "${GITHUB_LIMIT}" -lt 10 ]; then \
+        printf "\033[0;31m\n\n\nRate limit on https://api.github.com is reached so in order to build this image, "; \
+        printf "the build argument GITHUB_TOKEN needs to be provided so build will not fail.\n\n\n\033[0m"; \
+        exit 1; \
+      else \
+        echo "GITHUB_TOKEN variable is not set but https://api.github.com rate limit has enough slots"; \
+      fi \
+    fi
+
+# Clone and build che-theia plugins
+RUN git clone --branch ${CHE_THEIA_PLUGIN_BRANCH}  --single-branch --depth 1 https://github.com/eclipse/che-theia ${HOME}/che-theia-source-code
+
+WORKDIR ${HOME}/che-theia-source-code/plugins/
+RUN yarn
+
+RUN mkdir -p ${HOME}/che-theia-plugins/ && \
+    find ${HOME}/che-theia-source-code/plugins/ -name "*.theia"  -exec sh -c "chgrp 0 {}; chmod g+rwX {}; cp {} ${HOME}/che-theia-plugins/" \; 2>log.txt
+
+
 ###
 # Runtime Image
 #
@@ -96,6 +136,8 @@ ENV USE_LOCAL_GIT=true \
 
 EXPOSE 3100 3130
 
+COPY --from=plugins-builder /home/theia-dev/che-theia-plugins /default-theia-plugins
+
 # Install sudo
 # Install git
 # Install bzip2 to unpack files
@@ -108,12 +150,8 @@ RUN adduser --disabled-password -S -u 1001 -G root -h ${HOME} -s /bin/sh theia \
     && mkdir /projects \
     # Create root node_modules in order to not use node_modules in each project folder
     && mkdir /node_modules \
-    # Create internal plugins folder
-    && mkdir /default-theia-plugins \
     # Download yeoman generator plug-in
     && curl -L -o /default-theia-plugins/theia_yeoman_plugin.theia https://github.com/eclipse/theia-yeoman-plugin/releases/download/untagged-04f28ee329e479cc465b/theia_yeoman_plugin.theia \
-    && curl -L -o /default-theia-plugins/eclipse_che_theia_factory_plugin.theia https://github.com/eclipse/che-theia/releases/download/0.0.1/eclipse_che_theia_factory_plugin.theia \
-    && curl -L -o /default-theia-plugins/eclipse_che_theia_containers_plugin.theia https://github.com/eclipse/che-theia/releases/download/0.0.2/eclipse_che_theia_containers_plugin.theia \
     && for f in "${HOME}" "/etc/passwd" "/etc/group /node_modules /default-theia-plugins /projects"; do\
            sudo chgrp -R 0 ${f} && \
            sudo chmod -R g+rwX ${f}; \

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -119,7 +119,7 @@ WORKDIR ${HOME}/che-theia-source-code/plugins/
 RUN yarn
 
 RUN mkdir -p ${HOME}/che-theia-plugins/ && \
-    find ${HOME}/che-theia-source-code/plugins/ -name "*.theia"  -exec sh -c "cp {} ${HOME}/che-theia-plugins/" \; 2>log.txt
+    find ${HOME}/che-theia-source-code/plugins/ -not -name "*ssh*" -not -name "*ports*" -name "*.theia"  -exec sh -c "cp {} ${HOME}/che-theia-plugins/" \; 2>log.txt
 
 
 ###

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -119,7 +119,7 @@ WORKDIR ${HOME}/che-theia-source-code/plugins/
 RUN yarn
 
 RUN mkdir -p ${HOME}/che-theia-plugins/ && \
-    find ${HOME}/che-theia-source-code/plugins/ -name "*.theia"  -exec sh -c "chgrp 0 {}; chmod g+rwX {}; cp {} ${HOME}/che-theia-plugins/" \; 2>log.txt
+    find ${HOME}/che-theia-source-code/plugins/ -name "*.theia"  -exec sh -c "cp {} ${HOME}/che-theia-plugins/" \; 2>log.txt
 
 
 ###


### PR DESCRIPTION
It is a proposal, WDYT ?

Signed-off-by: Sun Seng David TAN <sutan@redhat.com>