### PR TITLE
Fix syntax error in Theia entrypoint.sh script

### DIFF
--- a/dockerfiles/theia/src/entrypoint.sh
+++ b/dockerfiles/theia/src/entrypoint.sh
@@ -90,3 +90,4 @@ EXIT_STATUS=$?
 while true
 do
   tail -f /dev/null & wait ${!}
+done


### PR DESCRIPTION
This PR fixes syntax error in bash script which is responsible for Theia start.

Signed-off-by: Mykola Morhun <mmorhun@redhat.com>