### PR TITLE
Show status bar message if workspace is in ephemeral mode

### DIFF
--- a/plugins/factory-plugin/src/ephemeral-workspace-checker.ts
+++ b/plugins/factory-plugin/src/ephemeral-workspace-checker.ts
@@ -13,19 +13,20 @@ import * as che from '@eclipse-che/plugin';
 import { che as cheApi } from '@eclipse-che/api';
 
 /**
- * Make checks on workspace configuration and shows dedicated information to user.
+ * Make checks on workspace ephemeral configuration and shows dedicated information to user.
  */
-export class WorkspaceManager {
+export class EphemeralWorkspaceChecker {
 
     constructor() {
     }
 
-    async run() {
-        const workspace = await che.workspace.getCurrentWorkspace();
-        const isEphemeralWorkspace = this.isEphemeralWorkspace(workspace);
-        if (isEphemeralWorkspace) {
-            this.displayEphemeralWarning();
-        }
+    public check() {
+        che.workspace.getCurrentWorkspace().then((workspace: cheApi.workspace.Workspace) => {
+            const isEphemeralWorkspace = this.isEphemeralWorkspace(workspace);
+            if (isEphemeralWorkspace) {
+                this.displayEphemeralWarning();
+            }
+        });
     }
 
     /**

--- a/plugins/factory-plugin/src/factory-plugin.ts
+++ b/plugins/factory-plugin/src/factory-plugin.ts
@@ -11,7 +11,7 @@
 import * as theia from '@theia/plugin';
 import { FactoryInitializer } from './factory-initializer';
 import { WorkspaceProjectsManager } from './workspace-projects-manager';
-import { WorkspaceManager } from './workspace-manager';
+import { EphemeralWorkspaceChecker } from './ephemeral-workspace-checker';
 
 export async function start(context: theia.PluginContext) {
     let projectsRoot = '/projects';
@@ -20,7 +20,7 @@ export async function start(context: theia.PluginContext) {
         projectsRoot = projectsRootEnvVar;
     }
 
-    await new WorkspaceManager().run();
+    new EphemeralWorkspaceChecker().check();
     await new FactoryInitializer(projectsRoot).run();
     await new WorkspaceProjectsManager(context, projectsRoot).run();
 }

--- a/plugins/factory-plugin/src/factory-plugin.ts
+++ b/plugins/factory-plugin/src/factory-plugin.ts
@@ -11,6 +11,7 @@
 import * as theia from '@theia/plugin';
 import { FactoryInitializer } from './factory-initializer';
 import { WorkspaceProjectsManager } from './workspace-projects-manager';
+import { WorkspaceManager } from './workspace-manager';
 
 export async function start(context: theia.PluginContext) {
     let projectsRoot = '/projects';
@@ -19,6 +20,7 @@ export async function start(context: theia.PluginContext) {
         projectsRoot = projectsRootEnvVar;
     }
 
+    await new WorkspaceManager().run();
     await new FactoryInitializer(projectsRoot).run();
     await new WorkspaceProjectsManager(context, projectsRoot).run();
 }

--- a/plugins/factory-plugin/src/workspace-manager.ts
+++ b/plugins/factory-plugin/src/workspace-manager.ts
@@ -1,0 +1,48 @@
+/*********************************************************************
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import * as theia from '@theia/plugin';
+import * as che from '@eclipse-che/plugin';
+import { che as cheApi } from '@eclipse-che/api';
+
+/**
+ * Make checks on workspace configuration and shows dedicated information to user.
+ */
+export class WorkspaceManager {
+
+    constructor() {
+    }
+
+    async run() {
+        const workspace = await che.workspace.getCurrentWorkspace();
+        const isEphemeralWorkspace = this.isEphemeralWorkspace(workspace);
+        if (isEphemeralWorkspace) {
+            this.displayEphemeralWarning();
+        }
+    }
+
+    /**
+     * Displays warning in status bar, that workspace is ephemeral.
+     */
+    private displayEphemeralWarning() {
+        const item = theia.window.createStatusBarItem(theia.StatusBarAlignment.Left);
+        item.text = '$(exclamation-triangle) Ephemeral Mode';
+        item.tooltip = 'All changes to the source code will be lost when the workspace is stopped unless they are pushed to a source code repository.';
+        item.color = '#fcc13d';
+        item.show();
+    }
+
+    /**
+     * Returns, whether provided workspace is ephmeral or not.
+     */
+    private isEphemeralWorkspace(workspace: cheApi.workspace.Workspace): boolean {
+        return workspace!.config!.attributes!.persistVolumes === 'true' || false;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

Show warning to user in Che Theia status bar - "Ephemeral mode" and tooltip "All changes to the source code will be lost when the workspace is stopped unless they are pushed to a source code repository."

Issue - https://github.com/eclipse/che/issues/12565

![screenshot from 2019-02-28 13-34-00](https://user-images.githubusercontent.com/1611939/53563726-9b98f200-3b5d-11e9-8cb7-d6a940885d86.png)

_A note: background of status bar item cannot be set by plugin API, thus only font color._
