### PR TITLE
Update nodejs to 8.15.0 which is using a newer version of yarn

### DIFF
--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -11,7 +11,7 @@
 ###
 # Builder Image
 #
-FROM node:8.12.0-alpine
+FROM node:8.15.0-alpine
 
 RUN apk add --update --no-cache \
     # Download some files

--- a/dockerfiles/theia-endpoint-runtime/Dockerfile
+++ b/dockerfiles/theia-endpoint-runtime/Dockerfile
@@ -46,7 +46,7 @@ COPY /tsconfig.json /home/workspace/packages/theia-plugin/tsconfig.json
 COPY /etc/package.json /home/workspace
 RUN cd /home/workspace/ && yarn install
 
-FROM node:8.12-alpine
+FROM node:8.15.0-alpine
 COPY --from=builder /home/workspace/node_modules /home/theia/node_modules
 RUN rm -rf /home/theia/node_modules/@eclipse-che/theia-plugin-ext /home/theia/node_modules/@eclipse-che/theia-remote
 COPY --from=builder /home/workspace/packages/theia-plugin-ext /home/theia/node_modules/@eclipse-che/theia-plugin-ext

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -86,7 +86,7 @@ RUN find production -exec sh -c "chgrp 0 {}; chmod g+rwX {}" \; 2>log.txt
 # Runtime Image
 #
 # Use node image
-FROM node:8.12.0-alpine as runtime
+FROM node:8.15.0-alpine as runtime
 ENV USE_LOCAL_GIT=true \
     HOME=/home/theia \
     THEIA_DEFAULT_PLUGINS=local-dir:///default-theia-plugins \


### PR DESCRIPTION
8.12.0 version was using yarn 1.9.4 and it doesn't work for building che-theia

Change-Id: I4c7e3c2059c5641aa8ce8ba8176a1687d395e879
Signed-off-by: Florent Benoit <fbenoit@redhat.com>