### PR TITLE
Add Dockerfile to build an image with .Net Core SDK

### DIFF
--- a/build_and_push_docker_images.sh
+++ b/build_and_push_docker_images.sh
@@ -20,6 +20,7 @@ dockerfiles/theia-endpoint-runtime
 dockerfiles/remote-plugin-runner-java8
 dockerfiles/remote-plugin-go-1.10.7
 dockerfiles/remote-plugin-python-3.7.2
+dockerfiles/remote-plugin-dotnet-2.2.105
 dockerfiles/remote-plugin-kubernetes-tooling-0.1.17
 dockerfiles/remote-plugin-openshift-connector-0.0.17
 )
@@ -31,6 +32,7 @@ eclipse/che-theia-endpoint-runtime
 eclipse/che-remote-plugin-runner-java8
 eclipse/che-remote-plugin-go-1.10.7
 eclipse/che-remote-plugin-python-3.7.2
+eclipse/che-remote-plugin-dotnet-2.2.105
 eclipse/che-remote-plugin-kubernetes-tooling-0.1.17
 eclipse/che-remote-plugin-openshift-connector-0.0.17
 )

--- a/dockerfiles/remote-plugin-dotnet-2.2.105/Dockerfile
+++ b/dockerfiles/remote-plugin-dotnet-2.2.105/Dockerfile
@@ -1,0 +1,57 @@
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:${BUILD_TAG}
+
+RUN apk add --no-cache \
+    ca-certificates \
+    \
+    # .NET Core dependencies
+    krb5-libs \
+    libgcc \
+    libintl \
+    icu-libs \
+    libssl1.0 \
+    libstdc++ \
+    tzdata \
+    userspace-rcu \
+    zlib \
+    lttng-ust \
+    bash \
+    mono mono-dev mono-lang --repository=http://dl-4.alpinelinux.org/alpine/edge/testing \
+    musl\>1.1.20 --repository http://dl-cdn.alpinelinux.org/alpine/edge/main
+
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8
+
+# Install .NET Core SDK
+ENV DOTNET_SDK_VERSION 2.2.105
+
+RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
+    && dotnet_sha512='04045f20440fca38bc517cf6ae1c6bea48e773629ada8b86f3ce0394784b1372a180aa829fa2bcc5abc184a0e41babe7c5ff0ef376c2b89aad271a0cfb3d75e4' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm dotnet.tar.gz
+
+ENV MSBuildSDKsPath=/usr/share/dotnet/sdk/2.2.105/Sdks \
+    PATH=$MSBuildSDKsPath:$PATH
+
+RUN wget -O /usr/lib/mono/xbuild/15.0/Microsoft.Common.props https://raw.githubusercontent.com/Microsoft/msbuild/v15.9.21.664/src/Tasks/Microsoft.Common.props
+
+# Enable correct mode for dotnet watch (only mode supported in a container)
+ENV DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip
+
+# Trigger first run experience by running arbitrary cmd to populate local package cache
+RUN dotnet --version

--- a/dockerfiles/remote-plugin-dotnet-2.2.105/Dockerfile
+++ b/dockerfiles/remote-plugin-dotnet-2.2.105/Dockerfile
@@ -43,7 +43,7 @@ RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DO
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && rm dotnet.tar.gz
 
-ENV MSBuildSDKsPath=/usr/share/dotnet/sdk/2.2.105/Sdks \
+ENV MSBuildSDKsPath=/usr/share/dotnet/sdk/$DOTNET_SDK_VERSION/Sdks \
     PATH=$MSBuildSDKsPath:$PATH
 
 RUN wget -O /usr/lib/mono/xbuild/15.0/Microsoft.Common.props https://raw.githubusercontent.com/Microsoft/msbuild/v15.9.21.664/src/Tasks/Microsoft.Common.props

--- a/dockerfiles/remote-plugin-dotnet-2.2.105/build.sh
+++ b/dockerfiles/remote-plugin-dotnet-2.2.105/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
+
+init --name:remote-plugin-dotnet-2.2.105 "$@"
+build


### PR DESCRIPTION
Provides a dockerfile to build an image which will make it possible to run OmniSharp-Roslyn as a C# language support. 

It is need for https://github.com/eclipse/che/issues/12792