### PR TITLE
Add Dockerfile to build an image for the OpenShift Connector Che Plugin

### DIFF
--- a/build_and_push_docker_images.sh
+++ b/build_and_push_docker_images.sh
@@ -20,6 +20,7 @@ dockerfiles/theia-endpoint-runtime
 dockerfiles/remote-plugin-runner-java8
 dockerfiles/remote-plugin-go-1.10.7
 dockerfiles/remote-plugin-python-3.7.2
+dockerfiles/remote-plugin-openshift-connector-0.0.17
 )
 
 IMAGES_LIST=(
@@ -29,6 +30,7 @@ eclipse/che-theia-endpoint-runtime
 eclipse/che-remote-plugin-runner-java8
 eclipse/che-remote-plugin-go-1.10.7
 eclipse/che-remote-plugin-python-3.7.2
+eclipse/che-remote-plugin-openshift-connector-0.0.17
 )
 
 

--- a/dockerfiles/remote-plugin-openshift-connector-0.0.17/Dockerfile
+++ b/dockerfiles/remote-plugin-openshift-connector-0.0.17/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:${BUILD_TAG}
+
+ENV GLIBC_VERSION 2.29-r0
+ENV OC_VERSION v3.11.0
+ENV OC_TAG 0cbc58b
+
+# install glibc compatibility layer package for Alpine Linux
+# see https://github.com/openshift/origin/issues/18942 for the details
+RUN wget -O glibc-${GLIBC_VERSION}.apk https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk && \
+    apk --allow-untrusted add glibc-${GLIBC_VERSION}.apk && \
+    rm -f glibc-${GLIBC_VERSION}.apk && \
+    # install ODO
+    wget -O /usr/local/bin/odo https://github.com/redhat-developer/odo/releases/download/v0.0.19/odo-linux-amd64 && \
+    chmod +x /usr/local/bin/odo && \
+    # install OC
+    wget -O- https://github.com/openshift/origin/releases/download/${OC_VERSION}/openshift-origin-client-tools-${OC_VERSION}-${OC_TAG}-linux-64bit.tar.gz | tar xvz -C /usr/local/bin --strip 1

--- a/dockerfiles/remote-plugin-openshift-connector-0.0.17/build.sh
+++ b/dockerfiles/remote-plugin-openshift-connector-0.0.17/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
+
+init --name:remote-plugin-openshift-connector-0.0.17 "$@"
+build


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

### What does this PR do?

The PR adds Dockerfile to build an image for the [OpenShift Connector Che Plugin](https://github.com/eclipse/che-plugin-registry/pull/104).

The related issue https://github.com/eclipse/che/issues/11488
