### PR TITLE
Add Helm into K8s plugin container to enable Helm funtionality

### DIFF
--- a/dockerfiles/remote-plugin-kubernetes-tooling-0.1.17/Dockerfile
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-0.1.17/Dockerfile
@@ -10,9 +10,11 @@
 
 FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:${BUILD_TAG}
 
-ENV KUBECTL_VERSION v1.13.4
+ENV KUBECTL_VERSION v1.14.0
+ENV HELM_VERSION v2.13.1
 
-WORKDIR /usr/local/bin
-
-RUN wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
-    chmod +x ./kubectl
+RUN apk add --no-cache ca-certificates && \
+    wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    wget -O- https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar xvz -C /usr/local/bin --strip 1 && \
+    helm init --client-only


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

### What does this PR do?
The PR extends the K8s plugin image:
- updates bundled `kubectl` version to 1.14.0;
- adds Helm client and certificates required by Helm to interact with the Chart repositories;
- sets up a local configuration for Helm to enable `Helm Repos` tree with no extra steps required from the user.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12982
