### PR TITLE
Reverse logic on ephemeral mode detecting

### DIFF
--- a/plugins/factory-plugin/src/ephemeral-workspace-checker.ts
+++ b/plugins/factory-plugin/src/ephemeral-workspace-checker.ts
@@ -44,6 +44,6 @@ export class EphemeralWorkspaceChecker {
      * Returns, whether provided workspace is ephmeral or not.
      */
     private isEphemeralWorkspace(workspace: cheApi.workspace.Workspace): boolean {
-        return workspace!.config!.attributes!.persistVolumes === 'true' || false;
+        return workspace!.config!.attributes!.persistVolumes === 'false' || false;
     }
 }


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

Reverse logic on how ephemeral mode is detected.
**Ephemeral mode** : property `persistVolumes` exists and is `false`
**Not Ephemeral mode**: no property `persistVolumes` or `persistVolumes` is `true`
