### PR TITLE
Update to Theia 0.3.19, build another image from upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
     before_script: skip
     script:
       - yarn
-      - ./build_and_push_docker_images.sh;
+      - travis_retry ./build_and_push_docker_images.sh;
       - ./che-plugins/build.sh
   - stage: deploy
     os: linux

--- a/build_and_push_docker_images.sh
+++ b/build_and_push_docker_images.sh
@@ -30,8 +30,7 @@ for image_dir in "${DOCKER_FILES_LOCATIONS[@]}"
     do
         if [ "$image_dir" == "dockerfiles/theia" ]; then
             THEIA_IMAGE_TAG="$(awk '/ARG THEIA_VERSION=/{print $NF}' dockerfiles/theia/Dockerfile | cut -d '=' -f2)-nightly"
-            bash $(pwd)/$image_dir/build.sh --build-arg:GITHUB_TOKEN=${GITHUB_TOKEN}
-            bash $(pwd)/$image_dir/build.sh --build-args:GITHUB_TOKEN=${GITHUB_TOKEN},THEIA_VERSION=master --name:theia-master
+            bash $(pwd)/$image_dir/build.sh --build-args:GITHUB_TOKEN=${GITHUB_TOKEN},THEIA_VERSION=master --branch:master --git-ref:refs\\/heads\\/master
         elif [ "$image_dir" == "dockerfiles/theia-dev" ]; then
             bash $(pwd)/$image_dir/build.sh --build-arg:GITHUB_TOKEN=${GITHUB_TOKEN}
         else

--- a/build_and_push_docker_images.sh
+++ b/build_and_push_docker_images.sh
@@ -21,6 +21,7 @@ dockerfiles/theia
 IMAGES_LIST=(
 eclipse/che-theia-dev
 eclipse/che-theia
+eclipse/che-theia-master
 )
 
 
@@ -30,6 +31,7 @@ for image_dir in "${DOCKER_FILES_LOCATIONS[@]}"
         if [ "$image_dir" == "dockerfiles/theia" ]; then
             THEIA_IMAGE_TAG="$(awk '/ARG THEIA_VERSION=/{print $NF}' dockerfiles/theia/Dockerfile | cut -d '=' -f2)-nightly"
             bash $(pwd)/$image_dir/build.sh --build-arg:GITHUB_TOKEN=${GITHUB_TOKEN}
+            bash $(pwd)/$image_dir/build.sh --build-args:GITHUB_TOKEN=${GITHUB_TOKEN},THEIA_VERSION=master --name:theia-master
         elif [ "$image_dir" == "dockerfiles/theia-dev" ]; then
             bash $(pwd)/$image_dir/build.sh --build-arg:GITHUB_TOKEN=${GITHUB_TOKEN}
         else

--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -50,6 +50,8 @@ init() {
   BUILD_ARGS=""
 
   PARENT_IMAGE=""
+  BRANCH=""
+  GIT_REF=""
 
   while [ $# -gt 0 ]; do
     case $1 in
@@ -83,6 +85,12 @@ init() {
       --build-arg*:*)
         BUILD_ARGS_CSV="${1#*:}"
         prepare_build_args $BUILD_ARGS_CSV
+        shift ;;
+      --branch:*)
+        BRANCH="${1#*:}"
+        shift ;;
+      --git-ref:*)
+        GIT_REF="${1#*:}"
         shift ;;
       --*)
         printf "${RED}Unknown parameter: $1${NC}\n"; exit 2 ;;
@@ -130,7 +138,7 @@ build() {
 build_image() {
   printf "${BOLD}Building Docker Image ${IMAGE_NAME} from $DIR directory with tag $TAG${NC}\n"
   # Replace macros in Dockerfiles
-  cat ${DIR}/${DOCKERFILE} | sed s/\$\{BUILD_ORGANIZATION\}/${ORGANIZATION}/ | sed s/\$\{BUILD_PREFIX\}/${PREFIX}/ | sed s/\$\{BUILD_TAG\}/${TAG}/ | sed s/\$\{BUILD_PARENT_IMAGE\}/${PARENT_IMAGE}/ > ${DIR}/.Dockerfile
+  cat ${DIR}/${DOCKERFILE} | sed s/\$\{BUILD_ORGANIZATION\}/${ORGANIZATION}/ | sed s/\$\{BUILD_PREFIX\}/${PREFIX}/ | sed s/\$\{BUILD_TAG\}/${TAG}/ | sed s/\$\{BUILD_PARENT_IMAGE\}/${PARENT_IMAGE}/ | sed s/\$\{GIT_BRANCH_NAME\}/${BRANCH}/ | sed s/\$\{GIT_REF\}/"${GIT_REF}"/ > ${DIR}/.Dockerfile
   cd "${DIR}" && docker build -f ${DIR}/.Dockerfile -t ${IMAGE_NAME} ${BUILD_ARGS} .
   rm ${DIR}/.Dockerfile
   if [ $? -eq 0 ]; then

--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -49,6 +49,8 @@ init() {
   DOCKERFILE=""
   BUILD_ARGS=""
 
+  PARENT_IMAGE=""
+
   while [ $# -gt 0 ]; do
     case $1 in
       --*)
@@ -128,7 +130,7 @@ build() {
 build_image() {
   printf "${BOLD}Building Docker Image ${IMAGE_NAME} from $DIR directory with tag $TAG${NC}\n"
   # Replace macros in Dockerfiles
-  cat ${DIR}/${DOCKERFILE} | sed s/\$\{BUILD_ORGANIZATION\}/${ORGANIZATION}/ | sed s/\$\{BUILD_PREFIX\}/${PREFIX}/ | sed s/\$\{BUILD_TAG\}/${TAG}/ > ${DIR}/.Dockerfile
+  cat ${DIR}/${DOCKERFILE} | sed s/\$\{BUILD_ORGANIZATION\}/${ORGANIZATION}/ | sed s/\$\{BUILD_PREFIX\}/${PREFIX}/ | sed s/\$\{BUILD_TAG\}/${TAG}/ | sed s/\$\{BUILD_PARENT_IMAGE\}/${PARENT_IMAGE}/ > ${DIR}/.Dockerfile
   cd "${DIR}" && docker build -f ${DIR}/.Dockerfile -t ${IMAGE_NAME} ${BUILD_ARGS} .
   rm ${DIR}/.Dockerfile
   if [ $? -eq 0 ]; then

--- a/dockerfiles/theia-dev/e2e/Dockerfile
+++ b/dockerfiles/theia-dev/e2e/Dockerfile
@@ -12,6 +12,6 @@ FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-dev:${BUILD_TAG}
 ARG GITHUB_TOKEN
 
 # Just try to build the latest theia with current image
-RUN git clone -b 'v0.3.17' --single-branch --depth 1 https://github.com/theia-ide/theia theia
+RUN git clone -b 'v0.3.19' --single-branch --depth 1 https://github.com/theia-ide/theia theia
 RUN cd theia && yarn
 

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -40,16 +40,10 @@ RUN if [ ! -z "${GITHUB_TOKEN-}" ]; then \
     fi
 
 #invalidate cashe
-ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/theia-ide/theia/git/${GIT_REF} /tmp/master.json
+ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/theia-ide/theia/git/${GIT_REF} /tmp/branch_info.json
 
 # Clone theia
 RUN git clone --branch ${GIT_BRANCH_NAME}  --single-branch --depth 1 https://github.com/theia-ide/theia ${HOME}/theia-source-code
-# RUN if [ $THEIA_VERSION == "master" ]; then \
-#         echo "Cloning Theia master branch"; \
-#         (git clone --branch master  --single-branch --depth 1 https://github.com/theia-ide/theia ${HOME}/theia-source-code) ; \
-#     else \
-#       (git clone --branch v${THEIA_VERSION}  --single-branch --depth 1 https://github.com/theia-ide/theia ${HOME}/theia-source-code); \
-#     fi
 
 # Add patches
 ADD src/patches ${HOME}/patches

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -40,16 +40,16 @@ RUN if [ ! -z "${GITHUB_TOKEN-}" ]; then \
     fi
 
 #invalidate cashe
-ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/theia-ide/theia/git/refs/heads/master /tmp/master.json
+ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/theia-ide/theia/git/${GIT_REF} /tmp/master.json
 
 # Clone theia
-#RUN git clone --branch v${THEIA_VERSION}  --single-branch --depth 1 https://github.com/theia-ide/theia ${HOME}/theia-source-code
-RUN if [ $THEIA_VERSION == "master" ]; then \
-        echo "Cloning Theia master branch"; \
-        (git clone --branch master  --single-branch --depth 1 https://github.com/theia-ide/theia ${HOME}/theia-source-code) ; \
-    else \
-      (git clone --branch v${THEIA_VERSION}  --single-branch --depth 1 https://github.com/theia-ide/theia ${HOME}/theia-source-code); \
-    fi
+RUN git clone --branch ${GIT_BRANCH_NAME}  --single-branch --depth 1 https://github.com/theia-ide/theia ${HOME}/theia-source-code
+# RUN if [ $THEIA_VERSION == "master" ]; then \
+#         echo "Cloning Theia master branch"; \
+#         (git clone --branch master  --single-branch --depth 1 https://github.com/theia-ide/theia ${HOME}/theia-source-code) ; \
+#     else \
+#       (git clone --branch v${THEIA_VERSION}  --single-branch --depth 1 https://github.com/theia-ide/theia ${HOME}/theia-source-code); \
+#     fi
 
 # Add patches
 ADD src/patches ${HOME}/patches

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR ${HOME}
 ARG GITHUB_TOKEN
 
 # Define upstream version of theia to use
-ARG THEIA_VERSION=0.3.18
+ARG THEIA_VERSION=0.3.19
 
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 
@@ -39,8 +39,17 @@ RUN if [ ! -z "${GITHUB_TOKEN-}" ]; then \
       fi \
     fi
 
+#invalidate cashe
+ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/theia-ide/theia/git/refs/heads/master /tmp/master.json
+
 # Clone theia
-RUN git clone --branch v${THEIA_VERSION}  --single-branch --depth 1 https://github.com/theia-ide/theia ${HOME}/theia-source-code
+#RUN git clone --branch v${THEIA_VERSION}  --single-branch --depth 1 https://github.com/theia-ide/theia ${HOME}/theia-source-code
+RUN if [ $THEIA_VERSION == "master" ]; then \
+        echo "Cloning Theia master branch"; \
+        (git clone --branch master  --single-branch --depth 1 https://github.com/theia-ide/theia ${HOME}/theia-source-code) ; \
+    else \
+      (git clone --branch v${THEIA_VERSION}  --single-branch --depth 1 https://github.com/theia-ide/theia ${HOME}/theia-source-code); \
+    fi
 
 # Add patches
 ADD src/patches ${HOME}/patches
@@ -61,7 +70,13 @@ WORKDIR ${HOME}/theia-source-code
 
 COPY che-theia/extensions.yml ${HOME}/extensions.yml
 
-RUN che:theia init -c ${HOME}/extensions.yml
+#RUN che:theia init -c ${HOME}/extensions.yml
+RUN if [ ${THEIA_VERSION} == "master" ]; then \
+        echo "Working in dev mode"; \
+        (che:theia init -d -c ${HOME}/extensions.yml); \
+    else \
+        (che:theia init -c ${HOME}/extensions.yml);\
+    fi
 RUN che:theia cdn --theia="${CDN_PREFIX}" --monaco="${MONACO_CDN_PREFIX}"
 
 # Compile Theia

--- a/dockerfiles/theia/build.sh
+++ b/dockerfiles/theia/build.sh
@@ -36,7 +36,7 @@ fi
 build
 
 if ! skip_tests; then
-  bash "${base_dir}"/e2e/build.sh "$@"
+  bash "${base_dir}"/e2e/build.sh "$PREFIX-$NAME" "$@" 
 fi
 
 echo "Extracting artifacts for the CDN"

--- a/dockerfiles/theia/e2e/Dockerfile
+++ b/dockerfiles/theia/e2e/Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: EPL-2.0
 
 # Use upstream image
-FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia:${BUILD_TAG} as theia
+FROM ${BUILD_ORGANIZATION}/${BUILD_PARENT_IMAGE}:${BUILD_TAG} as theia
 FROM cypress/browsers:chrome67
 
 USER root
@@ -26,4 +26,3 @@ ADD cypress /root/cypress/
 COPY --from=theia /home/theia /home/theia
 COPY --from=theia /entrypoint.sh /entrypoint.sh
 RUN find /home/theia/ -name "binding.gyp" |  xargs -i sh -c 'cd $(dirname {}) && node-gyp rebuild'
- 

--- a/dockerfiles/theia/e2e/build.sh
+++ b/dockerfiles/theia/e2e/build.sh
@@ -10,6 +10,7 @@ base_dir=$(cd "$(dirname "$0")"; pwd)
 . "${base_dir}/../../build.include"
 
 init --name:theia-e2e "$@"
+PARENT_IMAGE="$1"
 build
 if ! skip_tests; then
   bash "${base_dir}"/test.sh "$@"

--- a/dockerfiles/theia/e2e/cypress/integration/theia/commands.spec.ts
+++ b/dockerfiles/theia/e2e/cypress/integration/theia/commands.spec.ts
@@ -37,10 +37,8 @@ context('Check Extensions are installed', () => {
        '@theia/plugin-ext-vscode',
        '@theia/java',
        '@theia/typescript',
-       'che-theia-ssh-extension',
        '@eclipse-che/che-theia-hosted-plugin-manager-extension',
-       '@eclipse-che/theia-remote-extension',
-       'github-extension',
+       '@eclipse-che/theia-remote',
        '@eclipse-che/theia-activity-tracker',
        '@eclipse-che/theia-task-extension',
        '@eclipse-che/theia-terminal',
@@ -49,12 +47,4 @@ context('Check Extensions are installed', () => {
 
   })
 
-  // Search that SSH extension is there with actions
-  it('Command Palette include SSH extension', () => {
-    cy.theiaCommandPaletteItems('SSH:').then((value) => {
-      expect(value).to.have.length(4);
-      expect(value).to.have.members([
-        'SSH: copy public key to clipboard...', 'SSH: create key pair...', 'SSH: delete key pair...', 'SSH: generate key pair...']);
-    })
-  });
 })

--- a/extensions/extensions.yml
+++ b/extensions/extensions.yml
@@ -1,14 +1,4 @@
 extensions:
-- source: https://github.com/ws-skeleton/che-theia-remote-extension
-  checkoutTo: THEIA_0_3_18
-- source: https://github.com/eclipse/che-theia-github-plugin
-  folders:
-    - github-extension
-  checkoutTo: 0.0.2
-- source: https://github.com/eclipse/che-theia-ssh-plugin
-  folders:
-    - ssh-extension
-  checkoutTo: 0.0.2
 - source: https://github.com/eclipse/che-theia-dashboard-extension
   folders:
     - theia-dashboard-extension
@@ -18,7 +8,7 @@ extensions:
 - source: https://github.com/eclipse/che-theia-task-plugin
   folders:
     - che-theia-task-extension
-  checkoutTo: 0.3.17
+  checkoutTo: 0.3.19
 - source: https://github.com/eclipse/che-theia-activity-tracker
   folders:
     - che-theia-activity-tracker
@@ -28,4 +18,5 @@ extensions:
     - extensions/eclipse-che-theia-plugin
     - extensions/eclipse-che-theia-plugin-ext
     - extensions/eclipse-che-theia-terminal
-  checkoutTo: 0.0.3
+    - extensions/eclipse-che-theia-remote
+  checkoutTo: 0.0.4


### PR DESCRIPTION
Should fix #39

Also include build `che-theia-master` image from Theia and all extensions master branch.
Removes `che-theia-ssh-extension` and `github-extension` which is deprecated and no longer supported(there https://github.com/eclipse/che-theia/pull/31 pull which add ssh as plugin)
Signed-off-by: Yevhen Vydolob <yvydolob@redhat.com>