### PR TITLE
Plugin management

### DIFF
--- a/che-plugins/che-editor-theia/etc/che-plugin.yaml
+++ b/che-plugins/che-editor-theia/etc/che-plugin.yaml
@@ -46,6 +46,8 @@ containers:
    env:
        - name: THEIA_PLUGINS
          value: local-dir:///plugins
+       - name: VSCODE_PLUGINS
+         value: local-dir:///vscode-plugins
        - name: HOSTED_PLUGIN_HOSTNAME
          value: 0.0.0.0
        - name: HOSTED_PLUGIN_PORT
@@ -53,6 +55,8 @@ containers:
    volumes:
        - mountPath: "/plugins"
          name: plugins
+       - mountPath: "/vscode-plugins"
+         name: vscode-plugins
        - mountPath: "/home/theia/.theia"
          name: theia-data
        - mountPath: "/projects"

--- a/extensions/eclipse-che-theia-plugin-ext/package.json
+++ b/extensions/eclipse-che-theia-plugin-ext/package.json
@@ -16,7 +16,9 @@
         "@eclipse-che/plugin": "0.0.1",
         "@eclipse-che/workspace-client": "latest",
         "@theia/core": "next",
-        "@theia/plugin-ext": "next"
+        "@theia/plugin-ext": "next",
+        "axios": "0.18.0",
+        "js-yaml": "3.12.0"
     },
     "devDependencies": {
         "clean-webpack-plugin": "^0.1.19",
@@ -24,7 +26,8 @@
         "ts-node": "5.0.1",
         "webpack": "^4.20.2",
         "webpack-cli": "^3.1.1",
-        "typescript-formatter": "7.2.2"
+        "typescript-formatter": "7.2.2",
+        "@types/js-yaml": "3.11.2"
     },
     "scripts": {
         "prepare": "yarn clean && yarn build",

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-frontend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-frontend-module.ts
@@ -8,18 +8,30 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
+import '../../src/browser/style/che-plugins.css';
+
 import { ContainerModule } from 'inversify';
 import { MainPluginApiProvider } from '@theia/plugin-ext/lib/common/plugin-ext-api-contribution';
 import { CheApiProvider } from './che-api-provider';
 import {
     CHE_API_SERVICE_PATH,
     CHE_TASK_SERVICE_PATH,
+    CHE_PLUGIN_SERVICE_PATH,
     CheApiService,
     CheTaskClient,
-    CheTaskService
+    CheTaskService,
+    ChePluginService
 } from '../common/che-protocol';
-import { WebSocketConnectionProvider } from '@theia/core/lib/browser';
+import { WebSocketConnectionProvider, bindViewContribution, WidgetFactory } from '@theia/core/lib/browser';
+import { CommandContribution } from '@theia/core/lib/common';
 import { CheTaskClientImpl } from './che-task-client';
+import { ChePluginViewContribution } from './plugin/che-plugin-view-contribution';
+import { ChePluginWidget } from './plugin/che-plugin-widget';
+import { ChePluginFrontentService } from './plugin/che-plugin-frontend-service';
+import { ChePluginManager } from './plugin/che-plugin-manager';
+import { ChePluginMenu } from './plugin/che-plugin-menu';
+import { ChePluginCommandContribution } from './plugin/che-plugin-command-contribution';
+import { bindChePluginPreferences } from './plugin/che-plugin-preferences';
 
 export default new ContainerModule(bind => {
     bind(CheApiProvider).toSelf().inSingletonScope();
@@ -36,4 +48,26 @@ export default new ContainerModule(bind => {
         const client: CheTaskClient = ctx.container.get(CheTaskClient);
         return provider.createProxy<CheTaskService>(CHE_TASK_SERVICE_PATH, client);
     }).inSingletonScope();
+
+    bindChePluginPreferences(bind);
+
+    bind(ChePluginService).toDynamicValue(ctx => {
+        const provider = ctx.container.get(WebSocketConnectionProvider);
+        return provider.createProxy<CheApiService>(CHE_PLUGIN_SERVICE_PATH);
+    }).inSingletonScope();
+
+    bind(ChePluginFrontentService).toSelf().inSingletonScope();
+    bind(ChePluginManager).toSelf().inSingletonScope();
+
+    bindViewContribution(bind, ChePluginViewContribution);
+
+    bind(ChePluginMenu).toSelf().inSingletonScope();
+    bind(ChePluginWidget).toSelf().inSingletonScope();
+    bind(WidgetFactory).toDynamicValue(ctx => ({
+        id: ChePluginViewContribution.PLUGINS_WIDGET_ID,
+        createWidget: () => ctx.container.get(ChePluginWidget)
+    }));
+
+    bind(ChePluginCommandContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(ChePluginCommandContribution);
 });

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Red Hat, Inc. and others.
+ * Copyright (C) 2019 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
@@ -1,0 +1,177 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { CommandRegistry, CommandContribution } from '@theia/core/lib/common';
+import { MessageService, Command } from '@theia/core/lib/common';
+import { ChePluginRegistry } from '../../common/che-protocol';
+import { ChePluginManager } from './che-plugin-manager';
+import { QuickInputService } from '@theia/core/lib/browser';
+import { MonacoQuickOpenService } from '@theia/monaco/lib/browser/monaco-quick-open-service';
+import { QuickOpenModel, QuickOpenItem, QuickOpenMode } from '@theia/core/lib/browser/quick-open/quick-open-model';
+
+function cmd(id: string, label: string): Command {
+    return {
+        id: `${ChePluginManagerCommands.PLUGIN_MANAGER_ID}:${id}`,
+        category: ChePluginManagerCommands.PLUGIN_MANAGER_CATEGORY,
+        label: label
+    };
+}
+
+export namespace ChePluginManagerCommands {
+
+    export const PLUGIN_MANAGER_ID = 'plugin-manager';
+    export const PLUGIN_MANAGER_CATEGORY = 'Plugin Manager';
+
+    export const SHOW_AVAILABLE_PLUGINS = cmd('show-available-plugins', 'Show Available Plugins');
+    export const SHOW_INSTALLED_PLUGINS = cmd('show-installed-plugins', 'Show Installed Plugins');
+    export const SHOW_BUILT_IN_PLUGINS = cmd('show-built-in-plugins', 'Show Built-in Plugins');
+
+    export const CHANGE_REGISTRY = cmd('change-registry', 'Change Registry');
+    export const ADD_REGISTRY = cmd('add-registry', 'Add Registry');
+}
+
+@injectable()
+export class ChePluginCommandContribution implements CommandContribution {
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(QuickInputService)
+    protected readonly quickInputService: QuickInputService;
+
+    @inject(MonacoQuickOpenService)
+    protected readonly monacoQuickOpenService: MonacoQuickOpenService;
+
+    @inject(ChePluginManager)
+    protected readonly chePluginManager: ChePluginManager;
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(ChePluginManagerCommands.CHANGE_REGISTRY, {
+            execute: () => this.changePluginRegistry()
+        });
+
+        commands.registerCommand(ChePluginManagerCommands.ADD_REGISTRY, {
+            execute: () => this.addPluginRegistry()
+        });
+    }
+
+    //
+    async showAvailablePlugins() {
+        this.chePluginManager.changeFilter('', true);
+    }
+
+    // @installed
+    async showInstalledPlugins() {
+        this.chePluginManager.changeFilter('@installed', true);
+    }
+
+    // @builtin
+    async showBuiltInPlugins() {
+    }
+
+    /**
+     * Displays prompt to add new plugin registry
+     */
+    async addPluginRegistry(): Promise<void> {
+        const name = await this.quickInputService.open({
+            prompt: 'Name of your registry'
+        });
+
+        if (!name) {
+            return;
+        }
+
+        const uri = await this.quickInputService.open({
+            prompt: 'Registry URI'
+        });
+
+        if (!uri) {
+            return;
+        }
+
+        const registry = {
+            name,
+            uri
+        };
+
+        this.chePluginManager.addRegistry(registry);
+        this.chePluginManager.changeRegistry(registry);
+    }
+
+    private async pickPluginRegistry(): Promise<ChePluginRegistry | undefined> {
+        const registryList = this.chePluginManager.getRegistryList();
+
+        return new Promise<ChePluginRegistry | undefined>((resolve, reject) => {
+            // Return undefined if registry list is empty
+            if (!registryList || registryList.length === 0) {
+                resolve(undefined);
+                return;
+            }
+
+            // Active before appearing the pick menu
+            const activeElement: HTMLElement | undefined = window.document.activeElement as HTMLElement;
+
+            // ChePluginRegistry to be returned
+            let returnValue: ChePluginRegistry | undefined;
+
+            const items = registryList.map(registry =>
+                new QuickOpenItem({
+                    label: registry.name,
+                    detail: registry.uri,
+                    run: mode => {
+                        if (mode === QuickOpenMode.OPEN) {
+                            returnValue = {
+                                name: registry.name,
+                                uri: registry.uri
+                            } as ChePluginRegistry;
+                        }
+                        return true;
+                    }
+                })
+            );
+
+            // Create quick open model
+            const model = {
+                onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): void {
+                    acceptor(items);
+                }
+            } as QuickOpenModel;
+
+            // Show pick menu
+            this.monacoQuickOpenService.open(model, {
+                fuzzyMatchLabel: true,
+                fuzzyMatchDetail: true,
+                fuzzyMatchDescription: true,
+                onClose: () => {
+                    if (activeElement) {
+                        activeElement.focus();
+                    }
+
+                    resolve(returnValue);
+                }
+            });
+        });
+    }
+
+    async changePluginRegistry(): Promise<void> {
+        const registry = await this.pickPluginRegistry();
+        if (registry) {
+            this.chePluginManager.changeRegistry(registry);
+        }
+    }
+
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
@@ -80,11 +80,14 @@ export class ChePluginCommandContribution implements CommandContribution {
     }
 
     // @builtin
+    // Displays a list of built in plugins provided inside Theia editor container.
+    // Will be implemented soon.
     async showBuiltInPlugins() {
     }
 
     /**
-     * Displays prompt to add new plugin registry
+     * Displays prompt to add a new plugin registry.
+     * Makes new plugin registry active and displays a list of plugins from this registry.
      */
     async addPluginRegistry(): Promise<void> {
         const name = await this.quickInputService.open({

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-frontend-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-frontend-service.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Red Hat, Inc. and others.
+ * Copyright (C) 2019 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-frontend-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-frontend-service.ts
@@ -1,0 +1,146 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import {
+    HostedPluginServer,
+    PluginMetadata
+} from '@theia/plugin-ext/lib/common/plugin-protocol';
+
+import {
+    ChePluginMetadata
+} from '../../common/che-protocol';
+
+@injectable()
+export class ChePluginFrontentService {
+
+    @inject(HostedPluginServer)
+    protected readonly hostedPluginServer: HostedPluginServer;
+
+    async getDeployedPlugins(filter: string): Promise<ChePluginMetadata[]> {
+        if (this.hasType(filter, '@installed')) {
+            let pluginList = await this.getAllDeployedPlugins();
+            pluginList = this.filter(pluginList, filter);
+            return pluginList;
+        }
+
+        return [];
+    }
+
+    // @installed
+    // @builtin
+    // @enabled
+    // @disabled
+    hasType(filter: string, type: string) {
+        if (filter) {
+            const filters = filter.split(' ');
+            const found = filters.find(value => value === type);
+            return found !== undefined;
+        }
+
+        return false;
+    }
+
+    filterByType(plugins: ChePluginMetadata[], type: string): ChePluginMetadata[] {
+        return plugins.filter(plugin => {
+            const regex = / /gi;
+            const t = plugin.type.toLowerCase().replace(regex, '_');
+            return t === type;
+        });
+    }
+
+    filterByText(plugins: ChePluginMetadata[], text: string): ChePluginMetadata[] {
+        return plugins;
+    }
+
+    filter(plugins: ChePluginMetadata[], filter: string): ChePluginMetadata[] {
+        let filteredPlugins = plugins;
+        const filters = filter.split(' ');
+
+        filters.forEach(f => {
+            if (f) {
+                if (f.startsWith('@')) {
+                    if (f.startsWith('@type:')) {
+                        const type = f.substring('@type:'.length);
+                        filteredPlugins = this.filterByType(filteredPlugins, type);
+                    }
+                } else {
+                    filteredPlugins = this.filterByText(filteredPlugins, f);
+                }
+            }
+        });
+
+        return filteredPlugins;
+    }
+
+    private async getAllDeployedPlugins(): Promise<ChePluginMetadata[]> {
+        const metadata = await this.hostedPluginServer.getDeployedMetadata();
+
+        const plugins: ChePluginMetadata[] = await Promise.all(
+            metadata.map(async (meta: PluginMetadata) => {
+                const publisher = meta.source.publisher;
+                const name = meta.source.name;
+                const version = meta.source.version;
+                const type = this.determinePluginType(meta);
+                const displayName = meta.source.displayName ? meta.source.displayName : meta.source.name;
+
+                const title = name;
+
+                const description = meta.source.description;
+
+                // tslint:disable-next-line:no-any
+                const icon = (meta.source as any).icon;
+
+                const plugin = {
+                    publisher,
+                    name,
+                    version,
+                    type,
+                    displayName,
+                    title,
+                    description,
+                    icon,
+                    url: 'string',
+                    repository: 'string',
+                    firstPublicationDate: 'string',
+                    category: 'string',
+                    latestUpdateDate: 'string',
+
+                    // Plugin KEY. Used to set in workpsace configuration
+                    key: `${publisher}/${name}/${version}`
+                };
+
+                return plugin;
+
+            }
+            ));
+
+        return plugins;
+    }
+
+    private determinePluginType(meta: PluginMetadata): string {
+        if (meta && meta.model && meta.model.engine && meta.model.engine.type) {
+            if ('vscode' === meta.model.engine.type) {
+                return 'VS Code extension';
+            } else if ('theiaPlugin' === meta.model.engine.type) {
+                return 'Theia plugin';
+            }
+        }
+
+        return 'test';
+    }
+
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-frontend-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-frontend-service.ts
@@ -15,14 +15,9 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
-import {
-    HostedPluginServer,
-    PluginMetadata
-} from '@theia/plugin-ext/lib/common/plugin-protocol';
-
-import {
-    ChePluginMetadata
-} from '../../common/che-protocol';
+import { HostedPluginServer, PluginMetadata } from '@theia/plugin-ext/lib/common/plugin-protocol';
+import { ChePluginMetadata } from '../../common/che-protocol';
+import { PluginFilter } from '../../common/plugin/plugin-filter';
 
 @injectable()
 export class ChePluginFrontentService {
@@ -31,61 +26,18 @@ export class ChePluginFrontentService {
     protected readonly hostedPluginServer: HostedPluginServer;
 
     async getDeployedPlugins(filter: string): Promise<ChePluginMetadata[]> {
-        if (this.hasType(filter, '@installed')) {
+        if (PluginFilter.hasType(filter, '@installed')) {
             let pluginList = await this.getAllDeployedPlugins();
-            pluginList = this.filter(pluginList, filter);
+            pluginList = PluginFilter.filterPlugins(pluginList, filter);
             return pluginList;
         }
 
         return [];
     }
 
-    // @installed
-    // @builtin
-    // @enabled
-    // @disabled
-    hasType(filter: string, type: string) {
-        if (filter) {
-            const filters = filter.split(' ');
-            const found = filters.find(value => value === type);
-            return found !== undefined;
-        }
-
-        return false;
-    }
-
-    filterByType(plugins: ChePluginMetadata[], type: string): ChePluginMetadata[] {
-        return plugins.filter(plugin => {
-            const regex = / /gi;
-            const t = plugin.type.toLowerCase().replace(regex, '_');
-            return t === type;
-        });
-    }
-
-    filterByText(plugins: ChePluginMetadata[], text: string): ChePluginMetadata[] {
-        return plugins;
-    }
-
-    filter(plugins: ChePluginMetadata[], filter: string): ChePluginMetadata[] {
-        let filteredPlugins = plugins;
-        const filters = filter.split(' ');
-
-        filters.forEach(f => {
-            if (f) {
-                if (f.startsWith('@')) {
-                    if (f.startsWith('@type:')) {
-                        const type = f.substring('@type:'.length);
-                        filteredPlugins = this.filterByType(filteredPlugins, type);
-                    }
-                } else {
-                    filteredPlugins = this.filterByText(filteredPlugins, f);
-                }
-            }
-        });
-
-        return filteredPlugins;
-    }
-
+    /**
+     * Returns non-filtered list of the deployed plugins.
+     */
     private async getAllDeployedPlugins(): Promise<ChePluginMetadata[]> {
         const metadata = await this.hostedPluginServer.getDeployedMetadata();
 
@@ -113,11 +65,11 @@ export class ChePluginFrontentService {
                     title,
                     description,
                     icon,
-                    url: 'string',
-                    repository: 'string',
-                    firstPublicationDate: 'string',
-                    category: 'string',
-                    latestUpdateDate: 'string',
+                    url: '',
+                    repository: '',
+                    firstPublicationDate: '',
+                    category: '',
+                    latestUpdateDate: '',
 
                     // Plugin KEY. Used to set in workpsace configuration
                     key: `${publisher}/${name}/${version}`
@@ -140,7 +92,7 @@ export class ChePluginFrontentService {
             }
         }
 
-        return 'test';
+        return '';
     }
 
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-frontend-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-frontend-service.ts
@@ -41,44 +41,39 @@ export class ChePluginFrontentService {
     private async getAllDeployedPlugins(): Promise<ChePluginMetadata[]> {
         const metadata = await this.hostedPluginServer.getDeployedMetadata();
 
-        const plugins: ChePluginMetadata[] = await Promise.all(
-            metadata.map(async (meta: PluginMetadata) => {
-                const publisher = meta.source.publisher;
-                const name = meta.source.name;
-                const version = meta.source.version;
-                const type = this.determinePluginType(meta);
-                const displayName = meta.source.displayName ? meta.source.displayName : meta.source.name;
+        const plugins: ChePluginMetadata[] = metadata.map((meta: PluginMetadata) => {
+            const publisher = meta.source.publisher;
+            const name = meta.source.name;
+            const version = meta.source.version;
+            const type = this.determinePluginType(meta);
+            const displayName = meta.source.displayName ? meta.source.displayName : meta.source.name;
 
-                const title = name;
+            const title = name;
 
-                const description = meta.source.description;
+            const description = meta.source.description;
 
-                // tslint:disable-next-line:no-any
-                const icon = (meta.source as any).icon;
+            // tslint:disable-next-line:no-any
+            const icon = (meta.source as any).icon;
 
-                const plugin = {
-                    publisher,
-                    name,
-                    version,
-                    type,
-                    displayName,
-                    title,
-                    description,
-                    icon,
-                    url: '',
-                    repository: '',
-                    firstPublicationDate: '',
-                    category: '',
-                    latestUpdateDate: '',
+            return {
+                publisher,
+                name,
+                version,
+                type,
+                displayName,
+                title,
+                description,
+                icon,
+                url: '',
+                repository: '',
+                firstPublicationDate: '',
+                category: '',
+                latestUpdateDate: '',
 
-                    // Plugin KEY. Used to set in workpsace configuration
-                    key: `${publisher}/${name}/${version}`
-                };
-
-                return plugin;
-
-            }
-            ));
+                // Plugin KEY. Used to set in workspace configuration
+                key: `${publisher}/${name}/${version}`
+            };
+        });
 
         return plugins;
     }

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Red Hat, Inc. and others.
+ * Copyright (C) 2019 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
@@ -1,0 +1,328 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+
+import {
+    ChePluginRegistry,
+    ChePluginMetadata,
+    ChePluginService,
+    CheApiService
+} from '../../common/che-protocol';
+
+import { PluginServer } from '@theia/plugin-ext/lib/common/plugin-protocol';
+import { MessageService, Emitter, Event } from '@theia/core/lib/common';
+import { ConfirmDialog } from '@theia/core/lib/browser';
+
+import { ChePluginPreferences } from './che-plugin-preferences';
+import { ChePluginFrontentService } from './che-plugin-frontend-service';
+import { PreferenceService, PreferenceScope } from '@theia/core/lib/browser/preferences';
+
+@injectable()
+export class ChePluginManager {
+
+    /**
+     * Default plugin registry
+     */
+    private defaultRegistry: ChePluginRegistry;
+
+    /**
+     * Active plugin registry.
+     * Plugin widget should display the list of plugins from this registry.
+     */
+    private activeRegistry: ChePluginRegistry;
+
+    /**
+     * Registry list
+     */
+    private registryList: ChePluginRegistry[];
+
+    /**
+     * List of installed plugins received from workspace config.
+     */
+    private installedPlugins: string[];
+
+    /**
+     * List of plugins, currently available on active plugin registry.
+     */
+    private availablePlugins: ChePluginMetadata[] = [];
+
+    @inject(ChePluginService)
+    protected readonly chePluginService: ChePluginService;
+
+    @inject(PluginServer)
+    protected readonly pluginServer: PluginServer;
+
+    @inject(CheApiService)
+    protected readonly cheApiService: CheApiService;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(ChePluginPreferences)
+    protected readonly chePluginPreferences: ChePluginPreferences;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    @inject(ChePluginFrontentService)
+    protected readonly pluginFrontentService: ChePluginFrontentService;
+
+    protected readonly pluginRegistryChanged = new Emitter<ChePluginRegistry>();
+
+    protected readonly workspaceConfigurationChanged = new Emitter<boolean>();
+
+    get onPluginRegistryChanged(): Event<ChePluginRegistry> {
+        return this.pluginRegistryChanged.event;
+    }
+
+    get onWorkspaceConfigurationChanged(): Event<boolean> {
+        return this.workspaceConfigurationChanged.event;
+    }
+
+    /**
+     * Restores list of custom registries
+     */
+    private async restoreRegistryList(): Promise<void> {
+        // wait for preference service
+        await this.preferenceService.ready;
+
+        const prefs = this.chePluginPreferences['chePlugins.repositories'];
+        if (prefs) {
+            const instance = this;
+            Object.keys(prefs).forEach(repoName => {
+                const uri = prefs[repoName];
+
+                const registry = this.registryList.find(r => r.uri === uri);
+                if (registry === undefined) {
+                    instance.registryList.push({
+                        name: repoName,
+                        uri: uri
+                    });
+                }
+            });
+        }
+    }
+
+    private async initDefaults(): Promise<void> {
+        if (!this.defaultRegistry) {
+            this.defaultRegistry = await this.chePluginService.getDefaultRegistry();
+        }
+
+        if (!this.activeRegistry) {
+            this.activeRegistry = this.defaultRegistry;
+        }
+
+        if (!this.registryList) {
+            this.registryList = [this.defaultRegistry];
+
+            this.registryList.push({
+                name: 'Visual Studio Code plugins',
+                uri: 'https://marketplace.visualstudio.com/vscode'
+            });
+
+            await this.restoreRegistryList();
+        }
+
+        if (!this.installedPlugins) {
+            // Get list of plugins from workspace config
+            this.installedPlugins = await this.chePluginService.getWorkspacePlugins();
+        }
+    }
+
+    getDefaultRegistry(): ChePluginRegistry {
+        return this.defaultRegistry;
+    }
+
+    changeRegistry(registry: ChePluginRegistry): void {
+        this.activeRegistry = registry;
+        this.pluginRegistryChanged.fire(registry);
+    }
+
+    addRegistry(registry: ChePluginRegistry): void {
+        this.registryList.push(registry);
+
+        // Save list of custom repositories to preferences
+        const prefs = {};
+        this.registryList.forEach(r => {
+            if (r.name !== 'Default') {
+                prefs[r.name] = r.uri;
+            }
+        });
+
+        this.preferenceService.set('chePlugins.repositories', prefs, PreferenceScope.User);
+    }
+
+    removeRegistry(registry: ChePluginRegistry): void {
+        this.registryList = this.registryList.filter(r => r.uri !== registry.uri);
+    }
+
+    getRegistryList(): ChePluginRegistry[] {
+        return this.registryList;
+    }
+
+    /**
+     * Returns plugin list from active registry
+     */
+    async getPlugins(filter: string): Promise<ChePluginMetadata[]> {
+        await this.initDefaults();
+
+        this.availablePlugins = await this.chePluginService.getPlugins(this.activeRegistry, filter);
+        // The code will be use soon
+        // const deployedPlugins = await this.pluginFrontentService.getDeployedPlugins(filter);
+        // this.availablePlugins = this.availablePlugins.concat(deployedPlugins);
+        return this.availablePlugins;
+    }
+
+    isPluginInstalled(plugin: ChePluginMetadata): boolean {
+        return this.installedPlugins.indexOf(plugin.key) >= 0;
+    }
+
+    async install(plugin: ChePluginMetadata): Promise<boolean> {
+        try {
+            // add the plugin to workspace configuration
+            await this.chePluginService.addPlugin(plugin.key);
+            await this.delay(1000);
+            this.messageService.info(`Plugin '${plugin.publisher}/${plugin.name}/${plugin.version}' has been successfully installed`);
+
+            // add the plugin to the list of workspace plugins
+            this.installedPlugins.push(plugin.key);
+
+            // notify that workspace configuration has been changed
+            this.notifyWorkspaceConfigurationChanged();
+            return true;
+        } catch (error) {
+            this.messageService.error(`Unable to install plugin '${plugin.publisher}/${plugin.name}/${plugin.version}'. ${error.message}`);
+            return false;
+        }
+    }
+
+    async remove(plugin: ChePluginMetadata): Promise<boolean> {
+        try {
+            // remove the plugin from workspace configuration
+            await this.chePluginService.removePlugin(plugin.key);
+            await this.delay(1000);
+            this.messageService.info(`Plugin '${plugin.publisher}/${plugin.name}/${plugin.version}' has been successfully removed`);
+
+            // remove the plugin from the list of workspace plugins
+            this.installedPlugins = this.installedPlugins.filter(p => p !== plugin.key);
+
+            // notify that workspace configuration has been changed
+            this.notifyWorkspaceConfigurationChanged();
+            return true;
+        } catch (error) {
+            this.messageService.error(`Unable to remove plugin '${plugin.publisher}/${plugin.name}/${plugin.version}'. ${error.message}`);
+            return false;
+        }
+    }
+
+    private getIdPublisher(input: string): string {
+        if (input.startsWith('ext install ')) {
+            // check for 'ext install rebornix.Ruby'
+            return input.substring('ext install '.length);
+        } else if (input.startsWith('vscode:extension/')) {
+            // check for 'vscode:extension/rebornix.Ruby'
+            return input.substring('vscode:extension/'.length);
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Installs VS Code extension.
+     */
+    async installVSCodeExtension(command: string): Promise<boolean> {
+        const idPublisher = this.getIdPublisher(command);
+        try {
+            await this.pluginServer.deploy(command);
+            this.messageService.info(`VS Code plugin '${idPublisher}' has been installed`);
+            return true;
+        } catch (error) {
+            this.messageService.error(`Unable to install VS Code plugin '${idPublisher}'`);
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines whether the `input` is a command to install VS Code extension.
+     *
+     * Returns VS Code extension `publisher.ID`
+     */
+    checkVsCodeExtension(input: string): string {
+        try {
+            const idPublisher = this.getIdPublisher(input);
+            if (idPublisher) {
+                const parts = idPublisher.split('.');
+                if (parts.length === 2 && parts[0] && parts[1]) {
+                    return idPublisher;
+                }
+            }
+        } catch (error) {
+            console.log('error > ', error);
+        }
+
+        return undefined;
+    }
+
+    async delay(miliseconds: number): Promise<void> {
+        return new Promise<void>(resolve => {
+            setTimeout(() => {
+                resolve();
+            }, miliseconds);
+        });
+    }
+
+    private notifyWorkspaceConfigurationChanged() {
+        setTimeout(() => {
+            this.workspaceConfigurationChanged.fire(true);
+        }, 500);
+    }
+
+    async restartWorkspace(): Promise<void> {
+        const confirm = new ConfirmDialog({
+            title: 'Restart Workspace',
+            msg: 'Are you sure you want to restart your workspace?',
+            ok: 'Restart'
+        });
+
+        if (await confirm.open()) {
+            this.messageService.info('Workspace is restarting...');
+
+            try {
+                await this.cheApiService.stop();
+                setTimeout(() => {
+                    window.location.reload();
+                }, 1000);
+            } catch (error) {
+                this.messageService.error(`Unable to restart your workspace. ${error.message}`);
+            }
+        }
+    }
+
+    protected readonly filterChanged = new Emitter<string>();
+
+    get onFilterChanged(): Event<string> {
+        return this.filterChanged.event;
+    }
+
+    async changeFilter(filter: string, sendNotification: boolean = false) {
+        if (sendNotification) {
+            this.filterChanged.fire(filter);
+        }
+    }
+
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
@@ -51,7 +51,8 @@ export class ChePluginManager {
     private registryList: ChePluginRegistry[];
 
     /**
-     * List of installed plugins received from workspace config.
+     * List of installed plugins.
+     * Initialized by plugins received from workspace config.
      */
     private installedPlugins: string[];
 
@@ -102,13 +103,12 @@ export class ChePluginManager {
 
         const prefs = this.chePluginPreferences['chePlugins.repositories'];
         if (prefs) {
-            const instance = this;
             Object.keys(prefs).forEach(repoName => {
                 const uri = prefs[repoName];
 
                 const registry = this.registryList.find(r => r.uri === uri);
                 if (registry === undefined) {
-                    instance.registryList.push({
+                    this.registryList.push({
                         name: repoName,
                         uri: uri
                     });
@@ -195,7 +195,6 @@ export class ChePluginManager {
         try {
             // add the plugin to workspace configuration
             await this.chePluginService.addPlugin(plugin.key);
-            await this.delay(1000);
             this.messageService.info(`Plugin '${plugin.publisher}/${plugin.name}/${plugin.version}' has been successfully installed`);
 
             // add the plugin to the list of workspace plugins
@@ -214,7 +213,6 @@ export class ChePluginManager {
         try {
             // remove the plugin from workspace configuration
             await this.chePluginService.removePlugin(plugin.key);
-            await this.delay(1000);
             this.messageService.info(`Plugin '${plugin.publisher}/${plugin.name}/${plugin.version}' has been successfully removed`);
 
             // remove the plugin from the list of workspace plugins
@@ -272,18 +270,10 @@ export class ChePluginManager {
                 }
             }
         } catch (error) {
-            console.log('error > ', error);
+            console.log(error);
         }
 
         return undefined;
-    }
-
-    async delay(miliseconds: number): Promise<void> {
-        return new Promise<void>(resolve => {
-            setTimeout(() => {
-                resolve();
-            }, miliseconds);
-        });
     }
 
     private notifyWorkspaceConfigurationChanged() {

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-menu.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-menu.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Red Hat, Inc. and others.
+ * Copyright (C) 2019 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-menu.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-menu.ts
@@ -1,0 +1,118 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { Menu } from '@phosphor/widgets';
+import { CommandRegistry } from '@phosphor/commands';
+import { Emitter, Event } from '@theia/core/lib/common';
+import { ChePluginManager } from './che-plugin-manager';
+
+import { ChePluginManagerCommands, ChePluginCommandContribution } from './che-plugin-command-contribution';
+
+@injectable()
+export class ChePluginMenu {
+
+    @inject(ChePluginCommandContribution)
+    protected readonly chePluginCommandContribution: ChePluginCommandContribution;
+
+    @inject(ChePluginManager)
+    protected readonly chePluginManager: ChePluginManager;
+
+    protected readonly menuClosed = new Emitter<void>();
+
+    get onMenuClosed(): Event<void> {
+        return this.menuClosed.event;
+    }
+
+    show(x: number, y: number): void {
+        const commands = new CommandRegistry();
+        const menu = new Menu({
+            commands
+        });
+
+        this.addCommands(commands, menu);
+
+        menu.aboutToClose.connect(() => {
+            this.menuClosed.fire(undefined);
+        });
+
+        menu.open(x, y);
+    }
+
+    /**
+     * Adds commands to the menu for running plugin.
+     */
+    protected addCommands(commands: CommandRegistry, menu: Menu): void {
+
+        commands.addCommand(ChePluginManagerCommands.SHOW_AVAILABLE_PLUGINS.id, {
+            label: ChePluginManagerCommands.SHOW_AVAILABLE_PLUGINS.label,
+            isEnabled: () => true,
+            execute: () => setTimeout(() => this.chePluginCommandContribution.showAvailablePlugins(), 100)
+        });
+
+        commands.addCommand(ChePluginManagerCommands.SHOW_INSTALLED_PLUGINS.id, {
+            label: ChePluginManagerCommands.SHOW_INSTALLED_PLUGINS.label,
+            isEnabled: () => true,
+            execute: () => setTimeout(() => this.chePluginCommandContribution.showInstalledPlugins(), 100)
+        });
+
+        commands.addCommand(ChePluginManagerCommands.SHOW_BUILT_IN_PLUGINS.id, {
+            label: ChePluginManagerCommands.SHOW_BUILT_IN_PLUGINS.label,
+            isEnabled: () => false,
+            execute: () => setTimeout(() => this.chePluginCommandContribution.showBuiltInPlugins(), 100)
+        });
+
+        commands.addCommand(ChePluginManagerCommands.CHANGE_REGISTRY.id, {
+            label: ChePluginManagerCommands.CHANGE_REGISTRY.label,
+            execute: () => setTimeout(() => this.chePluginCommandContribution.changePluginRegistry(), 100)
+        });
+
+        commands.addCommand(ChePluginManagerCommands.ADD_REGISTRY.id, {
+            label: ChePluginManagerCommands.ADD_REGISTRY.label,
+            execute: () => setTimeout(() => this.chePluginCommandContribution.addPluginRegistry(), 100)
+        });
+
+        menu.addItem({
+            type: 'command',
+            command: ChePluginManagerCommands.SHOW_AVAILABLE_PLUGINS.id
+        });
+
+        menu.addItem({
+            type: 'command',
+            command: ChePluginManagerCommands.SHOW_INSTALLED_PLUGINS.id
+        });
+
+        menu.addItem({
+            type: 'command',
+            command: ChePluginManagerCommands.SHOW_BUILT_IN_PLUGINS.id
+        });
+
+        menu.addItem({
+            type: 'separator'
+        });
+
+        menu.addItem({
+            type: 'command',
+            command: ChePluginManagerCommands.CHANGE_REGISTRY.id
+        });
+
+        menu.addItem({
+            type: 'command',
+            command: ChePluginManagerCommands.ADD_REGISTRY.id
+        });
+    }
+
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-menu.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-menu.ts
@@ -60,29 +60,29 @@ export class ChePluginMenu {
         commands.addCommand(ChePluginManagerCommands.SHOW_AVAILABLE_PLUGINS.id, {
             label: ChePluginManagerCommands.SHOW_AVAILABLE_PLUGINS.label,
             isEnabled: () => true,
-            execute: () => setTimeout(() => this.chePluginCommandContribution.showAvailablePlugins(), 100)
+            execute: () => this.chePluginCommandContribution.showAvailablePlugins()
         });
 
         commands.addCommand(ChePluginManagerCommands.SHOW_INSTALLED_PLUGINS.id, {
             label: ChePluginManagerCommands.SHOW_INSTALLED_PLUGINS.label,
             isEnabled: () => true,
-            execute: () => setTimeout(() => this.chePluginCommandContribution.showInstalledPlugins(), 100)
+            execute: () => this.chePluginCommandContribution.showInstalledPlugins()
         });
 
         commands.addCommand(ChePluginManagerCommands.SHOW_BUILT_IN_PLUGINS.id, {
             label: ChePluginManagerCommands.SHOW_BUILT_IN_PLUGINS.label,
             isEnabled: () => false,
-            execute: () => setTimeout(() => this.chePluginCommandContribution.showBuiltInPlugins(), 100)
+            execute: () => this.chePluginCommandContribution.showBuiltInPlugins()
         });
 
         commands.addCommand(ChePluginManagerCommands.CHANGE_REGISTRY.id, {
             label: ChePluginManagerCommands.CHANGE_REGISTRY.label,
-            execute: () => setTimeout(() => this.chePluginCommandContribution.changePluginRegistry(), 100)
+            execute: () => this.chePluginCommandContribution.changePluginRegistry()
         });
 
         commands.addCommand(ChePluginManagerCommands.ADD_REGISTRY.id, {
             label: ChePluginManagerCommands.ADD_REGISTRY.label,
-            execute: () => setTimeout(() => this.chePluginCommandContribution.addPluginRegistry(), 100)
+            execute: () => this.chePluginCommandContribution.addPluginRegistry()
         });
 
         menu.addItem({

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-preferences.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-preferences.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Red Hat, Inc. and others.
+ * Copyright (C) 2019 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-preferences.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-preferences.ts
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces } from 'inversify';
+import {
+    createPreferenceProxy,
+    PreferenceProxy,
+    PreferenceService,
+    PreferenceSchema,
+    PreferenceContribution
+} from '@theia/core/lib/browser/preferences';
+
+export const chePluginPreferenceSchema: PreferenceSchema = {
+    'type': 'object',
+    'properties': {
+        'chePlugins.repositories': {
+            'description': 'Custom plugin repositories',
+            'type': 'object',
+            'default': {}
+        }
+    }
+};
+
+export interface ChePluginPreferenceConfiguration {
+    'chePlugins.repositories': { [name: string]: string };
+}
+
+export const ChePluginPreferences = Symbol('ChePluginPreferences');
+export type ChePluginPreferences = PreferenceProxy<ChePluginPreferenceConfiguration>;
+
+export function createChePluginPreferences(preferences: PreferenceService): ChePluginPreferences {
+    return createPreferenceProxy(preferences, chePluginPreferenceSchema);
+}
+
+export function bindChePluginPreferences(bind: interfaces.Bind): void {
+    bind(ChePluginPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        return createChePluginPreferences(preferences);
+    }).inSingletonScope();
+
+    bind(PreferenceContribution).toConstantValue({ schema: chePluginPreferenceSchema });
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-view-contribution.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-view-contribution.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Red Hat, Inc. and others.
+ * Copyright (C) 2019 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-view-contribution.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-view-contribution.ts
@@ -1,0 +1,39 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
+import { ChePluginWidget } from './che-plugin-widget';
+
+@injectable()
+export class ChePluginViewContribution extends AbstractViewContribution<ChePluginWidget> {
+
+    public static PLUGINS_WIDGET_ID = 'che-plugins';
+
+    constructor() {
+        super({
+            widgetId: ChePluginViewContribution.PLUGINS_WIDGET_ID,
+            widgetName: 'Che Plugins',
+            defaultWidgetOptions: {
+                area: 'left',
+                rank: 400
+            },
+            toggleCommandId: 'chePluginsView:toggle',
+            toggleKeybinding: 'ctrlcmd+shift+j'
+        });
+    }
+
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-widget.tsx
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-widget.tsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Red Hat, Inc. and others.
+ * Copyright (C) 2019 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-widget.tsx
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-widget.tsx
@@ -1,0 +1,481 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { Message } from '@phosphor/messaging';
+import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import { AlertMessage } from '@theia/core/lib/browser/widgets/alert-message';
+import * as React from 'react';
+import { ChePluginRegistry, ChePluginMetadata } from '../../common/che-protocol';
+import { ChePluginManager } from './che-plugin-manager';
+import { ChePluginMenu } from './che-plugin-menu';
+import { Key } from '@theia/core/lib/browser';
+import { ConfirmDialog } from '@theia/core/lib/browser';
+
+@injectable()
+export class ChePluginWidget extends ReactWidget {
+
+    protected plugins: ChePluginMetadata[] = [];
+
+    protected status: 'ready' | 'loading' | 'failed' = 'loading';
+
+    protected needToBeRendered = true;
+
+    protected needToRestartWorkspace = false;
+    protected hidingRestartWorkspaceNotification = false;
+
+    protected currentFilter: string;
+
+    constructor(
+        @inject(ChePluginManager) protected chePluginManager: ChePluginManager,
+        @inject(ChePluginMenu) protected chePluginMenu: ChePluginMenu
+    ) {
+        super();
+        this.id = 'che-plugins';
+        this.title.label = 'Che Plugins';
+        this.title.caption = 'Che Plugins';
+        this.title.iconClass = 'fa che-plugins-tab-icon';
+        this.title.closable = true;
+        this.addClass('theia-plugins');
+
+        this.node.tabIndex = 0;
+
+        chePluginManager.onPluginRegistryChanged(
+            registry => this.onPluginRegistryChanged(registry));
+
+        chePluginManager.onWorkspaceConfigurationChanged(
+            needToRestart => this.onWorkspaceConfigurationChanged(needToRestart));
+
+        chePluginManager.onFilterChanged(
+            filter => this.updateFilter(filter, true));
+
+        this.node.ondrop = event => {
+            event.preventDefault();
+            const text = event.dataTransfer.getData('text');
+            this.onDrop(text);
+        };
+
+        this.node.ondragover = event => {
+            event.preventDefault();
+        };
+    }
+
+    protected onAfterShow(msg: Message) {
+        super.onAfterShow(msg);
+
+        if (this.needToBeRendered) {
+            this.needToBeRendered = false;
+
+            this.update();
+            this.updatePlugins();
+        }
+    }
+
+    protected onActivateRequest(msg: Message) {
+        super.onActivateRequest(msg);
+
+        this.node.focus();
+    }
+
+    protected async onPluginRegistryChanged(registry?: ChePluginRegistry): Promise<void> {
+        this.status = 'loading';
+        this.update();
+
+        await this.updatePlugins();
+    }
+
+    protected async onWorkspaceConfigurationChanged(needToRestart: boolean): Promise<void> {
+        if (this.needToRestartWorkspace !== needToRestart) {
+            this.needToRestartWorkspace = needToRestart;
+            this.update();
+        }
+    }
+
+    protected updateFilter = async (filter: string, reloadPlugins: boolean) => {
+        this.currentFilter = filter;
+
+        if (reloadPlugins) {
+            this.status = 'loading';
+            this.update();
+
+            this.updatePlugins();
+        }
+    }
+
+    protected clearFilter = async () => {
+        this.currentFilter = '';
+
+        this.status = 'ready';
+        this.update();
+    }
+
+    protected async updatePlugins(): Promise<void> {
+        try {
+            this.plugins = await this.chePluginManager.getPlugins(this.currentFilter);
+            this.status = 'ready';
+        } catch (error) {
+            this.status = 'failed';
+        }
+
+        this.update();
+    }
+
+    protected onChangeFilter = async (filter: string, enterPressed: boolean) => {
+        // user may want to install plugin
+        if (enterPressed) {
+            if (this.chePluginManager.checkVsCodeExtension(filter)) {
+                if (await this.installExtension(filter)) {
+                    return;
+                }
+            }
+        }
+
+        await this.updateFilter(filter, enterPressed);
+    }
+
+    protected async onDrop(input: string) {
+        const extension = this.chePluginManager.checkVsCodeExtension(input);
+        if (extension) {
+            const confirm = new ConfirmDialog({
+                title: 'Install extension',
+                msg: `You are going to install VS Code extension '${extension}'`,
+                ok: 'Install'
+            });
+
+            if (await confirm.open()) {
+                if (await this.installExtension(input)) {
+                    return;
+                }
+            }
+        }
+    }
+
+    protected async installExtension(extension: string): Promise<boolean> {
+        this.status = 'loading';
+        this.update();
+
+        await this.chePluginManager.installVSCodeExtension(extension);
+        await this.clearFilter();
+        return true;
+    }
+
+    protected render(): React.ReactNode {
+        const chePluginListControls = <ChePluginListControls
+            chePluginMenu={this.chePluginMenu}
+            filter={this.currentFilter}
+            update={this.onChangeFilter}
+            status={this.status} />;
+
+        return <React.Fragment>
+            {this.renderUpdateWorkspaceNotification()}
+            {chePluginListControls}
+            {this.renderPluginList()}
+        </React.Fragment>;
+    }
+
+    // Restart your workspace to apply changes
+    protected renderUpdateWorkspaceNotification(): React.ReactNode {
+        if (this.needToRestartWorkspace) {
+            const notificationStyle = this.hidingRestartWorkspaceNotification ? 'notification hiding' : 'notification';
+            return <div className='che-plugins-notification' >
+                <div className={notificationStyle}>
+                    <div className='notification-message' onClick={this.restartWorkspace}>
+                        <i className='fa fa-check-circle'></i>&nbsp;
+                        Click here to apply changes and restart your workspace
+                    </div>
+
+                    <div className='notification-control'>
+                        <div className='notification-hide' onClick={this.hideNotification}>
+                            <i className='fa fa-close alert-close' ></i>
+                        </div>
+                    </div>
+                </div>
+            </div>;
+        }
+
+        return undefined;
+    }
+
+    protected renderPluginList(): React.ReactNode {
+        // STATUS: loading
+        if (this.status === 'loading') {
+            return <div className='spinnerContainer'>
+                <div className='fa fa-spinner fa-pulse fa-3x fa-fw'></div>
+            </div>;
+        }
+
+        // STATUS: failed
+        if (this.status === 'failed') {
+            return <AlertMessage type='ERROR' header='Your registry is invalid' />;
+        }
+
+        // STATUS: ready
+        if (!this.plugins.length) {
+            return <AlertMessage type='INFO' header='No plugins currently available' />;
+        }
+
+        const list = this.plugins.map(plugin =>
+            <ChePlugin key={plugin.key}
+                plugin={plugin} pluginManager={this.chePluginManager}></ChePlugin>);
+        return <div className='che-plugin-list'>
+            {list}
+        </div>;
+    }
+
+    protected restartWorkspace = async e => {
+        await this.chePluginManager.restartWorkspace();
+    }
+
+    protected hideNotification = async e => {
+        this.hidingRestartWorkspaceNotification = true;
+        this.update();
+
+        setTimeout(() => {
+            this.needToRestartWorkspace = false;
+            this.hidingRestartWorkspaceNotification = false;
+            this.update();
+        }, 500);
+    }
+
+}
+
+export class ChePluginListControls extends React.Component<
+    {
+        chePluginMenu: ChePluginMenu,
+        filter: string,
+        update: (filter: string, reloadPlugins: boolean) => void,
+        status: string
+    },
+    { menuButtonPressed: boolean, filter: string }> {
+
+    private defaultFilter: string;
+
+    constructor(props: {
+        chePluginMenu: ChePluginMenu,
+        filter: string,
+        update: (filter: string, reloadPlugins: boolean) => void,
+        status: string
+    }) {
+        super(props);
+
+        this.state = {
+            menuButtonPressed: false,
+            filter: props.filter
+        };
+
+        props.chePluginMenu.onMenuClosed(() => {
+            this.setState({
+                menuButtonPressed: false,
+                filter: this.state.filter
+            });
+        });
+    }
+
+    protected readonly doFilter = (e: React.KeyboardEvent) => {
+        if (e.target) {
+            if (Key.ENTER.keyCode === e.keyCode) {
+                const filter = (e.target as HTMLInputElement).value;
+                this.props.update(filter, true);
+            }
+        }
+    }
+
+    protected readonly handleChange = event => {
+        if (event.target) {
+            this.setState(
+                {
+                    menuButtonPressed: false,
+                    filter: event.target.value
+                });
+
+            this.props.update(event.target.value, false);
+        }
+    }
+
+    render(): React.ReactNode {
+        let value;
+        if (this.props.filter !== undefined && this.props.filter !== this.defaultFilter) {
+            this.defaultFilter = this.props.filter;
+            value = this.props.filter;
+            this.state = {
+                menuButtonPressed: this.state.menuButtonPressed,
+                filter: value
+            };
+        } else {
+            value = this.state.filter;
+        }
+
+        const input = this.props.status === 'loading' ?
+            <input
+                className='search'
+                type='text'
+                value={value}
+                onChange={this.handleChange}
+                onKeyUp={this.doFilter}
+                disabled
+            /> : <input
+                className='search'
+                type='text'
+                value={value}
+                onChange={this.handleChange}
+                onKeyUp={this.doFilter}
+            />;
+
+        return <div className='che-plugin-control-panel'>
+            <div>
+                {input}
+                <div tabIndex={0} className={this.menuButtonStyle()} onFocus={this.onFocus} >
+                    <i className='fa fa-ellipsis-v'></i>
+                </div>
+            </div>
+        </div>;
+    }
+
+    protected menuButtonStyle(): string {
+        if (this.state.menuButtonPressed) {
+            return 'menu-button menu-button-active';
+        } else {
+            return 'menu-button';
+        }
+    }
+
+    protected onFocus = async param => {
+        const rect = document.activeElement.getBoundingClientRect();
+
+        const left = rect.left;
+        const top = rect.top + rect.height - 2;
+
+        this.setState({
+            menuButtonPressed: true,
+            filter: this.state.filter
+        });
+
+        this.props.chePluginMenu.show(left, top);
+    }
+
+}
+
+export class ChePlugin extends React.Component<ChePlugin.Props, ChePlugin.State> {
+
+    constructor(props: ChePlugin.Props) {
+        super(props);
+
+        const plugin = props.plugin;
+        const state = props.pluginManager.isPluginInstalled(plugin) ? 'installed' : 'not_installed';
+
+        this.state = {
+            pluginState: state
+        };
+    }
+
+    render(): React.ReactNode {
+        const plugin = this.props.plugin;
+
+        // I'm not sure whether 'key' attribute is necessary here
+        return <div key={plugin.key} className='che-plugin'>
+            <div className='che-plugin-content'>
+                <div className='che-plugin-icon'>
+                    <img src={plugin.icon}></img>
+                </div>
+                <div className='che-plugin-info'>
+                    <div className='che-plugin-title'>
+                        <div className='che-plugin-name'>{plugin.name}</div>
+                        <div className='che-plugin-version'>{plugin.version}</div>
+                    </div>
+                    <div className='che-plugin-description'>
+                        <div>
+                            <div>{plugin.description}</div>
+                        </div>
+                    </div>
+                    <div className='che-plugin-publisher'>
+                        {plugin.publisher}
+                        <span className='che-plugin-type'>{plugin.type}</span>
+                    </div>
+                    {this.renderPluginAction(plugin)}
+                </div>
+            </div>
+        </div>;
+    }
+
+    protected renderPluginAction(plugin: ChePluginMetadata): React.ReactNode {
+        // Don't show the button for 'Che Editor' plugins
+        if ('Che Editor' === plugin.type) {
+            return undefined;
+        }
+
+        switch (this.state.pluginState) {
+            case 'installed':
+                return <div className='che-plugin-action-remove' onClick={this.removePlugin}>Installed</div>;
+            case 'installing':
+                return <div className='che-plugin-action-installing'>Installing...</div>;
+            case 'removing':
+                return <div className='che-plugin-action-removing'>Removing...</div>;
+        }
+
+        // 'not_installed'
+        return <div className='che-plugin-action-add' onClick={this.installPlugin}>Install</div>;
+    }
+
+    protected set(state: ChePluginState): void {
+        this.setState({
+            pluginState: state
+        });
+    }
+
+    protected installPlugin = async () => {
+        const previousState = this.state.pluginState;
+        this.set('installing');
+
+        const installed = await this.props.pluginManager.install(this.props.plugin);
+        if (installed) {
+            this.set('installed');
+        } else {
+            this.set(previousState);
+        }
+    }
+
+    protected removePlugin = async () => {
+        const previousState = this.state.pluginState;
+        this.set('removing');
+
+        const removed = await this.props.pluginManager.remove(this.props.plugin);
+        if (removed) {
+            this.set('not_installed');
+        } else {
+            this.set(previousState);
+        }
+    }
+
+}
+
+export type ChePluginState =
+    'not_installed'
+    | 'installed'
+    | 'installing'
+    | 'removing';
+
+export namespace ChePlugin {
+
+    export interface Props {
+        pluginManager: ChePluginManager;
+        plugin: ChePluginMetadata;
+    }
+
+    export interface State {
+        pluginState: ChePluginState;
+    }
+
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/style/che-plugins.css
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/style/che-plugins.css
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Red Hat, Inc. and others.
+ * Copyright (C) 2019 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/style/che-plugins.css
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/style/che-plugins.css
@@ -1,0 +1,376 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+.che-plugins-tab-icon::before {
+    content: "\F14A";
+}
+
+/*-----------------------------------------------------------------------------
+| Notification informing that workspace has been changed
+|----------------------------------------------------------------------------*/
+
+.che-plugins-notification {
+    position: relative;
+    width: 100%;
+    height: 46px;
+}
+
+.che-plugins-notification .notification {
+    width: calc(100% - 2px);
+    height: 28px;
+    margin-top: 9px;
+    margin-bottom: 9px;
+    margin-left: 1px;
+    overflow: hidden;
+    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, opacity 500ms ease-in-out 0ms;
+    background-color: var(--theia-success-color0);
+    color: #FFFFFF;
+}
+
+.che-plugins-notification .notification.hiding {
+    opacity: 0;
+}
+
+.che-plugins-notification .notification-message {
+    position: absolute;
+    left: 0px;
+    top: 9px;
+    right: 28px;
+    height: 28px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 28px;
+    padding-left: 9px;
+    cursor: pointer;
+}
+
+.che-plugins-notification .notification:hover {
+    background-color: var(--theia-success-color1);
+}
+
+.che-plugins-notification .notification:active {
+    box-shadow: 0px 0px 2px 0px var(--theia-success-color2);
+    outline: none;
+}
+
+.che-plugins-notification .notification-control {
+    position: absolute;
+    right: 1px;
+    top: 9px;
+    width: 28px;
+    height: 28px;
+    overflow: hidden;
+}
+
+.che-plugins-notification .notification-hide {
+    position: absolute;
+    left: 4px;
+    top: 4px;
+    width: 20px;
+    height: 20px;
+    overflow: hidden;
+    cursor: pointer;
+    text-align: center;
+    line-height: 20px;
+    opacity: 0.7;
+}
+
+.che-plugins-notification .notification-hide:hover {
+    opacity: 1;
+}
+
+.che-plugins-notification .notification-hide:active {
+    opacity: 0.8;
+}
+
+/*-----------------------------------------------------------------------------
+| Control pane. Contains text box to filter plugins and menu button
+|----------------------------------------------------------------------------*/
+
+.che-plugin-control-panel {
+    width: 100%;
+    position: relative;
+}
+
+.che-plugin-control-panel > div {
+    position: relative;
+    width: 100%;
+    height: 35px;
+    overflow: hidden;
+}
+
+/*-----------------------------------------------------------------------------
+| Text box to filter plugins
+|----------------------------------------------------------------------------*/
+
+.che-plugin-control-panel .search {
+    position: absolute;
+    left: 8px;
+    top: 0px;
+    width: calc(100% - 16px);
+    height: 24px;
+    border: 1px solid transparent;
+    box-sizing: border-box;
+    padding-right: 24px;
+}
+
+.che-plugin-control-panel .search:focus {
+    border-color: var(--theia-accent-color3);
+}
+
+.che-plugin-control-panel .search[disabled] {
+    color: var(--theia-ui-font-color2);
+}
+
+/*-----------------------------------------------------------------------------
+| Menu button
+|----------------------------------------------------------------------------*/
+
+.che-plugin-control-panel .menu-button {
+    position: absolute;
+    width: 24px;
+    height: 24px;
+    right: 8px;
+    top: 0px;
+    overflow: hidden;
+    text-align: center;
+    line-height: 26px;
+    cursor: pointer;
+    color: var(--theia-ui-font-color2);
+    box-sizing: border-box;
+}
+
+.che-plugin-control-panel .menu-button:hover {
+    color: var(--theia-ui-font-color1);
+}
+
+.che-plugin-control-panel .menu-button-active {
+    color: var(--theia-ui-font-color1);
+    border: none;
+    background: var(--theia-menu-color1);
+    box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.2);
+}
+
+/*-----------------------------------------------------------------------------
+| List of plugins
+|----------------------------------------------------------------------------*/
+
+.che-plugin-list {
+    position: relative;
+    width: 100%;
+    box-sizing: border-box;
+    overflow-y: auto;
+    min-width: 250px !important;
+}
+
+.che-plugin-list .che-plugin {
+    position: relative;
+    height: 104px;
+    display: block;
+}
+
+.che-plugin-list .che-plugin-content {
+    position: absolute;
+    overflow: hidden;
+    left: 5px;
+    top: 0px;
+    height: 100%;
+    right: 4px;
+    border-bottom: 1px solid var(--theia-layout-color4);
+    box-sizing: border-box;
+}
+
+.che-plugin-list .che-plugin-content:hover {
+    background: var(--theia-layout-color2);
+}
+
+.che-plugin-list .che-plugin-icon {
+    position: absolute;
+    display: block;
+    overflow: hidden;
+    width: 64px;
+    height: 64px;
+    left: 8px;
+    top: 16px;
+}
+
+.che-plugin-list .che-plugin-icon > img {
+    width: 64px;
+    height: 64px;
+}
+
+.che-plugin-list .che-plugin-info {
+    position: absolute;
+    display: block;
+    overflow: hidden;
+    height: calc(100% - 16px);
+    left: 84px;
+    top: 8px;
+    right: 2px;
+}
+
+.che-plugin-list .che-plugin-title {
+    height: 20px;
+    line-height: 20px;
+    position: absolute;
+    left: 0px;
+    top: 7px;
+    right: 4px;
+}
+
+.che-plugin-list .che-plugin-name {
+    font-size: var(--theia-ui-font-size0);
+    font-weight: bold;
+    color: var(--theia-ui-font-color2);
+    position: absolute;
+    left: 0px;
+    top: 0px;
+    right: 66px;
+    height: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.che-plugin-list .che-plugin-version {
+    font-size: var(--theia-ui-font-size0);
+    color: var(--theia-ui-font-color2);
+    position: absolute;
+    right: 0px;
+    top: 0px;
+    width: 65px;
+    height: 100%;
+    text-align: right;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.che-plugin-list .che-plugin-description {
+    position: absolute;
+    left: 0px;
+    top: 31px;
+    right: 4px;
+    height: 26px;
+    font-size: var(--theia-ui-font-size0);
+    color: var(--theia-ui-font-color1);
+    display: block;
+    overflow: hidden;
+}
+
+.che-plugin-list .che-plugin-description > div {
+    display: table;
+    position: relative;
+    height: 100%;
+}
+
+.che-plugin-list .che-plugin-description > div > div {
+    display: table-cell;
+    vertical-align: middle;
+}
+
+.che-plugin-list .che-plugin-publisher {
+    position: absolute;
+    color: var(--theia-ui-font-color2);
+    font-size: var(--theia-ui-font-size0);
+    font-weight: bold;
+    left: 0px;
+    top: 58px;
+    height: 20px;
+    line-height: 20px;
+    right: 85px;
+
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.che-plugin-list .che-plugin-type {
+    font-size: var(--theia-ui-font-size0);
+    font-weight: normal;
+    margin-left: 10px;
+    padding-left: 4px;
+    padding-right: 4px;
+    box-sizing: border-box;
+    padding-top: 1px;
+    padding-bottom: 1px;
+    background-color: var(--theia-disabled-color0);
+    color: var(--theia-disabled-color3);
+}
+
+/*-----------------------------------------------------------------------------
+| Plugin actions
+|----------------------------------------------------------------------------*/
+
+.che-plugin-list .che-plugin-action-add,
+.che-plugin-list .che-plugin-action-remove,
+.che-plugin-list .che-plugin-action-installing,
+.che-plugin-list .che-plugin-action-removing {
+    display: block;
+    position: absolute;
+    font-size: var(--theia-ui-font-size0);
+    font-weight: bold;
+    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+    top: 64px;
+    height: 22px;
+    line-height: 22px;
+    right: 4px;
+    width: 75px;
+    text-align: center;
+    user-select: none;
+    border-radius: 1px;
+}
+
+.che-plugin-list .che-plugin-action-add {
+    cursor: pointer;
+    color: var(--theia-ui-button-font-color);
+    background-color: var(--theia-ui-button-color);
+}
+
+.che-plugin-list .che-plugin-action-add:hover {
+    background-color: var(--theia-ui-button-color-hover);
+}
+
+.che-plugin-list .che-plugin-action-add:active {
+    box-shadow: 0px 0px 1px 1px var(--theia-ui-button-color-hover);
+    outline: none;
+}
+
+.che-plugin-list .che-plugin-action-remove {
+    cursor: pointer;
+    color: var(--theia-success-font-color0);
+    background-color: var(--theia-success-color0);
+}
+
+.che-plugin-list .che-plugin-action-remove:hover {
+    background-color: var(--theia-success-color1);
+}
+
+.che-plugin-list .che-plugin-action-remove:active {
+    box-shadow: 0px 0px 1px 1px var(--theia-success-color0);
+    outline: none;
+}
+
+.che-plugin-list .che-plugin-action-installing {
+    color: var(--theia-ui-button-font-color-secondary-disabled);
+    background-color: var(--theia-ui-button-color-secondary-disabled);
+}
+
+.che-plugin-list .che-plugin-action-removing {
+    color: var(--theia-ui-button-font-color-secondary-disabled);
+    background-color: var(--theia-ui-button-color-secondary-disabled);
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -345,6 +345,10 @@ export interface Preferences {
     [key: string]: string;
 }
 
+export interface WorkspaceSettings {
+    [key: string]: string;
+}
+
 export const PLUGIN_RPC_CONTEXT = {
     CHE_WORKSPACE: <ProxyIdentifier<CheWorkspace>>createProxyIdentifier<CheWorkspace>('CheWorkspace'),
     CHE_WORKSPACE_MAIN: <ProxyIdentifier<CheWorkspaceMain>>createProxyIdentifier<CheWorkspaceMain>('CheWorkspaceMain'),
@@ -378,6 +382,7 @@ export interface CheApiService {
     getWorkspaceById(workspaceId: string): Promise<cheApi.workspace.Workspace>;
 
     updateWorkspace(workspaceId: string, workspace: cheApi.workspace.Workspace): Promise<cheApi.workspace.Workspace>;
+    stop(): Promise<void>;
 
     getFactoryById(factoryId: string): Promise<cheApi.factory.Factory>;
 
@@ -387,6 +392,7 @@ export interface CheApiService {
     replaceUserPreferences(preferences: Preferences): Promise<Preferences>;
     deleteUserPreferences(): Promise<void>;
     deleteUserPreferences(list: string[] | undefined): Promise<void>;
+    getWorkspaceSettings(): Promise<WorkspaceSettings>;
 
     generateSshKey(service: string, name: string): Promise<cheApi.ssh.SshPair>;
     createSshKey(sshKeyPair: cheApi.ssh.SshPair): Promise<void>;
@@ -415,4 +421,68 @@ export interface CheTaskClient {
     addRunTaskHandler(func: (id: number, config: che.TaskConfiguration, ctx?: string) => Promise<void>): void;
     addTaskExitedHandler(func: (id: number) => Promise<void>): void;
     onKillEvent: Event<number>
+}
+
+export interface ChePluginRegistry {
+    name: string,
+    uri: string
+}
+
+/**
+ * Describes properties in plugin meta.yaml
+ */
+export interface ChePluginMetadata {
+    publisher: string,
+    name: string,
+    version: string,
+    type: string,
+    displayName: string,
+    title: string,
+    description: string,
+    icon: string,
+    url: string,
+    repository: string,
+    firstPublicationDate: string,
+    category: string,
+    latestUpdateDate: string,
+
+    // Plugin KEY. Used to set in workpsace configuration
+    key: string
+}
+
+export const CHE_PLUGIN_SERVICE_PATH = '/che-plugin-service';
+
+export const ChePluginService = Symbol('ChePluginService');
+
+export interface ChePluginService {
+
+    /**
+     * Returns default plugin registry;
+     */
+    getDefaultRegistry(): Promise<ChePluginRegistry>;
+
+    /**
+     * Returns a list of available plugins on the plugin registry.
+     *
+     * @param registry ChePluginRegistry plugin registry
+     * @param filter filter
+     * @return list of available plugins
+     */
+    getPlugins(registry: ChePluginRegistry, filter: string): Promise<ChePluginMetadata[]>;
+
+    /**
+     * Returns list of plugins described in workspace configuration.
+     */
+    getWorkspacePlugins(): Promise<string[]>;
+
+    /**
+     * Adds a plugin to workspace configuration.
+     */
+    addPlugin(pluginKey: string): Promise<void>;
+
+    /**
+     * Removes a plugin from workspace configuration.
+     */
+    removePlugin(pluginKey: string): Promise<void>;
+
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/plugin/plugin-filter.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/plugin/plugin-filter.ts
@@ -1,0 +1,67 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ChePluginMetadata } from '../che-protocol';
+
+export namespace PluginFilter {
+
+    // @installed
+    // @builtin
+    // @enabled
+    // @disabled
+    export function hasType(filter: string, type: string): boolean {
+        if (filter) {
+            const filters = filter.split(' ');
+            const found = filters.find(value => value === type);
+            return found !== undefined;
+        }
+
+        return false;
+    }
+
+    export function filterByType(plugins: ChePluginMetadata[], type: string): ChePluginMetadata[] {
+        return plugins.filter(plugin => {
+            const regex = / /gi;
+            const t = plugin.type.toLowerCase().replace(regex, '_');
+            return t === type;
+        });
+    }
+
+    export function filterByText(plugins: ChePluginMetadata[], text: string): ChePluginMetadata[] {
+        return plugins;
+    }
+
+    export function filterPlugins(plugins: ChePluginMetadata[], filter: string): ChePluginMetadata[] {
+        let filteredPlugins = plugins;
+        const filters = filter.split(' ');
+
+        filters.forEach(f => {
+            if (f) {
+                if (f.startsWith('@')) {
+                    if (f.startsWith('@type:')) {
+                        const type = f.substring('@type:'.length);
+                        filteredPlugins = PluginFilter.filterByType(filteredPlugins, type);
+                    }
+                } else {
+                    filteredPlugins = PluginFilter.filterByText(filteredPlugins, f);
+                }
+            }
+        });
+
+        return filteredPlugins;
+    }
+
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-api-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-api-service.ts
@@ -7,10 +7,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { CheApiService, Preferences } from '../common/che-protocol';
+import { CheApiService, Preferences, WorkspaceSettings } from '../common/che-protocol';
 import { che as cheApi } from '@eclipse-che/api';
 import WorkspaceClient, { IRestAPIConfig, IRemoteAPI } from '@eclipse-che/workspace-client';
 import { injectable } from 'inversify';
+
+const ENV_WORKSPACE_ID_IS_NOT_SET = 'Environment variable CHE_WORKSPACE_ID is not set';
 
 @injectable()
 export class CheApiServiceImpl implements CheApiService {
@@ -45,11 +47,16 @@ export class CheApiServiceImpl implements CheApiService {
         return cheApiClient.deleteUserPreferences(list);
     }
 
+    async getWorkspaceSettings(): Promise<WorkspaceSettings> {
+        const cheApiClient = await this.getCheApiClient();
+        return cheApiClient.getSettings();
+    }
+
     async currentWorkspace(): Promise<cheApi.workspace.Workspace> {
         try {
             const workspaceId = process.env.CHE_WORKSPACE_ID;
             if (!workspaceId) {
-                return Promise.reject('Cannot find Che workspace id, environment variable "CHE_WORKSPACE_ID" is not set');
+                return Promise.reject(ENV_WORKSPACE_ID_IS_NOT_SET);
             }
 
             const cheApiClient = await this.getCheApiClient();
@@ -98,6 +105,16 @@ export class CheApiServiceImpl implements CheApiService {
             console.log(e);
             return Promise.reject('Cannot create Che API REST Client');
         }
+    }
+
+    async stop(): Promise<void> {
+        const workspaceId = process.env.CHE_WORKSPACE_ID;
+        if (!workspaceId) {
+            return Promise.reject(ENV_WORKSPACE_ID_IS_NOT_SET);
+        }
+
+        const cheApiClient = await this.getCheApiClient();
+        return await cheApiClient.stop(workspaceId);
     }
 
     async getFactoryById(factoryId: string): Promise<cheApi.factory.Factory> {
@@ -207,8 +224,9 @@ export class CheApiServiceImpl implements CheApiService {
     private getWorkspaceIdFromEnv(): string {
         const workspaceId = process.env.CHE_WORKSPACE_ID;
         if (!workspaceId) {
-            throw new Error('Environment variable CHE_WORKSPACE_ID is not set.');
+            throw new Error(ENV_WORKSPACE_ID_IS_NOT_SET);
         }
+
         return workspaceId;
     }
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2018 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -1,0 +1,398 @@
+/*********************************************************************
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import {
+    CheApiService,
+    ChePluginService,
+    ChePluginRegistry,
+    ChePluginMetadata,
+    WorkspaceSettings
+} from '../common/che-protocol';
+
+import { injectable, interfaces } from 'inversify';
+import axios, { AxiosInstance } from 'axios';
+import { che as cheApi } from '@eclipse-che/api';
+import URI from '@theia/core/lib/common/uri';
+
+const yaml = require('js-yaml');
+
+/**
+ * Describes plugin inside plugin list
+ * https://che-plugin-registry.openshift.io/plugins/
+ */
+export interface ChePluginMetadataInternal {
+    id: string,
+    displayName: string,
+    version: string,
+    type: string,
+    name: string,
+    description: string,
+    publisher: string,
+    links: {
+        self?: string,
+        [link: string]: string
+    }
+}
+
+@injectable()
+export class ChePluginServiceImpl implements ChePluginService {
+
+    private axiosInstance: AxiosInstance = axios;
+
+    private cheApiService: CheApiService;
+
+    private defaultRegistry: ChePluginRegistry;
+
+    constructor(container: interfaces.Container) {
+        this.cheApiService = container.get(CheApiService);
+    }
+
+    async getDefaultRegistry(): Promise<ChePluginRegistry> {
+        if (this.defaultRegistry) {
+            return this.defaultRegistry;
+        }
+
+        try {
+            const workpsaceSettings: WorkspaceSettings = await this.cheApiService.getWorkspaceSettings();
+            if (workpsaceSettings && workpsaceSettings['cheWorkspacePluginRegistryUrl']) {
+                let uri = workpsaceSettings['cheWorkspacePluginRegistryUrl'];
+
+                if (uri.endsWith('/')) {
+                    uri = uri.substring(0, uri.length - 1);
+                }
+
+                if (!uri.endsWith('/plugins')) {
+                    uri += '/plugins/';
+                }
+
+                this.defaultRegistry = {
+                    name: 'Eclipse Che plugins',
+                    uri: uri
+                };
+
+                return this.defaultRegistry;
+            }
+
+            return Promise.reject('Plugin registry URI is not set.');
+        } catch (error) {
+            // console.log('ERROR', error);
+            // return Promise.reject('Unable to get default plugin registry URI. ' + error.message);
+
+            // A temporary solution. Should throw an error instead.
+            this.defaultRegistry = {
+                name: 'Eclipse Che plugin registry',
+                uri: 'https://che-plugin-registry.openshift.io/plugins/'
+            };
+            return this.defaultRegistry;
+        }
+    }
+
+    // @installed
+    // @builtin
+    // @enabled
+    // @disabled
+    hasType(filter: string, type: string) {
+        if (filter) {
+            const filters = filter.split(' ');
+            const found = filters.find(value => value === type);
+            return found !== undefined;
+        }
+
+        return false;
+    }
+
+    filterByType(plugins: ChePluginMetadata[], type: string): ChePluginMetadata[] {
+        return plugins.filter(plugin => {
+            const regex = / /gi;
+            const t = plugin.type.toLowerCase().replace(regex, '_');
+            return t === type;
+        });
+    }
+
+    filterByText(plugins: ChePluginMetadata[], text: string): ChePluginMetadata[] {
+        return plugins;
+    }
+
+    filter(plugins: ChePluginMetadata[], filter: string): ChePluginMetadata[] {
+        let filteredPlugins = plugins;
+        const filters = filter.split(' ');
+
+        filters.forEach(f => {
+            if (f) {
+                if (f.startsWith('@')) {
+                    if (f.startsWith('@type:')) {
+                        const type = f.substring('@type:'.length);
+                        filteredPlugins = this.filterByType(filteredPlugins, type);
+                    }
+                } else {
+                    filteredPlugins = this.filterByText(filteredPlugins, f);
+                }
+            }
+        });
+
+        return filteredPlugins;
+    }
+
+    /**
+     * Removes plugins with type 'Che Editor' if type '@type:che_editor' is not set
+     */
+    squeezeOutEditors(plugins: ChePluginMetadata[], filter: string): ChePluginMetadata[] {
+        // do not filter if user requested list of editors
+        if (this.hasType(filter, '@type:che_editor')) {
+            return plugins;
+        }
+
+        return plugins.filter(plugin => 'Che Editor' !== plugin.type);
+    }
+
+    /**
+     * Returns a list of available plugins on the plugin registry.
+     *
+     * @param registry ChePluginRegistry plugin registry
+     * @param filter filter
+     * @return list of available plugins
+     */
+    async getPlugins(registry: ChePluginRegistry, filter: string): Promise<ChePluginMetadata[]> {
+        // ensure default plugin registry URI is set
+        if (!this.defaultRegistry) {
+            await this.getDefaultRegistry();
+        }
+
+        let pluginList;
+        if (filter) {
+            if (this.hasType(filter, '@installed')) {
+                pluginList = await this.getInstalledPlugins();
+            } else {
+                pluginList = await this.getAllPlugins(registry);
+            }
+
+            pluginList = this.filter(pluginList, filter);
+        } else {
+            pluginList = await this.getAllPlugins(registry);
+        }
+
+        // remove che_editor if type @type:che_editor is not set
+        pluginList = this.squeezeOutEditors(pluginList, filter);
+
+        return pluginList;
+    }
+
+    // without prefix
+    async getAllPlugins(registry: ChePluginRegistry): Promise<ChePluginMetadata[]> {
+        // Get list of ChePluginMetadataInternal from plugin registry
+        const marketplacePlugins = await this.loadPluginList(registry);
+        if (!marketplacePlugins) {
+            return Promise.reject('Unable to get plugins from marketplace');
+        }
+
+        const longKeyFormat = registry.uri !== this.defaultRegistry.uri;
+        const plugins: ChePluginMetadata[] = await Promise.all(
+            marketplacePlugins.map(async marketplacePlugin => {
+                const pluginYamlURI = this.getPluginYampURI(registry, marketplacePlugin);
+                return await this.loadPluginMetadata(pluginYamlURI, longKeyFormat);
+            }
+            ));
+
+        return plugins.filter(plugin => plugin !== null && plugin !== undefined);
+    }
+
+    // has prefix @installed
+    async getInstalledPlugins(): Promise<ChePluginMetadata[]> {
+        const workspacePlugins = await this.getWorkspacePlugins();
+        const plugins: ChePluginMetadata[] = await Promise.all(
+            workspacePlugins.map(async workspacePlugin => {
+                let pluginYamlURI;
+                let longKeyFormat = false;
+
+                if (workspacePlugin.startsWith('http://') || workspacePlugin.startsWith('https://')) {
+                    pluginYamlURI = `${workspacePlugin}/meta.yaml`;
+                    longKeyFormat = true;
+                } else {
+                    let uri = this.defaultRegistry.uri;
+                    if (uri.endsWith('/')) {
+                        uri = uri.substring(0, uri.length - 1);
+                    }
+
+                    pluginYamlURI = `${uri}/${workspacePlugin}/meta.yaml`;
+                }
+
+                return await this.loadPluginMetadata(pluginYamlURI, longKeyFormat);
+            }
+            ));
+
+        return plugins.filter(plugin => plugin !== null && plugin !== undefined);
+    }
+
+    /**
+     * Loads list of plugins from plugin registry.
+     *
+     * @param registry ChePluginRegistry plugin registry
+     * @return list of available plugins
+     */
+    private async loadPluginList(registry: ChePluginRegistry): Promise<ChePluginMetadataInternal[] | undefined> {
+        try {
+            const noCache = { headers: { 'Cache-Control': 'no-cache' } };
+            return (await this.axiosInstance.get<ChePluginMetadataInternal[]>(registry.uri, noCache)).data;
+        } catch (error) {
+            return undefined;
+        }
+    }
+
+    /**
+     * Creates an URI to plugin metadata yaml file.
+     *
+     * @param registry: ChePluginRegistry plugin registry
+     * @param plugin plugin metadata
+     * @return uri to plugin yaml file
+     */
+    private getPluginYampURI(registry: ChePluginRegistry, plugin: ChePluginMetadataInternal): string | undefined {
+        if (plugin.links && plugin.links.self) {
+            const self: string = plugin.links.self;
+            if (self.startsWith('/')) {
+                const uri = new URI(registry.uri);
+                return `${uri.scheme}://${uri.authority}${self}`;
+            } else {
+                const base = this.getBaseDirectory(registry);
+                return `${base}${self}`;
+            }
+        } else {
+            const base = this.getBaseDirectory(registry);
+            return `${base}/${plugin.id}/meta.yaml`;
+        }
+    }
+
+    private getBaseDirectory(registry: ChePluginRegistry): string {
+        let uri = registry.uri;
+
+        if (uri.endsWith('.json')) {
+            uri = uri.substring(0, uri.lastIndexOf('/') + 1);
+        } else {
+            if (!uri.endsWith('/')) {
+                uri += '/';
+            }
+        }
+
+        return uri;
+    }
+
+    private async loadPluginYaml(yamlURI: string): Promise<ChePluginMetadata> {
+        const noCache = { headers: { 'Cache-Control': 'no-cache' } };
+
+        let err;
+        try {
+            const data = (await this.axiosInstance.get<ChePluginMetadata[]>(yamlURI, noCache)).data;
+            return yaml.safeLoad(data);
+        } catch (error) {
+            err = error;
+        }
+
+        try {
+            if (!yamlURI.endsWith('/')) {
+                yamlURI += '/';
+            }
+            yamlURI += 'meta.yaml';
+            const data = (await this.axiosInstance.get<ChePluginMetadata[]>(yamlURI, noCache)).data;
+            return yaml.safeLoad(data);
+        } catch (error) {
+            return Promise.reject('Unable to load plugin metadata. ' + err.message);
+        }
+    }
+
+    private async loadPluginMetadata(yamlURI: string, longKeyFormat: boolean): Promise<ChePluginMetadata> {
+        try {
+            const props: ChePluginMetadata = await this.loadPluginYaml(yamlURI);
+
+            let key = `${props.publisher}/${props.name}/${props.version}`;
+            if (longKeyFormat) {
+                if (yamlURI.endsWith(key)) {
+                    const uri = yamlURI.substring(0, yamlURI.length - key.length);
+                    key = `${uri}${props.publisher}/${props.name}/${props.version}`;
+                } else if (yamlURI.endsWith(`${key}/meta.yaml`)) {
+                    const uri = yamlURI.substring(0, yamlURI.length - `${key}/meta.yaml`.length);
+                    key = `${uri}${props.publisher}/${props.name}/${props.version}`;
+                }
+            }
+
+            return {
+                publisher: props.publisher,
+                name: props.name,
+                version: props.version,
+                type: props.type,
+                displayName: props.displayName,
+                title: props.title,
+                description: props.description,
+                icon: props.icon,
+                url: props.url,
+                repository: props.repository,
+                firstPublicationDate: props.firstPublicationDate,
+                category: props.category,
+                latestUpdateDate: props.latestUpdateDate,
+                key: key
+            };
+
+        } catch (error) {
+            console.log(error);
+            return Promise.reject('Unable to load plugin metadata. ' + error.message);
+        }
+    }
+
+    /**
+     * Returns list of plugins described in workspace configuration.
+     */
+    async getWorkspacePlugins(): Promise<string[]> {
+        const workspace: cheApi.workspace.Workspace = await this.cheApiService.currentWorkspace();
+
+        if (workspace.config && workspace.config.attributes && workspace.config.attributes['plugins']) {
+            const plugins = workspace.config.attributes['plugins'];
+            return plugins.split(',');
+        }
+
+        return Promise.reject('Unable to get Workspace plugins');
+    }
+
+    /**
+     * Sets new list of plugins to workspace configuration.
+     */
+    async setWorkspacePlugins(plugins: string[]): Promise<void> {
+        const workspace: cheApi.workspace.Workspace = await this.cheApiService.currentWorkspace();
+        if (workspace.config && workspace.config.attributes && workspace.config.attributes['plugins']) {
+            workspace.config.attributes['plugins'] = plugins.join(',');
+            await this.cheApiService.updateWorkspace(workspace.id, workspace);
+        }
+    }
+
+    /**
+     * Adds a plugin to workspace configuration.
+     */
+    async addPlugin(pluginKey: string): Promise<void> {
+        try {
+            const plugins: string[] = await this.getWorkspacePlugins();
+            plugins.push(pluginKey);
+            await this.setWorkspacePlugins(plugins);
+        } catch (error) {
+            console.error(error);
+            return Promise.reject('Unable to install plugin ' + pluginKey + ' ' + error.message);
+        }
+    }
+
+    /**
+     * Removes a plugin from workspace configuration.
+     */
+    async removePlugin(pluginKey: string): Promise<void> {
+        try {
+            const plugins: string[] = await this.getWorkspacePlugins();
+            const filteredPlugins = plugins.filter(p => p !== pluginKey);
+            await this.setWorkspacePlugins(filteredPlugins);
+        } catch (error) {
+            console.error(error);
+            return Promise.reject('Unable to remove plugin ' + pluginKey + ' ' + error.message);
+        }
+    }
+
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -60,9 +60,9 @@ export class ChePluginServiceImpl implements ChePluginService {
         }
 
         try {
-            const workpsaceSettings: WorkspaceSettings = await this.cheApiService.getWorkspaceSettings();
-            if (workpsaceSettings && workpsaceSettings['cheWorkspacePluginRegistryUrl']) {
-                let uri = workpsaceSettings['cheWorkspacePluginRegistryUrl'];
+            const workspaceSettings: WorkspaceSettings = await this.cheApiService.getWorkspaceSettings();
+            if (workspaceSettings && workspaceSettings['cheWorkspacePluginRegistryUrl']) {
+                let uri = workspaceSettings['cheWorkspacePluginRegistryUrl'];
 
                 if (uri.endsWith('/')) {
                     uri = uri.substring(0, uri.length - 1);

--- a/extensions/eclipse-che-theia-plugin-ext/tsconfig.json
+++ b/extensions/eclipse-che-theia-plugin-ext/tsconfig.json
@@ -8,7 +8,8 @@
         "sourceMap": true,
         "rootDir": "src",
         "outDir": "lib",
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "jsx": "react"
     },
     "include": [
         "src"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

- Displays a dedicated view with list of available plugins
- Installs / uninstalls a plugin by simple mouse click
- Displays installed plugins in separate list
- Allows the user to install a plugin from custom registry
- Installs VS Code extension using a command or drag and drop

![Screenshot from 2019-04-05 16-39-18](https://user-images.githubusercontent.com/1655894/55707237-ccd1d100-59eb-11e9-9ee2-effcab4b5f1c.png)

Video demonstrating the feature
https://www.youtube.com/watch?v=2_GPZb1_Hew

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12932

Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>
