### PR TITLE
Add Theia user preferences synchronizer

### DIFF
--- a/extensions/eclipse-che-theia-user-preferences/.gitignore
+++ b/extensions/eclipse-che-theia-user-preferences/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.browser_modules
+lib
+*.log
+*-app/*
+!*-app/package.json
+.idea

--- a/extensions/eclipse-che-theia-user-preferences/package.json
+++ b/extensions/eclipse-che-theia-user-preferences/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@eclipse-che/theia-user-preferences-synchronizer",
+  "keywords": [
+    "theia-extension",
+    "che",
+    "preferences"
+  ],
+  "version": "0.0.1",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "dependencies": {
+    "@theia/core": "^0.3.19",
+    "@theia/preferences": "^0.3.19",
+    "@eclipse-che/theia-plugin-ext": "^0.0.1"
+  },
+  "devDependencies": {
+    "rimraf": "latest",
+    "typescript": "latest"
+  },
+  "scripts": {
+    "prepare": "yarn run clean && yarn run build",
+    "clean": "rimraf lib",
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "theiaExtensions": [
+    {
+      "backend": "lib/node/che-theia-user-preferences-backend-module"
+    }
+  ]
+}

--- a/extensions/eclipse-che-theia-user-preferences/package.json
+++ b/extensions/eclipse-che-theia-user-preferences/package.json
@@ -22,7 +22,10 @@
   "scripts": {
     "prepare": "yarn run clean && yarn run build",
     "clean": "rimraf lib",
-    "build": "tsc",
+    "format": "tsfmt -r --useTsfmt ../../configs/tsfmt.json",
+    "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
+    "compile": "tsc",
+    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\"",
     "watch": "tsc -w"
   },
   "theiaExtensions": [

--- a/extensions/eclipse-che-theia-user-preferences/package.json
+++ b/extensions/eclipse-che-theia-user-preferences/package.json
@@ -11,8 +11,8 @@
     "src"
   ],
   "dependencies": {
-    "@theia/core": "^0.3.19",
-    "@theia/preferences": "^0.3.19",
+    "@theia/core": "next",
+    "@theia/preferences": "next",
     "@eclipse-che/theia-plugin-ext": "^0.0.1"
   },
   "devDependencies": {

--- a/extensions/eclipse-che-theia-user-preferences/src/node/che-theia-preferences-contribution.ts
+++ b/extensions/eclipse-che-theia-user-preferences/src/node/che-theia-preferences-contribution.ts
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (C) 2018-2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from "inversify";
+import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
+import { CheTheiaUserPreferencesSynchronizer } from './che-theia-preferences-synchronizer';
+
+@injectable()
+export class CheTheiaPreferencesContribution implements BackendApplicationContribution {
+
+    @inject(CheTheiaUserPreferencesSynchronizer)
+    cheTheiaUserPreferencesSynchronizer: CheTheiaUserPreferencesSynchronizer
+
+    async onStart(): Promise<void> {
+        await this.cheTheiaUserPreferencesSynchronizer.readTheiaUserPreferencesFromCheSettings();
+        this.cheTheiaUserPreferencesSynchronizer.watchUserPreferencesChanges();
+    }
+}

--- a/extensions/eclipse-che-theia-user-preferences/src/node/che-theia-preferences-contribution.ts
+++ b/extensions/eclipse-che-theia-user-preferences/src/node/che-theia-preferences-contribution.ts
@@ -24,8 +24,14 @@ export class CheTheiaPreferencesContribution implements BackendApplicationContri
     @inject(CheTheiaUserPreferencesSynchronizer)
     cheTheiaUserPreferencesSynchronizer: CheTheiaUserPreferencesSynchronizer;
 
-    public onStart(): void {
-        this.cheTheiaUserPreferencesSynchronizer.readTheiaUserPreferencesFromCheSettings();
+     public onStart(): void {
+        // do not block Theia start here, initialize preferences asynchronously
+        this.retrieveAndWatchSettings();
+    }
+
+    private async retrieveAndWatchSettings(): Promise<void> {
+        // to be able to start file watcher the settings.json file should be in place
+        await this.cheTheiaUserPreferencesSynchronizer.readTheiaUserPreferencesFromCheSettings();
         this.cheTheiaUserPreferencesSynchronizer.watchUserPreferencesChanges();
     }
 }

--- a/extensions/eclipse-che-theia-user-preferences/src/node/che-theia-preferences-contribution.ts
+++ b/extensions/eclipse-che-theia-user-preferences/src/node/che-theia-preferences-contribution.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from "inversify";
+import { injectable, inject } from 'inversify';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
 import { CheTheiaUserPreferencesSynchronizer } from './che-theia-preferences-synchronizer';
 
@@ -22,10 +22,10 @@ import { CheTheiaUserPreferencesSynchronizer } from './che-theia-preferences-syn
 export class CheTheiaPreferencesContribution implements BackendApplicationContribution {
 
     @inject(CheTheiaUserPreferencesSynchronizer)
-    cheTheiaUserPreferencesSynchronizer: CheTheiaUserPreferencesSynchronizer
+    cheTheiaUserPreferencesSynchronizer: CheTheiaUserPreferencesSynchronizer;
 
-    async onStart(): Promise<void> {
-        await this.cheTheiaUserPreferencesSynchronizer.readTheiaUserPreferencesFromCheSettings();
+    public onStart(): void {
+        this.cheTheiaUserPreferencesSynchronizer.readTheiaUserPreferencesFromCheSettings();
         this.cheTheiaUserPreferencesSynchronizer.watchUserPreferencesChanges();
     }
 }

--- a/extensions/eclipse-che-theia-user-preferences/src/node/che-theia-preferences-synchronizer.ts
+++ b/extensions/eclipse-che-theia-user-preferences/src/node/che-theia-preferences-synchronizer.ts
@@ -14,17 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-/// <reference types="@theia/core/src/typings/nsfw/index"/>
+/// <reference types='@theia/core/src/typings/nsfw/index'/>
 
-import { injectable, inject } from "inversify";
+import { injectable, inject } from 'inversify';
 import { readFileSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
-import { sep as PATH_SEPARATOR } from 'path';
+import { resolve } from 'path';
 import * as nsfw from 'vscode-nsfw';
-import { CheApiService, Preferences } from "@eclipse-che/theia-plugin-ext/lib/common/che-protocol";
+import { CheApiService, Preferences } from '@eclipse-che/theia-plugin-ext/lib/common/che-protocol';
 
 export const THEIA_PREFERENCES_KEY = 'theia-user-preferences';
-export const THEIA_USER_PREFERENCES_PATH = homedir() + PATH_SEPARATOR + '.theia' + PATH_SEPARATOR + 'settings.json';
+export const THEIA_USER_PREFERENCES_PATH = resolve(homedir(), '.theia', 'settings.json');
 
 @injectable()
 export class CheTheiaUserPreferencesSynchronizer {
@@ -35,8 +35,8 @@ export class CheTheiaUserPreferencesSynchronizer {
     protected settingsJsonWatcher: nsfw.NSFW | undefined;
 
     /**
-    * Provides stored Theia user preferences into workspace.
-    */
+     * Provides stored Theia user preferences into workspace.
+     */
     public async readTheiaUserPreferencesFromCheSettings(): Promise<void> {
         const chePreferences = await this.cheApiService.getUserPreferences(THEIA_PREFERENCES_KEY);
         const theiaPreferences = chePreferences[THEIA_PREFERENCES_KEY] ? chePreferences[THEIA_PREFERENCES_KEY] : '{}';
@@ -68,11 +68,14 @@ export class CheTheiaUserPreferencesSynchronizer {
         }
     }
 
+    /**
+     * Updates Theia user preferences which stored in Che
+     */
     protected async updateTheiaUserPreferencesInCheSettings(): Promise<void> {
         let userPreferences = readFileSync(THEIA_USER_PREFERENCES_PATH, 'utf8');
         try {
-             // check json validity and remove indents
-             userPreferences = JSON.stringify(JSON.parse(userPreferences));
+            // check json validity and remove indents
+            userPreferences = JSON.stringify(JSON.parse(userPreferences));
         } catch (error) {
             // settings.json has syntax error, do not update anything
             return;

--- a/extensions/eclipse-che-theia-user-preferences/src/node/che-theia-preferences-synchronizer.ts
+++ b/extensions/eclipse-che-theia-user-preferences/src/node/che-theia-preferences-synchronizer.ts
@@ -1,0 +1,86 @@
+/********************************************************************************
+ * Copyright (C) 2018-2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/// <reference types="@theia/core/src/typings/nsfw/index"/>
+
+import { injectable, inject } from "inversify";
+import { readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { sep as PATH_SEPARATOR } from 'path';
+import * as nsfw from 'vscode-nsfw';
+import { CheApiService, Preferences } from "@eclipse-che/theia-plugin-ext/lib/common/che-protocol";
+
+export const THEIA_PREFERENCES_KEY = 'theia-user-preferences';
+export const THEIA_USER_PREFERENCES_PATH = homedir() + PATH_SEPARATOR + '.theia' + PATH_SEPARATOR + 'settings.json';
+
+@injectable()
+export class CheTheiaUserPreferencesSynchronizer {
+
+    @inject(CheApiService)
+    protected cheApiService: CheApiService;
+
+    protected settingsJsonWatcher: nsfw.NSFW | undefined;
+
+    /**
+    * Provides stored Theia user preferences into workspace.
+    */
+    public async readTheiaUserPreferencesFromCheSettings(): Promise<void> {
+        const chePreferences = await this.cheApiService.getUserPreferences(THEIA_PREFERENCES_KEY);
+        const theiaPreferences = chePreferences[THEIA_PREFERENCES_KEY] ? chePreferences[THEIA_PREFERENCES_KEY] : '{}';
+        const theiaPreferencesBeautified = JSON.stringify(JSON.parse(theiaPreferences), undefined, 3);
+        writeFileSync(THEIA_USER_PREFERENCES_PATH, theiaPreferencesBeautified, 'utf8');
+    }
+
+    public async watchUserPreferencesChanges(): Promise<void> {
+        if (this.settingsJsonWatcher) {
+            // Already watching
+            return;
+        }
+
+        this.settingsJsonWatcher = await nsfw(THEIA_USER_PREFERENCES_PATH, (events: nsfw.ChangeEvent[]) => {
+            for (const event of events) {
+                if (event.action === nsfw.actions.MODIFIED) {
+                    this.updateTheiaUserPreferencesInCheSettings();
+                    return;
+                }
+            }
+        });
+        await this.settingsJsonWatcher.start();
+    }
+
+    public async unwatchUserPreferencesChanges(): Promise<void> {
+        if (this.settingsJsonWatcher) {
+            await this.settingsJsonWatcher.stop();
+            this.settingsJsonWatcher = undefined;
+        }
+    }
+
+    protected async updateTheiaUserPreferencesInCheSettings(): Promise<void> {
+        let userPreferences = readFileSync(THEIA_USER_PREFERENCES_PATH, 'utf8');
+        try {
+             // check json validity and remove indents
+             userPreferences = JSON.stringify(JSON.parse(userPreferences));
+        } catch (error) {
+            // settings.json has syntax error, do not update anything
+            return;
+        }
+
+        const update: Preferences = {};
+        update[THEIA_PREFERENCES_KEY] = userPreferences;
+        await this.cheApiService.updateUserPreferences(update);
+    }
+
+}

--- a/extensions/eclipse-che-theia-user-preferences/src/node/che-theia-user-preferences-backend-module.ts
+++ b/extensions/eclipse-che-theia-user-preferences/src/node/che-theia-user-preferences-backend-module.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule } from "inversify";
+import { ContainerModule } from 'inversify';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
 import { CheTheiaUserPreferencesSynchronizer } from './che-theia-preferences-synchronizer';
 import { CheTheiaPreferencesContribution } from './che-theia-preferences-contribution';

--- a/extensions/eclipse-che-theia-user-preferences/src/node/che-theia-user-preferences-backend-module.ts
+++ b/extensions/eclipse-che-theia-user-preferences/src/node/che-theia-user-preferences-backend-module.ts
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (C) 2018-2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from "inversify";
+import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
+import { CheTheiaUserPreferencesSynchronizer } from './che-theia-preferences-synchronizer';
+import { CheTheiaPreferencesContribution } from './che-theia-preferences-contribution';
+
+export default new ContainerModule(bind => {
+    bind(CheTheiaUserPreferencesSynchronizer).toSelf().inSingletonScope();
+
+    bind(CheTheiaPreferencesContribution).toSelf().inSingletonScope();
+    bind(BackendApplicationContribution).toService(CheTheiaPreferencesContribution);
+});

--- a/extensions/eclipse-che-theia-user-preferences/tsconfig.json
+++ b/extensions/eclipse-che-theia-user-preferences/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "extends": "../../configs/base.tsconfig.json",
+    "compilerOptions": {
+        "experimentalDecorators": true,
+        "noUnusedLocals": true,
+        "emitDecoratorMetadata": true,
+        "downlevelIteration": true,
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "sourceMap": true,
+        "rootDir": "src",
+        "outDir": "lib"
+    },
+    "include": [
+        "src"
+    ]
+}

--- a/extensions/extensions.yml
+++ b/extensions/extensions.yml
@@ -18,5 +18,6 @@ extensions:
     - extensions/eclipse-che-theia-plugin
     - extensions/eclipse-che-theia-plugin-ext
     - extensions/eclipse-che-theia-terminal
+    - extensions/eclipse-che-theia-user-preferences
     - dockerfiles/theia-endpoint-runtime
   checkoutTo: master

--- a/yarn.lock
+++ b/yarn.lock
@@ -851,6 +851,22 @@
     semver "^5.4.1"
     write-json-file "^2.2.0"
 
+"@theia/application-package@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-0.3.19.tgz#31c111e727b081ac0e8c7dc4d0cbfecc1cdec533"
+  integrity sha512-dQ4xvabtCpXl7NAqEl4akRubVgvyes1/Z7iDMJQyKFci+DE4u7AS8BDn5fg8jCTOi/Q5MnXjNCSSWYkv/KBVlw==
+  dependencies:
+    "@types/fs-extra" "^4.0.2"
+    "@types/request" "^2.0.3"
+    "@types/semver" "^5.4.0"
+    "@types/write-json-file" "^2.2.1"
+    changes-stream "^2.2.0"
+    fs-extra "^4.0.2"
+    is-electron "^2.1.0"
+    request "^2.82.0"
+    semver "^5.4.1"
+    write-json-file "^2.2.0"
+
 "@theia/console@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
   resolved "https://registry.yarnpkg.com/@theia/console/-/console-0.4.0-next.5967a992.tgz#1ab41dbcd71d5470efad24409118a389cdb94281"
@@ -867,6 +883,50 @@
   dependencies:
     "@phosphor/widgets" "^1.5.0"
     "@theia/application-package" "0.4.0-next.5967a992"
+    "@types/body-parser" "^1.16.4"
+    "@types/bunyan" "^1.8.0"
+    "@types/express" "^4.16.0"
+    "@types/lodash.debounce" "4.0.3"
+    "@types/lodash.throttle" "^4.1.3"
+    "@types/react" "^16.4.1"
+    "@types/react-dom" "^16.0.6"
+    "@types/react-virtualized" "^9.18.3"
+    "@types/route-parser" "^0.1.1"
+    "@types/ws" "^5.1.2"
+    "@types/yargs" "^11.1.0"
+    ajv "^6.5.3"
+    body-parser "^1.17.2"
+    electron "^2.0.14"
+    es6-promise "^4.2.4"
+    express "^4.16.3"
+    file-icons-js "^1.0.3"
+    fix-path "^2.1.0"
+    font-awesome "^4.7.0"
+    fuzzy "^0.1.3"
+    inversify "^4.14.0"
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+    perfect-scrollbar "^1.3.0"
+    react "^16.4.1"
+    react-dom "^16.4.1"
+    react-virtualized "^9.20.0"
+    reconnecting-websocket "^3.0.7"
+    reflect-metadata "^0.1.10"
+    route-parser "^0.0.5"
+    vscode-languageserver-types "^3.10.0"
+    vscode-nsfw "^1.0.17"
+    vscode-uri "^1.0.1"
+    vscode-ws-jsonrpc "^0.0.2-1"
+    ws "^5.2.2"
+    yargs "^11.1.0"
+
+"@theia/core@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.3.19.tgz#4bc0830224d94cef163a0dbe55042b9570d05f10"
+  integrity sha512-LS8UwImoWjVS2qBSuHF/6DZyNHJ3YdAboG8c0c2VAuVa1NCqlMCLag5WPyJ7aoQHpSyNbGcnuLa0hLS5EfRcEQ==
+  dependencies:
+    "@phosphor/widgets" "^1.5.0"
+    "@theia/application-package" "^0.3.19"
     "@types/body-parser" "^1.16.4"
     "@types/bunyan" "^1.8.0"
     "@types/express" "^4.16.0"
@@ -941,6 +1001,17 @@
     "@types/base64-arraybuffer" "0.1.0"
     base64-arraybuffer "^0.1.5"
 
+"@theia/editor@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-0.3.19.tgz#d5c3233b0bd35dee3ea9f73d52f58fbc8fb7639b"
+  integrity sha512-Pc6DuTwEkm/qi/aTEoY5yohq64/fjvCSkJsdMlV8d5yLhKZLX1Ot2u2ahE2j1a+ybi+ZF1XjO/5RpoElP6aumQ==
+  dependencies:
+    "@theia/core" "^0.3.19"
+    "@theia/languages" "^0.3.19"
+    "@theia/variable-resolver" "^0.3.19"
+    "@types/base64-arraybuffer" "0.1.0"
+    base64-arraybuffer "^0.1.5"
+
 "@theia/file-search@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
   resolved "https://registry.yarnpkg.com/@theia/file-search/-/file-search-0.4.0-next.5967a992.tgz#3188621258e421f2321004005dbb2e8d46dbc69d"
@@ -960,6 +1031,35 @@
   integrity sha512-NAA9mG7x8B05eBkR+rdx9HQsVP2yTLam45BmH6d2Il14RM5pksmHc4VZqKDjyLJics4cGiO27Wn4qvhfZE4p+Q==
   dependencies:
     "@theia/core" "0.4.0-next.5967a992"
+    "@types/base64-js" "^1.2.5"
+    "@types/body-parser" "^1.17.0"
+    "@types/fs-extra" "^4.0.2"
+    "@types/mime-types" "^2.1.0"
+    "@types/rimraf" "^2.0.2"
+    "@types/tar-fs" "^1.16.1"
+    "@types/touch" "0.0.1"
+    "@types/uuid" "^3.4.3"
+    base64-js "^1.2.1"
+    body-parser "^1.18.3"
+    drivelist "^6.4.3"
+    fs-extra "^4.0.2"
+    http-status-codes "^1.3.0"
+    mime-types "^2.1.18"
+    minimatch "^3.0.4"
+    mv "^2.1.1"
+    rimraf "^2.6.2"
+    tar-fs "^1.16.2"
+    touch "^3.1.0"
+    trash "^4.0.1"
+    uuid "^3.2.1"
+    zip-dir "^1.0.2"
+
+"@theia/filesystem@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-0.3.19.tgz#d1dce1c8a4f8c65c6ce949fee60205121e4af885"
+  integrity sha512-NdAA1HaZTmrrazooSEVcJBK2rAyCQSXHZsl5qN//qvoXueuLTm4OPwOEQymtHJEHBfDuTsC9kHb+AYVMMB4nxA==
+  dependencies:
+    "@theia/core" "^0.3.19"
     "@types/base64-js" "^1.2.5"
     "@types/body-parser" "^1.17.0"
     "@types/fs-extra" "^4.0.2"
@@ -1007,6 +1107,20 @@
     monaco-languageclient "^0.9.0"
     uuid "^3.2.1"
 
+"@theia/languages@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-0.3.19.tgz#564f30434ea9377787d56dbb26742a2e6bfa1607"
+  integrity sha512-EVVmukMAv/QYYx0ILK0XrP3NtjLeUJmp++IL0PGV92QYEK9R1x2nASXe0CWXEjeoPOqyYtq0SNWu+hGWsjlWVg==
+  dependencies:
+    "@theia/core" "^0.3.19"
+    "@theia/output" "^0.3.19"
+    "@theia/process" "^0.3.19"
+    "@theia/workspace" "^0.3.19"
+    "@typefox/monaco-editor-core" "^0.14.6"
+    "@types/uuid" "^3.4.3"
+    monaco-languageclient "^0.9.0"
+    uuid "^3.2.1"
+
 "@theia/markers@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
   resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-0.4.0-next.5967a992.tgz#17ff621e625b21fdf73b1b5eef3b7bf2688bbc30"
@@ -1016,6 +1130,16 @@
     "@theia/filesystem" "0.4.0-next.5967a992"
     "@theia/navigator" "0.4.0-next.5967a992"
     "@theia/workspace" "0.4.0-next.5967a992"
+
+"@theia/markers@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-0.3.19.tgz#e13be2405c241cf263b036e6f0d648d532759601"
+  integrity sha512-gIi3MsukAwiNdII8JdxyOFxJFFV1q9YFpToZBkK9zNogFpxgXTwPLrk/chpXel10+Le9ed85of3EQ+0kvjQSAg==
+  dependencies:
+    "@theia/core" "^0.3.19"
+    "@theia/filesystem" "^0.3.19"
+    "@theia/navigator" "^0.3.19"
+    "@theia/workspace" "^0.3.19"
 
 "@theia/messages@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
@@ -1043,6 +1167,24 @@
     onigasm "^2.1.0"
     vscode-textmate "^4.0.1"
 
+"@theia/monaco@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-0.3.19.tgz#51e80e1a3e640fc54cccd047ba69fee799a067ea"
+  integrity sha512-nW/LNBCjJoLUKk37boVdBLH5ODXvqvkyCi/HC8sZPqeYLMWydgBfeN4Z8ch+t1PBds+sQpLlE7ozdz5xWnuqdw==
+  dependencies:
+    "@theia/core" "^0.3.19"
+    "@theia/editor" "^0.3.19"
+    "@theia/filesystem" "^0.3.19"
+    "@theia/languages" "^0.3.19"
+    "@theia/markers" "^0.3.19"
+    "@theia/outline-view" "^0.3.19"
+    "@theia/workspace" "^0.3.19"
+    jsonc-parser "^2.0.2"
+    monaco-css "^2.0.1"
+    monaco-html "^2.0.2"
+    onigasm "^2.1.0"
+    vscode-textmate "^4.0.1"
+
 "@theia/navigator@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
   resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-0.4.0-next.5967a992.tgz#aa28eea7e5e6c61880b2dd7881f701e36aa6d0da"
@@ -1051,6 +1193,17 @@
     "@theia/core" "0.4.0-next.5967a992"
     "@theia/filesystem" "0.4.0-next.5967a992"
     "@theia/workspace" "0.4.0-next.5967a992"
+    fuzzy "^0.1.3"
+    minimatch "^3.0.4"
+
+"@theia/navigator@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-0.3.19.tgz#0f392938021456bd8d47ae2c33b0890ec60ad3b0"
+  integrity sha512-7Rb8jJSHl5VxDGO6Y+HH8+rutSPxM7LNAwKtD69VFp7giE6nQHnYdlyyHBhBxYDonPVP2MsSA8R3MfTXmosHyA==
+  dependencies:
+    "@theia/core" "^0.3.19"
+    "@theia/filesystem" "^0.3.19"
+    "@theia/workspace" "^0.3.19"
     fuzzy "^0.1.3"
     minimatch "^3.0.4"
 
@@ -1068,12 +1221,26 @@
   dependencies:
     "@theia/core" "0.4.0-next.5967a992"
 
+"@theia/outline-view@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-0.3.19.tgz#4880519797bc8997837080833090d60c129f63e8"
+  integrity sha512-BOwqsc2u0ou2v5gboqGlZ38CUgX23mHatbAQenOntEilHNYi4pcXdA6ogzfwgu+MigQGy+5aNa+vduJiGu77ew==
+  dependencies:
+    "@theia/core" "^0.3.19"
+
 "@theia/output@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
   resolved "https://registry.yarnpkg.com/@theia/output/-/output-0.4.0-next.5967a992.tgz#a484d64c43579d30f7f1d2e84e60b3f9a04da34d"
   integrity sha512-MWI6lIZoLU3nsS4Hp0kJ1k+9abyxZOhxqIoL6Ztj3+Bmo5+lfVOp3UnpSLt+z9fCm8lwPY/d8hVQ1SZ0dARmsA==
   dependencies:
     "@theia/core" "0.4.0-next.5967a992"
+
+"@theia/output@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/output/-/output-0.3.19.tgz#2d7bce2e568acf1a6a2eaac9a12eac0b30b3b896"
+  integrity sha512-5lK9N+ZQz8/O1Fq+ivFhQbDyg+FVNtW68RcTKWyT10N/Z9dlmoJ7QnwsEw/7njEleCB9W22ugmyyjJp7ik0L5w==
+  dependencies:
+    "@theia/core" "^0.3.19"
 
 "@theia/plugin-ext@next":
   version "0.4.0-next.5967a992"
@@ -1140,6 +1307,21 @@
     fs-extra "^4.0.2"
     jsonc-parser "^2.0.2"
 
+"@theia/preferences@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-0.3.19.tgz#10b9655c2a5dc88d515793810bbb942bcb864b58"
+  integrity sha512-shArvTSEvF1QBaVc+IykSJVtm8Ch4Eiri8wjpE/gK9FdqFOdHxEYwfXGHxj4/OojWu6Xdcm8eAYayC/gspYtRA==
+  dependencies:
+    "@theia/core" "^0.3.19"
+    "@theia/editor" "^0.3.19"
+    "@theia/filesystem" "^0.3.19"
+    "@theia/monaco" "^0.3.19"
+    "@theia/userstorage" "^0.3.19"
+    "@theia/workspace" "^0.3.19"
+    "@types/fs-extra" "^4.0.2"
+    fs-extra "^4.0.2"
+    jsonc-parser "^2.0.2"
+
 "@theia/process@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
   resolved "https://registry.yarnpkg.com/@theia/process/-/process-0.4.0-next.5967a992.tgz#6d1bd9587a0aef173f6fc6483dbfa53bb5149082"
@@ -1147,6 +1329,15 @@
   dependencies:
     "@theia/core" "0.4.0-next.5967a992"
     "@theia/node-pty" "0.7.8-theia004"
+    string-argv "^0.1.1"
+
+"@theia/process@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/process/-/process-0.3.19.tgz#1dddd0d3dfc4e6b87c76157fb10f33fb76179b70"
+  integrity sha512-H/hje3afKKaCq0rUXux/ZoXnJE6peP7TkhTlULfloAq1Yfjv7dH6CqBW8TLHc4ExJbCSoYqAQVmlG69WcqWCLQ==
+  dependencies:
+    "@theia/core" "^0.3.19"
+    node-pty "0.7.6"
     string-argv "^0.1.1"
 
 "@theia/search-in-workspace@0.4.0-next.5967a992":
@@ -1195,12 +1386,27 @@
     "@theia/core" "0.4.0-next.5967a992"
     "@theia/filesystem" "0.4.0-next.5967a992"
 
+"@theia/userstorage@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-0.3.19.tgz#2807679fc060b7343416d0217f2f884c919675f0"
+  integrity sha512-CETJznVFPsGb0V+M8t8LWc0sPPT+AKDkhmU+enT9kFKdg/JL4WOs+nY4BqTQnxNObXrMbOXfyatK43h+TcajOg==
+  dependencies:
+    "@theia/core" "^0.3.19"
+    "@theia/filesystem" "^0.3.19"
+
 "@theia/variable-resolver@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
   resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-0.4.0-next.5967a992.tgz#98df91afdc95648398c79676c2b5ef322d9dc063"
   integrity sha512-4UwFm1NqT9L505XxSp86X0goDnFHAHckog02Z9mZ3RtZE9GhlTLnqXrIcm5VSwLM5v+Pmw7VuXn3Gl2GupWaew==
   dependencies:
     "@theia/core" "0.4.0-next.5967a992"
+
+"@theia/variable-resolver@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-0.3.19.tgz#215671143c843f6187c414159a19208308972a07"
+  integrity sha512-6dMugQgsGs5ERnrjElFfvTglG+IxgQp0nYUkWGIfZkvbDo6zVe0coXY9pikIFxAJyrq1kkngCr6QwrNqq8gGRA==
+  dependencies:
+    "@theia/core" "^0.3.19"
 
 "@theia/workspace@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
@@ -1210,6 +1416,21 @@
     "@theia/core" "0.4.0-next.5967a992"
     "@theia/filesystem" "0.4.0-next.5967a992"
     "@theia/variable-resolver" "0.4.0-next.5967a992"
+    "@types/fs-extra" "^4.0.2"
+    ajv "^6.5.3"
+    fs-extra "^4.0.2"
+    jsonc-parser "^2.0.2"
+    moment "^2.21.0"
+    valid-filename "^2.0.1"
+
+"@theia/workspace@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-0.3.19.tgz#ad4f3234286371435345461f0577bec8f52f2132"
+  integrity sha512-qkCc/xfJT62ytSL+BcYU0BiVinn+d0jIYNxAb0KIvkk8S1uapkehJc60PZhYiTxramdQTo98b333iVCjMIIuEA==
+  dependencies:
+    "@theia/core" "^0.3.19"
+    "@theia/filesystem" "^0.3.19"
+    "@theia/variable-resolver" "^0.3.19"
     "@types/fs-extra" "^4.0.2"
     ajv "^6.5.3"
     fs-extra "^4.0.2"
@@ -1343,12 +1564,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/node@*":
-  version "11.9.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.9.4.tgz#ceb0048a546db453f6248f2d1d95e937a6f00a14"
-  integrity sha512-Zl8dGvAcEmadgs1tmSPcvwzO1YRsz38bVJQvH1RvRqSR9/5n61Q1ktcDL0ht3FXWR+ZpVmXVwN1LuH4Ax23NsA==
-
-"@types/node@11.9.4":
+"@types/node@*", "@types/node@11.9.4":
   version "11.9.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.9.4.tgz#ceb0048a546db453f6248f2d1d95e937a6f00a14"
   integrity sha512-Zl8dGvAcEmadgs1tmSPcvwzO1YRsz38bVJQvH1RvRqSR9/5n61Q1ktcDL0ht3FXWR+ZpVmXVwN1LuH4Ax23NsA==
@@ -6978,6 +7194,13 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
+node-pty@0.7.6:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.7.6.tgz#bff6148c9c5836ca7e73c7aaaec067dcbdac2f7b"
+  integrity sha512-ECzKUB7KkAFZ0cjyjMXp5WLJ+7YIZ1xnNmiiegOI6WdDaKABUNV5NbB1Dw9MXD4KrZipWII0wQ7RGZ6StU/7jA==
+  dependencies:
+    nan "2.10.0"
+
 noop-logger@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
@@ -8332,7 +8555,7 @@ retry@^0.10.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@latest:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -9466,6 +9689,11 @@ typescript@3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.3.tgz#01b70247a6d3c2467f70c45795ef5ea18ce191d5"
   integrity sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==
+
+typescript@latest:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3.tgz#f1657fc7daa27e1a8930758ace9ae8da31403221"
+  integrity sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==
 
 uglify-js@^3.1.4:
   version "3.4.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,10 +835,10 @@
   dependencies:
     execa "^0.2.2"
 
-"@theia/application-package@0.4.0-next.5967a992":
-  version "0.4.0-next.5967a992"
-  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-0.4.0-next.5967a992.tgz#0b351fde73d04358f847c89e2eae0c7db8babe50"
-  integrity sha512-jkfoMobS3uGhnfF8UramtN9khzW9ut1Rv1jSMlb2Gnfg5VPFQnBYNxJIlGbjEjTYj+5afhdTcPGcWGPllQfogg==
+"@theia/application-package@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-0.4.0-next.1ca7db0a.tgz#36c4f0c265e378d94acbf7637e61a3cbd99d8ecc"
+  integrity sha512-ksVe0pUAMimWvMrE8hafIqlAunHoc42nWp8q1RdV5f1AJXdHsdCHfVYb4D3MiPSIaeKbpeoRaUpo70uC/HF2zg==
   dependencies:
     "@types/fs-extra" "^4.0.2"
     "@types/request" "^2.0.3"
@@ -851,10 +851,10 @@
     semver "^5.4.1"
     write-json-file "^2.2.0"
 
-"@theia/application-package@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-0.3.19.tgz#31c111e727b081ac0e8c7dc4d0cbfecc1cdec533"
-  integrity sha512-dQ4xvabtCpXl7NAqEl4akRubVgvyes1/Z7iDMJQyKFci+DE4u7AS8BDn5fg8jCTOi/Q5MnXjNCSSWYkv/KBVlw==
+"@theia/application-package@0.4.0-next.5967a992":
+  version "0.4.0-next.5967a992"
+  resolved "https://registry.yarnpkg.com/@theia/application-package/-/application-package-0.4.0-next.5967a992.tgz#0b351fde73d04358f847c89e2eae0c7db8babe50"
+  integrity sha512-jkfoMobS3uGhnfF8UramtN9khzW9ut1Rv1jSMlb2Gnfg5VPFQnBYNxJIlGbjEjTYj+5afhdTcPGcWGPllQfogg==
   dependencies:
     "@types/fs-extra" "^4.0.2"
     "@types/request" "^2.0.3"
@@ -876,13 +876,13 @@
     "@theia/monaco" "0.4.0-next.5967a992"
     anser "^1.4.7"
 
-"@theia/core@0.4.0-next.5967a992", "@theia/core@next":
-  version "0.4.0-next.5967a992"
-  resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.4.0-next.5967a992.tgz#743168d28d5ae3e3e7d5e3c8fbafd777b123d7ad"
-  integrity sha512-v3350KgjTw7klRiPy/IVR2eMIY7Atk8w/Pb5eMaPJqCibuTwiTNRxlA0yL1sAxF1wIvg8gkfO0ClYxguY8Xf1A==
+"@theia/core@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.4.0-next.1ca7db0a.tgz#f851dc57cda1ba60c7d0759783f30adabb7961db"
+  integrity sha512-jem7dp02XqNibykZ0HUV/Skdjfj1H/hmR8ko4zjh14zEY/oAOpsSMcHuIQTDcBpxDmHmZ2PNZXSFjcukzIEfUg==
   dependencies:
     "@phosphor/widgets" "^1.5.0"
-    "@theia/application-package" "0.4.0-next.5967a992"
+    "@theia/application-package" "0.4.0-next.1ca7db0a"
     "@types/body-parser" "^1.16.4"
     "@types/bunyan" "^1.8.0"
     "@types/express" "^4.16.0"
@@ -897,6 +897,7 @@
     ajv "^6.5.3"
     body-parser "^1.17.2"
     electron "^2.0.14"
+    electron-store "^2.0.0"
     es6-promise "^4.2.4"
     express "^4.16.3"
     file-icons-js "^1.0.3"
@@ -920,13 +921,13 @@
     ws "^5.2.2"
     yargs "^11.1.0"
 
-"@theia/core@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.3.19.tgz#4bc0830224d94cef163a0dbe55042b9570d05f10"
-  integrity sha512-LS8UwImoWjVS2qBSuHF/6DZyNHJ3YdAboG8c0c2VAuVa1NCqlMCLag5WPyJ7aoQHpSyNbGcnuLa0hLS5EfRcEQ==
+"@theia/core@0.4.0-next.5967a992", "@theia/core@next":
+  version "0.4.0-next.5967a992"
+  resolved "https://registry.yarnpkg.com/@theia/core/-/core-0.4.0-next.5967a992.tgz#743168d28d5ae3e3e7d5e3c8fbafd777b123d7ad"
+  integrity sha512-v3350KgjTw7klRiPy/IVR2eMIY7Atk8w/Pb5eMaPJqCibuTwiTNRxlA0yL1sAxF1wIvg8gkfO0ClYxguY8Xf1A==
   dependencies:
     "@phosphor/widgets" "^1.5.0"
-    "@theia/application-package" "^0.3.19"
+    "@theia/application-package" "0.4.0-next.5967a992"
     "@types/body-parser" "^1.16.4"
     "@types/bunyan" "^1.8.0"
     "@types/express" "^4.16.0"
@@ -990,6 +991,17 @@
     vscode-debugprotocol "^1.32.0"
     vscode-uri "^1.0.1"
 
+"@theia/editor@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-0.4.0-next.1ca7db0a.tgz#cf2f42b3a4caaacfd8390fbfe423f5e60d605aef"
+  integrity sha512-DtRjYglFtIoJF5ZdAIM/h/6bqm5XhBAiu+ggmFRRNFiTR90R8YSypFdcGuBIqiVN61g5cKpD2Uiwo5zqkp8M1A==
+  dependencies:
+    "@theia/core" "0.4.0-next.1ca7db0a"
+    "@theia/languages" "0.4.0-next.1ca7db0a"
+    "@theia/variable-resolver" "0.4.0-next.1ca7db0a"
+    "@types/base64-arraybuffer" "0.1.0"
+    base64-arraybuffer "^0.1.5"
+
 "@theia/editor@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
   resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-0.4.0-next.5967a992.tgz#985106e23a9b6627b11744bd8b88a0cdf8d86b72"
@@ -998,17 +1010,6 @@
     "@theia/core" "0.4.0-next.5967a992"
     "@theia/languages" "0.4.0-next.5967a992"
     "@theia/variable-resolver" "0.4.0-next.5967a992"
-    "@types/base64-arraybuffer" "0.1.0"
-    base64-arraybuffer "^0.1.5"
-
-"@theia/editor@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/editor/-/editor-0.3.19.tgz#d5c3233b0bd35dee3ea9f73d52f58fbc8fb7639b"
-  integrity sha512-Pc6DuTwEkm/qi/aTEoY5yohq64/fjvCSkJsdMlV8d5yLhKZLX1Ot2u2ahE2j1a+ybi+ZF1XjO/5RpoElP6aumQ==
-  dependencies:
-    "@theia/core" "^0.3.19"
-    "@theia/languages" "^0.3.19"
-    "@theia/variable-resolver" "^0.3.19"
     "@types/base64-arraybuffer" "0.1.0"
     base64-arraybuffer "^0.1.5"
 
@@ -1024,6 +1025,35 @@
     "@theia/workspace" "0.4.0-next.5967a992"
     fuzzy "^0.1.3"
     vscode-ripgrep "^1.2.4"
+
+"@theia/filesystem@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-0.4.0-next.1ca7db0a.tgz#cca943a2bb5d30844bf01cf9939f83d5ed93939b"
+  integrity sha512-J2X3JiyCy6vp1RJFO9FcxItH1kgWwklyE2nNqG1gaujowko5eVz/onx3VJrByc+j9S4kQh1Cf+B7mPV05Y9T0Q==
+  dependencies:
+    "@theia/core" "0.4.0-next.1ca7db0a"
+    "@types/base64-js" "^1.2.5"
+    "@types/body-parser" "^1.17.0"
+    "@types/fs-extra" "^4.0.2"
+    "@types/mime-types" "^2.1.0"
+    "@types/rimraf" "^2.0.2"
+    "@types/tar-fs" "^1.16.1"
+    "@types/touch" "0.0.1"
+    "@types/uuid" "^3.4.3"
+    base64-js "^1.2.1"
+    body-parser "^1.18.3"
+    drivelist "^6.4.3"
+    fs-extra "^4.0.2"
+    http-status-codes "^1.3.0"
+    mime-types "^2.1.18"
+    minimatch "^3.0.4"
+    mv "^2.1.1"
+    rimraf "^2.6.2"
+    tar-fs "^1.16.2"
+    touch "^3.1.0"
+    trash "^4.0.1"
+    uuid "^3.2.1"
+    zip-dir "^1.0.2"
 
 "@theia/filesystem@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
@@ -1054,34 +1084,15 @@
     uuid "^3.2.1"
     zip-dir "^1.0.2"
 
-"@theia/filesystem@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-0.3.19.tgz#d1dce1c8a4f8c65c6ce949fee60205121e4af885"
-  integrity sha512-NdAA1HaZTmrrazooSEVcJBK2rAyCQSXHZsl5qN//qvoXueuLTm4OPwOEQymtHJEHBfDuTsC9kHb+AYVMMB4nxA==
+"@theia/json@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/json/-/json-0.4.0-next.1ca7db0a.tgz#55532bfa6004ea292cee2338834bf8876aca96fc"
+  integrity sha512-JchDWWf/FpDqk0VaSyHB4fTgSohlQqcpPOQJvhNyUBCFP2fFHNO53an5qSfM3Syk5imgeM48qb3IM0RGOlefmA==
   dependencies:
-    "@theia/core" "^0.3.19"
-    "@types/base64-js" "^1.2.5"
-    "@types/body-parser" "^1.17.0"
-    "@types/fs-extra" "^4.0.2"
-    "@types/mime-types" "^2.1.0"
-    "@types/rimraf" "^2.0.2"
-    "@types/tar-fs" "^1.16.1"
-    "@types/touch" "0.0.1"
-    "@types/uuid" "^3.4.3"
-    base64-js "^1.2.1"
-    body-parser "^1.18.3"
-    drivelist "^6.4.3"
-    fs-extra "^4.0.2"
-    http-status-codes "^1.3.0"
-    mime-types "^2.1.18"
-    minimatch "^3.0.4"
-    mv "^2.1.1"
-    rimraf "^2.6.2"
-    tar-fs "^1.16.2"
-    touch "^3.1.0"
-    trash "^4.0.1"
-    uuid "^3.2.1"
-    zip-dir "^1.0.2"
+    "@theia/core" "0.4.0-next.1ca7db0a"
+    "@theia/languages" "0.4.0-next.1ca7db0a"
+    "@theia/monaco" "0.4.0-next.1ca7db0a"
+    vscode-json-languageserver "^1.0.1"
 
 "@theia/json@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
@@ -1092,6 +1103,20 @@
     "@theia/languages" "0.4.0-next.5967a992"
     "@theia/monaco" "0.4.0-next.5967a992"
     vscode-json-languageserver "^1.0.1"
+
+"@theia/languages@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-0.4.0-next.1ca7db0a.tgz#f8948bbf62d5096bfa4530b9034a03634e4cbf5f"
+  integrity sha512-/QOnSRHXvpmL4Xi1Ah6Wd/8jFN2RddpApZ1xbiP+PyONUxwfdD3tugIN27MmLa4DsbfJpZgH4qGVinSVXaWLrw==
+  dependencies:
+    "@theia/core" "0.4.0-next.1ca7db0a"
+    "@theia/output" "0.4.0-next.1ca7db0a"
+    "@theia/process" "0.4.0-next.1ca7db0a"
+    "@theia/workspace" "0.4.0-next.1ca7db0a"
+    "@typefox/monaco-editor-core" "^0.14.6"
+    "@types/uuid" "^3.4.3"
+    monaco-languageclient "^0.9.0"
+    uuid "^3.2.1"
 
 "@theia/languages@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
@@ -1107,19 +1132,15 @@
     monaco-languageclient "^0.9.0"
     uuid "^3.2.1"
 
-"@theia/languages@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/languages/-/languages-0.3.19.tgz#564f30434ea9377787d56dbb26742a2e6bfa1607"
-  integrity sha512-EVVmukMAv/QYYx0ILK0XrP3NtjLeUJmp++IL0PGV92QYEK9R1x2nASXe0CWXEjeoPOqyYtq0SNWu+hGWsjlWVg==
+"@theia/markers@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-0.4.0-next.1ca7db0a.tgz#97537a8f5135e7dfe884a3cbd3b5a5d2b5b5a3ca"
+  integrity sha512-PSAh8Wp2iXhVuwOX89PhkdhvZ2xEo/T4j8ksGIXSHk3ne96gmYn6uqqywIiII78cfW1bOWpslSQgkbqQoUGSSw==
   dependencies:
-    "@theia/core" "^0.3.19"
-    "@theia/output" "^0.3.19"
-    "@theia/process" "^0.3.19"
-    "@theia/workspace" "^0.3.19"
-    "@typefox/monaco-editor-core" "^0.14.6"
-    "@types/uuid" "^3.4.3"
-    monaco-languageclient "^0.9.0"
-    uuid "^3.2.1"
+    "@theia/core" "0.4.0-next.1ca7db0a"
+    "@theia/filesystem" "0.4.0-next.1ca7db0a"
+    "@theia/navigator" "0.4.0-next.1ca7db0a"
+    "@theia/workspace" "0.4.0-next.1ca7db0a"
 
 "@theia/markers@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
@@ -1131,22 +1152,31 @@
     "@theia/navigator" "0.4.0-next.5967a992"
     "@theia/workspace" "0.4.0-next.5967a992"
 
-"@theia/markers@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/markers/-/markers-0.3.19.tgz#e13be2405c241cf263b036e6f0d648d532759601"
-  integrity sha512-gIi3MsukAwiNdII8JdxyOFxJFFV1q9YFpToZBkK9zNogFpxgXTwPLrk/chpXel10+Le9ed85of3EQ+0kvjQSAg==
-  dependencies:
-    "@theia/core" "^0.3.19"
-    "@theia/filesystem" "^0.3.19"
-    "@theia/navigator" "^0.3.19"
-    "@theia/workspace" "^0.3.19"
-
 "@theia/messages@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
   resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-0.4.0-next.5967a992.tgz#b1c668ada3d3bf123de102d56c8fc03d80130454"
   integrity sha512-yS/JIenf3Mx1lkPNz562xtpOk0kvUWU1obxI5vFMp+sMo9G9Mswbxno3OwzmilfcrSLHQxOwBA7e5WRAQwlk5Q==
   dependencies:
     "@theia/core" "0.4.0-next.5967a992"
+
+"@theia/monaco@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-0.4.0-next.1ca7db0a.tgz#2e64c68b4670a630a61d01cb132e6a1b7c0241a6"
+  integrity sha512-2At4KjzMCg2mK8jhIA6s0iHP7I/q3E3MZZ7DWFezd8YlgprMYL1ioT9IJMcg6FVDhJF0GQ1z0S+YgEVMql1KIQ==
+  dependencies:
+    "@theia/core" "0.4.0-next.1ca7db0a"
+    "@theia/editor" "0.4.0-next.1ca7db0a"
+    "@theia/filesystem" "0.4.0-next.1ca7db0a"
+    "@theia/languages" "0.4.0-next.1ca7db0a"
+    "@theia/markers" "0.4.0-next.1ca7db0a"
+    "@theia/outline-view" "0.4.0-next.1ca7db0a"
+    "@theia/workspace" "0.4.0-next.1ca7db0a"
+    deepmerge "2.0.1"
+    jsonc-parser "^2.0.2"
+    monaco-css "^2.0.1"
+    monaco-html "^2.0.2"
+    onigasm "^2.1.0"
+    vscode-textmate "^4.0.1"
 
 "@theia/monaco@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
@@ -1167,23 +1197,16 @@
     onigasm "^2.1.0"
     vscode-textmate "^4.0.1"
 
-"@theia/monaco@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/monaco/-/monaco-0.3.19.tgz#51e80e1a3e640fc54cccd047ba69fee799a067ea"
-  integrity sha512-nW/LNBCjJoLUKk37boVdBLH5ODXvqvkyCi/HC8sZPqeYLMWydgBfeN4Z8ch+t1PBds+sQpLlE7ozdz5xWnuqdw==
+"@theia/navigator@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-0.4.0-next.1ca7db0a.tgz#cebe0b700f82978022f40864cb1a9dd7b9c43cb2"
+  integrity sha512-/Wh/fLzP4vYBCMnsRxMfk9Ak+ySklQo12f7WVKvndHFeEL/R7ocz4NulEWkhRNB0xyYFIl23i7+yMwkklaV2JQ==
   dependencies:
-    "@theia/core" "^0.3.19"
-    "@theia/editor" "^0.3.19"
-    "@theia/filesystem" "^0.3.19"
-    "@theia/languages" "^0.3.19"
-    "@theia/markers" "^0.3.19"
-    "@theia/outline-view" "^0.3.19"
-    "@theia/workspace" "^0.3.19"
-    jsonc-parser "^2.0.2"
-    monaco-css "^2.0.1"
-    monaco-html "^2.0.2"
-    onigasm "^2.1.0"
-    vscode-textmate "^4.0.1"
+    "@theia/core" "0.4.0-next.1ca7db0a"
+    "@theia/filesystem" "0.4.0-next.1ca7db0a"
+    "@theia/workspace" "0.4.0-next.1ca7db0a"
+    fuzzy "^0.1.3"
+    minimatch "^3.0.4"
 
 "@theia/navigator@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
@@ -1196,23 +1219,19 @@
     fuzzy "^0.1.3"
     minimatch "^3.0.4"
 
-"@theia/navigator@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/navigator/-/navigator-0.3.19.tgz#0f392938021456bd8d47ae2c33b0890ec60ad3b0"
-  integrity sha512-7Rb8jJSHl5VxDGO6Y+HH8+rutSPxM7LNAwKtD69VFp7giE6nQHnYdlyyHBhBxYDonPVP2MsSA8R3MfTXmosHyA==
-  dependencies:
-    "@theia/core" "^0.3.19"
-    "@theia/filesystem" "^0.3.19"
-    "@theia/workspace" "^0.3.19"
-    fuzzy "^0.1.3"
-    minimatch "^3.0.4"
-
 "@theia/node-pty@0.7.8-theia004":
   version "0.7.8-theia004"
   resolved "https://registry.yarnpkg.com/@theia/node-pty/-/node-pty-0.7.8-theia004.tgz#0fe31b958df9315352d5fbeea7075047cf69c935"
   integrity sha512-GetaD2p1qVPq/xbNCHCwKYjIr9IWjksf9V2iiv/hV6f885cJ+ie0Osr4+C159PrwzGRYW2jQVUtXghBJoyOCLg==
   dependencies:
     nan "2.10.0"
+
+"@theia/outline-view@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-0.4.0-next.1ca7db0a.tgz#5fdedb3cda633bb88a022b8bcefc524e2bf24b71"
+  integrity sha512-KAoyTO8Ov9Flu5qBaPub9sTIn/UGAsw7LAdc+TA3vqBmuPz3MVx+Jy6/oK2E5PM95Edcp6VR1q84n+HnSfzntQ==
+  dependencies:
+    "@theia/core" "0.4.0-next.1ca7db0a"
 
 "@theia/outline-view@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
@@ -1221,12 +1240,12 @@
   dependencies:
     "@theia/core" "0.4.0-next.5967a992"
 
-"@theia/outline-view@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/outline-view/-/outline-view-0.3.19.tgz#4880519797bc8997837080833090d60c129f63e8"
-  integrity sha512-BOwqsc2u0ou2v5gboqGlZ38CUgX23mHatbAQenOntEilHNYi4pcXdA6ogzfwgu+MigQGy+5aNa+vduJiGu77ew==
+"@theia/output@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/output/-/output-0.4.0-next.1ca7db0a.tgz#d59c4b2328b031d25aa4f3fdb47cd3e70fcb32b5"
+  integrity sha512-x/TDnL6tLuqN4trnBQDPHAFckAxo20h05nH44FjZ/EGnrxL94VcvN1IBGwu0Zc8eL/MTcxUKydX8LqK/K0RKRA==
   dependencies:
-    "@theia/core" "^0.3.19"
+    "@theia/core" "0.4.0-next.1ca7db0a"
 
 "@theia/output@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
@@ -1234,13 +1253,6 @@
   integrity sha512-MWI6lIZoLU3nsS4Hp0kJ1k+9abyxZOhxqIoL6Ztj3+Bmo5+lfVOp3UnpSLt+z9fCm8lwPY/d8hVQ1SZ0dARmsA==
   dependencies:
     "@theia/core" "0.4.0-next.5967a992"
-
-"@theia/output@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/output/-/output-0.3.19.tgz#2d7bce2e568acf1a6a2eaac9a12eac0b30b3b896"
-  integrity sha512-5lK9N+ZQz8/O1Fq+ivFhQbDyg+FVNtW68RcTKWyT10N/Z9dlmoJ7QnwsEw/7njEleCB9W22ugmyyjJp7ik0L5w==
-  dependencies:
-    "@theia/core" "^0.3.19"
 
 "@theia/plugin-ext@next":
   version "0.4.0-next.5967a992"
@@ -1307,20 +1319,30 @@
     fs-extra "^4.0.2"
     jsonc-parser "^2.0.2"
 
-"@theia/preferences@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-0.3.19.tgz#10b9655c2a5dc88d515793810bbb942bcb864b58"
-  integrity sha512-shArvTSEvF1QBaVc+IykSJVtm8Ch4Eiri8wjpE/gK9FdqFOdHxEYwfXGHxj4/OojWu6Xdcm8eAYayC/gspYtRA==
+"@theia/preferences@next":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/preferences/-/preferences-0.4.0-next.1ca7db0a.tgz#cb5288d5057b4e3b8c66b8d1baf848b01ebfbda9"
+  integrity sha512-c2iuSRtKPJsliNkv/6JutUr2+czqYLMsmdTa2G8YBod5bLC59Z0DUWyIMnTFbCDbWY9z/F9RPCISVVBoxIa6PA==
   dependencies:
-    "@theia/core" "^0.3.19"
-    "@theia/editor" "^0.3.19"
-    "@theia/filesystem" "^0.3.19"
-    "@theia/monaco" "^0.3.19"
-    "@theia/userstorage" "^0.3.19"
-    "@theia/workspace" "^0.3.19"
+    "@theia/core" "0.4.0-next.1ca7db0a"
+    "@theia/editor" "0.4.0-next.1ca7db0a"
+    "@theia/filesystem" "0.4.0-next.1ca7db0a"
+    "@theia/json" "0.4.0-next.1ca7db0a"
+    "@theia/monaco" "0.4.0-next.1ca7db0a"
+    "@theia/userstorage" "0.4.0-next.1ca7db0a"
+    "@theia/workspace" "0.4.0-next.1ca7db0a"
     "@types/fs-extra" "^4.0.2"
     fs-extra "^4.0.2"
     jsonc-parser "^2.0.2"
+
+"@theia/process@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/process/-/process-0.4.0-next.1ca7db0a.tgz#8b753157cd90e822ef7f19cd47f6652fdbbc00de"
+  integrity sha512-ccZjeF+4IXdtd8cx5Dzl24Oljc2HuvrtYIiypQ/zEWLRiiQNwhqyA2CzPX476TdT1TzqxnEAUY/L+gkn8gx7GA==
+  dependencies:
+    "@theia/core" "0.4.0-next.1ca7db0a"
+    "@theia/node-pty" "0.7.8-theia004"
+    string-argv "^0.1.1"
 
 "@theia/process@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
@@ -1329,15 +1351,6 @@
   dependencies:
     "@theia/core" "0.4.0-next.5967a992"
     "@theia/node-pty" "0.7.8-theia004"
-    string-argv "^0.1.1"
-
-"@theia/process@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/process/-/process-0.3.19.tgz#1dddd0d3dfc4e6b87c76157fb10f33fb76179b70"
-  integrity sha512-H/hje3afKKaCq0rUXux/ZoXnJE6peP7TkhTlULfloAq1Yfjv7dH6CqBW8TLHc4ExJbCSoYqAQVmlG69WcqWCLQ==
-  dependencies:
-    "@theia/core" "^0.3.19"
-    node-pty "0.7.6"
     string-argv "^0.1.1"
 
 "@theia/search-in-workspace@0.4.0-next.5967a992":
@@ -1378,6 +1391,14 @@
     "@theia/workspace" "0.4.0-next.5967a992"
     xterm "3.9.2"
 
+"@theia/userstorage@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-0.4.0-next.1ca7db0a.tgz#b57b61d1002fd39eb5fec206a1854f9d53eb8a37"
+  integrity sha512-qxzHe6OIxbdcxkO4Fu9DSFiZPHTXt7sZp2x6K3ekL3OiTdDxMgPn6AQLu1UZJRe86dWmVKkRXP5qy26qRMsrRA==
+  dependencies:
+    "@theia/core" "0.4.0-next.1ca7db0a"
+    "@theia/filesystem" "0.4.0-next.1ca7db0a"
+
 "@theia/userstorage@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
   resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-0.4.0-next.5967a992.tgz#5ceb712f21a942a9d64dfea6008557e5c97fe012"
@@ -1386,13 +1407,12 @@
     "@theia/core" "0.4.0-next.5967a992"
     "@theia/filesystem" "0.4.0-next.5967a992"
 
-"@theia/userstorage@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/userstorage/-/userstorage-0.3.19.tgz#2807679fc060b7343416d0217f2f884c919675f0"
-  integrity sha512-CETJznVFPsGb0V+M8t8LWc0sPPT+AKDkhmU+enT9kFKdg/JL4WOs+nY4BqTQnxNObXrMbOXfyatK43h+TcajOg==
+"@theia/variable-resolver@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-0.4.0-next.1ca7db0a.tgz#22550fd9639c3f38a9c94fea66803f576f8ec1e4"
+  integrity sha512-mm8S0CXhQng+rFBXNdvIuHSVYz4Dv/mrwxrGcqzS8KnrvXUPa6kdU8qa9XHumxKf3T5ewSyj9VIRrtC3K3eueA==
   dependencies:
-    "@theia/core" "^0.3.19"
-    "@theia/filesystem" "^0.3.19"
+    "@theia/core" "0.4.0-next.1ca7db0a"
 
 "@theia/variable-resolver@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
@@ -1401,12 +1421,20 @@
   dependencies:
     "@theia/core" "0.4.0-next.5967a992"
 
-"@theia/variable-resolver@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/variable-resolver/-/variable-resolver-0.3.19.tgz#215671143c843f6187c414159a19208308972a07"
-  integrity sha512-6dMugQgsGs5ERnrjElFfvTglG+IxgQp0nYUkWGIfZkvbDo6zVe0coXY9pikIFxAJyrq1kkngCr6QwrNqq8gGRA==
+"@theia/workspace@0.4.0-next.1ca7db0a":
+  version "0.4.0-next.1ca7db0a"
+  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-0.4.0-next.1ca7db0a.tgz#5c213e9e0a71a57a92cf20a606a93a71c3b35d13"
+  integrity sha512-0+5U6aEEdC1SecUxbVmUsX3z+b6SScs6pPvH5LrOL31KRIMs05HMYO5OW+Qywt9M8uc6g0X4SeRpNoXOPZ9efA==
   dependencies:
-    "@theia/core" "^0.3.19"
+    "@theia/core" "0.4.0-next.1ca7db0a"
+    "@theia/filesystem" "0.4.0-next.1ca7db0a"
+    "@theia/variable-resolver" "0.4.0-next.1ca7db0a"
+    "@types/fs-extra" "^4.0.2"
+    ajv "^6.5.3"
+    fs-extra "^4.0.2"
+    jsonc-parser "^2.0.2"
+    moment "^2.21.0"
+    valid-filename "^2.0.1"
 
 "@theia/workspace@0.4.0-next.5967a992":
   version "0.4.0-next.5967a992"
@@ -1416,21 +1444,6 @@
     "@theia/core" "0.4.0-next.5967a992"
     "@theia/filesystem" "0.4.0-next.5967a992"
     "@theia/variable-resolver" "0.4.0-next.5967a992"
-    "@types/fs-extra" "^4.0.2"
-    ajv "^6.5.3"
-    fs-extra "^4.0.2"
-    jsonc-parser "^2.0.2"
-    moment "^2.21.0"
-    valid-filename "^2.0.1"
-
-"@theia/workspace@^0.3.19":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-0.3.19.tgz#ad4f3234286371435345461f0577bec8f52f2132"
-  integrity sha512-qkCc/xfJT62ytSL+BcYU0BiVinn+d0jIYNxAb0KIvkk8S1uapkehJc60PZhYiTxramdQTo98b333iVCjMIIuEA==
-  dependencies:
-    "@theia/core" "^0.3.19"
-    "@theia/filesystem" "^0.3.19"
-    "@theia/variable-resolver" "^0.3.19"
     "@types/fs-extra" "^4.0.2"
     ajv "^6.5.3"
     fs-extra "^4.0.2"
@@ -3153,6 +3166,17 @@ concurrently@^3.5.0:
     supports-color "^3.2.3"
     tree-kill "^1.1.0"
 
+conf@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/conf/-/conf-2.2.0.tgz#ee282efafc1450b61e205372041ad7d866802d9a"
+  integrity sha512-93Kz74FOMo6aWRVpAZsonOdl2I57jKtHrNmxhumehFQw4X8Sk37SohNY11PG7Q8Okta+UnrVaI006WLeyp8/XA==
+  dependencies:
+    dot-prop "^4.1.0"
+    env-paths "^1.0.0"
+    make-dir "^1.0.0"
+    pkg-up "^2.0.0"
+    write-file-atomic "^2.3.0"
+
 config-chain@^1.1.11:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
@@ -3816,7 +3840,7 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-dot-prop@^4.2.0:
+dot-prop@^4.1.0, dot-prop@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
   integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
@@ -3889,6 +3913,13 @@ electron-download@^3.0.1:
     semver "^5.3.0"
     sumchecker "^1.2.0"
 
+electron-store@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/electron-store/-/electron-store-2.0.0.tgz#1035cca2a95409d1f54c7466606345852450d64a"
+  integrity sha512-1WCFYHsYvZBqDsoaS0Relnz0rd81ZkBAI0Fgx7Nq2UWU77rSNs1qxm4S6uH7TCZ0bV3LQpJFk7id/is/ZgoOPA==
+  dependencies:
+    conf "^2.0.0"
+
 electron@^2.0.14:
   version "2.0.17"
   resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.17.tgz#871c02eabcdfe11f7452c01b2f36510241b6de19"
@@ -3943,6 +3974,11 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
     graceful-fs "^4.1.2"
     memory-fs "^0.4.0"
     tapable "^1.0.0"
+
+env-paths@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
+  integrity sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=
 
 err-code@^1.0.0:
   version "1.1.2"
@@ -7194,13 +7230,6 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-pty@0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.7.6.tgz#bff6148c9c5836ca7e73c7aaaec067dcbdac2f7b"
-  integrity sha512-ECzKUB7KkAFZ0cjyjMXp5WLJ+7YIZ1xnNmiiegOI6WdDaKABUNV5NbB1Dw9MXD4KrZipWII0wQ7RGZ6StU/7jA==
-  dependencies:
-    nan "2.10.0"
-
 noop-logger@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
@@ -7873,6 +7902,13 @@ pkg-dir@^3.0.0:
   integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
   dependencies:
     find-up "^3.0.0"
+
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
+  integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
+  dependencies:
+    find-up "^2.1.0"
 
 pn@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Theia user preferences synchronizer is designed to handle Theia user settings synchronization between workspaces. It retrieves Theia user preferences from Che user preferences on Theia server start and watches changes, so when any update is done it will be reflected back to Che storage.

Depends on [Preferences API PR](https://github.com/eclipse/che-theia/pull/79)

Signed-off-by: Mykola Morhun <mmorhun@redhat.com>