### PR TITLE
Only push CDN files on cron-triggered CI builds

### DIFF
--- a/dockerfiles/theia/build.sh
+++ b/dockerfiles/theia/build.sh
@@ -34,5 +34,7 @@ if [ -n "${LABEL_CONTENT}" ]; then
   BUILD_ARGS+="--label che-plugin.cdn.artifacts=$(echo ${LABEL_CONTENT} | sed 's/ //g') "
   echo "Rebuilding with CDN label..."
   build
-  "${base_dir}"/push-cdn-files-to-akamai.sh
+  if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+    "${base_dir}"/push-cdn-files-to-akamai.sh
+  fi
 fi

--- a/dockerfiles/theia/build.sh
+++ b/dockerfiles/theia/build.sh
@@ -34,7 +34,7 @@ if [ -n "${LABEL_CONTENT}" ]; then
   BUILD_ARGS+="--label che-plugin.cdn.artifacts=$(echo ${LABEL_CONTENT} | sed 's/ //g') "
   echo "Rebuilding with CDN label..."
   build
-  if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+  if [ "${TRAVIS_EVENT_TYPE:-}" == "cron" ]; then
     "${base_dir}"/push-cdn-files-to-akamai.sh
   fi
 fi


### PR DESCRIPTION
Just as it is done for docker images.