### PR TITLE
Add icon for 'Containers' view container

### DIFF
--- a/plugins/containers-plugin/package.json
+++ b/plugins/containers-plugin/package.json
@@ -7,14 +7,16 @@
   "version": "0.0.2",
   "license": "EPL-2.0",
   "files": [
-    "src"
+    "src",
+    "resources"
   ],
   "contributes": {
     "viewsContainers": {
       "right": [
         {
           "id": "containers",
-          "title": "Containers"
+          "title": "Containers",
+          "icon": "resources/cube.svg"
         }
       ]
     },

--- a/plugins/containers-plugin/resources/cube.svg
+++ b/plugins/containers-plugin/resources/cube.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="12px" height="12px" viewBox="0 0 98 90">
+    <path d="M94.0,21.0L49.0,4.5c-0.5-0.2-1.0-0.2-1.5,0L1.6,21.0c-0.5,0.2-0.9,0.5-1.0,1.0
+			C0.2,22.0,0,22.0,0,23.0V74.0c0,1.0,0.5,2.0,1.5,2.0L47.0,91.0c0.5,0.2,1.5,0.2,1.5,0
+			l45.5-16.0c1.0-0.3,1.5-1.2,1.5-2.0V23.0C96.0,22.0,95.0,22.0,94.0,21.0z M48.0,37.0
+			l-34.5-12.0l34.0-12.0l33.0,12.0L48.0,37.0z M88.0,67.0L53.0,82.0V44.0l35.0-13.0V69.5z"/>
+</svg>

--- a/plugins/containers-plugin/resources/cube.svg
+++ b/plugins/containers-plugin/resources/cube.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2012-2018 Red Hat, Inc.
+    Copyright (c) 2012-2019 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/


### PR DESCRIPTION
Recent changes in Theia requires to provide an icon for `viewContainer`, so this pull add icon for containers plugin. Icon copied from [there ](https://github.com/eclipse/che/blob/master/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/machine/cube.svg)
Signed-off-by: Yevhen Vydolob <yvydolob@redhat.com>