### PR TITLE
Set permissions for .cache folder

### DIFF
--- a/dockerfiles/remote-plugin-go-1.10.7/Dockerfile
+++ b/dockerfiles/remote-plugin-go-1.10.7/Dockerfile
@@ -67,6 +67,8 @@ RUN set -eux; \
     ; \
 	apk del .build-deps \
     ; \
+	mkdir ${HOME}/.cache && chmod -R 777 ${HOME}/.cache \
+	; \
     go version
 
 ENV GOPATH /go


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

### What does this PR do
In OpenShift `anyuid` is off, as a result a user in a container does not have write permissions to some directories. This PR sets permissions for user to get access to `.cache` folder which is used by GO plugin.

