### PR TITLE
Preparing next che:theia init generator model that would include plugins

### DIFF
--- a/extensions/extensions.yml
+++ b/extensions/extensions.yml
@@ -9,4 +9,19 @@ extensions:
     - extensions/che-theia-hosted-plugin-manager-extension
     - extensions/eclipse-che-theia-dashboard
     - extensions/eclipse-che-theia-activity-tracker
+  extensionFolders:
+    - dockerfiles/theia-endpoint-runtime
+    - extensions/eclipse-che-theia-plugin
+    - extensions/eclipse-che-theia-plugin-ext
+    - extensions/eclipse-che-theia-terminal
+    - extensions/eclipse-che-theia-user-preferences
+    - extensions/che-theia-hosted-plugin-manager-extension
+    - extensions/eclipse-che-theia-dashboard
+    - extensions/eclipse-che-theia-activity-tracker
+  pluginFolders:
+    - plugins/containers-plugin
+    - plugins/factory-plugin
+    - plugins/ports-plugin
+    - plugins/task-plugin
+    - plugins/welcome-plugin
   checkoutTo: master


### PR DESCRIPTION
### What does this PR do?
Preparing the inclusion of plugins when using `che:theia init` commands. https://github.com/eclipse/che-theia/issues/45
We would have folders for extensions and folders for plugins to create symblink.

So `folders` -> `extensionFolders`
and we would have a new section for plugins: `pluginFolders`

I kept the old version (`folders`) for the time being.

WDYT ?

### What issues does this PR fix or reference?
https://github.com/eclipse/che-theia/issues/45