### PR TITLE
[ports plug-in] Limit the number of pre-defined routes to #3

### DIFF
--- a/che-plugins/che-editor-theia/etc/che-plugin.yaml
+++ b/che-plugins/che-editor-theia/etc/che-plugin.yaml
@@ -40,42 +40,6 @@ endpoints:
     attributes:
       protocol: http
       discoverable: false
- -  name: "theia-redirect-4"
-    public: true
-    targetPort: 13134
-    attributes:
-      protocol: http
-      discoverable: false
- -  name: "theia-redirect-5"
-    public: true
-    targetPort: 13135
-    attributes:
-      protocol: http
-      discoverable: false
- -  name: "theia-redirect-6"
-    public: true
-    targetPort: 13136
-    attributes:
-      protocol: http
-      discoverable: false
- -  name: "theia-redirect-7"
-    public: true
-    targetPort: 13137
-    attributes:
-      protocol: http
-      discoverable: false
- -  name: "theia-redirect-8"
-    public: true
-    targetPort: 13138
-    attributes:
-      protocol: http
-      discoverable: false
- -  name: "theia-redirect-9"
-    public: true
-    targetPort: 13139
-    attributes:
-      protocol: http
-      discoverable: false
 containers:
  - name: theia-ide
    image: eclipse/che-theia:next
@@ -97,11 +61,5 @@ containers:
        - exposedPort: 13131
        - exposedPort: 13132
        - exposedPort: 13133
-       - exposedPort: 13134
-       - exposedPort: 13135
-       - exposedPort: 13136
-       - exposedPort: 13137
-       - exposedPort: 13138
-       - exposedPort: 13139
    memory-limit: "1536M"
    memoryLimit: "1536M"

--- a/plugins/ports-plugin/src/ports-plugin.ts
+++ b/plugins/ports-plugin/src/ports-plugin.ts
@@ -85,6 +85,13 @@ async function askRedirect(port: Port, redirectMessage: string, errorMessage: st
 // Callback when a new port is being opened in workspace
 async function onOpenPort(port: Port) {
 
+    // handle ephemeral ports
+    if (port.portNumber >= 32000) {
+        // this port is ephemeral so just print a notice but does not propose a redirect
+        await theia.window.showInformationMessage(`Ephemeral port now listening on port ${port.portNumber} (port range >= 32000). No redirect proposed for ephemerals.`);
+        return;
+    }
+
     // if not listening on 0.0.0.0 then raise a prompt to add a port redirect
     if (port.interfaceListen !== LISTEN_ALL_IPV4 && port.interfaceListen !== LISTEN_ALL_IPV6) {
         const desc = `A new process is now listening on port ${port.portNumber} but is listening on interface ${port.interfaceListen} which is internal.


### PR DESCRIPTION
### What does this PR do?

Limit the number of pre-defined routes to #3
Also do not propose redirect for ephemeral ports

### What issues does this PR fix or reference?
#139 

Change-Id: I98570624346a5a63cfd55da66677cced634aa775
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
