### PR TITLE
Change base image of remote-plugin-runner-java8 image

### DIFF
--- a/dockerfiles/remote-plugin-runner-java8/Dockerfile
+++ b/dockerfiles/remote-plugin-runner-java8/Dockerfile
@@ -8,7 +8,7 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
-FROM wsskeleton/theia-endpoint-runtime
+FROM eclipse/che-theia-endpoint-runtime:nightly
 RUN apk --no-cache add openjdk8
 ENV JAVA_HOME /usr/lib/jvm/default-jvm/
 WORKDIR /projects


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>
This PR changes base image of remote-plugin-runner-java8 because https://github.com/ws-skeleton/che-theia-remote-extension was moved into `che-theia`.