### PR TITLE
Fix the workspace URL for UD

### DIFF
--- a/extensions/eclipse-che-theia-dashboard/src/browser/theia-dashboard-client.ts
+++ b/extensions/eclipse-che-theia-dashboard/src/browser/theia-dashboard-client.ts
@@ -92,7 +92,7 @@ export class TheiaDashboardClient implements FrontendApplicationContribution {
         }
         const ideWorkspaceUrl = workspace!.links!.ide!;
 
-        return ideWorkspaceUrl.replace('/che/', '/dashboard/#/ide/che/');
+        return ideWorkspaceUrl.replace(/^https?:\/\/[^\/]+/, match => `${match}/dashboard/#/ide`);
     }
 
 }


### PR DESCRIPTION
Existing solution, which depends on user ''che", doesn't work with che-multiuser.

In this PR regexp and replacement were fixed.

Signed-off-by: Oleksii Orel <oorel@redhat.com>