### PR TITLE
Add context at creating Che tasks

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-task-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-task-service.ts
@@ -42,7 +42,7 @@ export class CheTaskServiceImpl implements CheTaskService {
             for (const client of this.clients) {
                 await client.runTask(id, config, ctx);
             }
-            return new CheTask(id, this.taskManager, this.logger, { label: config.label, config }, this.clients);
+            return new CheTask(id, this.taskManager, this.logger, { label: config.label, config, context: ctx }, this.clients);
         };
     }
 


### PR DESCRIPTION
At [creating Che Tasks](https://github.com/eclipse/che-theia/blob/master/extensions/eclipse-che-theia-plugin-ext/src/node/che-task-service.ts#L45) we do not add context, so task manager [register](https://github.com/theia-ide/theia/blob/master/packages/task/src/node/task-manager.ts#L40) tasks without context.
But context is passed when we tried to get Che tasks by [taskManager.getTasks()](https://github.com/theia-ide/theia/blob/master/packages/task/src/node/task-manager.ts#L62) and we get no tasks for this case.
So we need to specify context at creating Che tasks.

Fixes: https://github.com/eclipse/che-theia/issues/76

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>