### PR TITLE
Install procps into java8 image

### DIFF
--- a/dockerfiles/remote-plugin-runner-java8/Dockerfile
+++ b/dockerfiles/remote-plugin-runner-java8/Dockerfile
@@ -9,6 +9,6 @@
 #   Red Hat, Inc. - initial API and implementation
 
 FROM eclipse/che-theia-endpoint-runtime:nightly
-RUN apk --no-cache add openjdk8
+RUN apk --no-cache add openjdk8 procps
 ENV JAVA_HOME /usr/lib/jvm/default-jvm/
 WORKDIR /projects


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

Current `ps` utility isn't full, it is a [BusyBox command](https://busybox.net/downloads/BusyBox.html#ps).
[Java Language Server](https://github.com/eclipse/eclipse.jdt.ls/blob/master/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ParentProcessWatcher.java#L66) checks if the process is alive by executing `ps -p [PID]`, but `-p` is unknown parameter for current version of `procps`.

This PR adds full `procps` into the `eclipse/che-remote-plugin-runner-java8` image.