### PR TITLE
Do not show list of containers where to run a che commands if target container/component is already defined in the devfile #154

### DIFF
--- a/plugins/task-plugin/src/che-workspace-client.ts
+++ b/plugins/task-plugin/src/che-workspace-client.ts
@@ -32,14 +32,14 @@ export class CheWorkspaceClient {
     }
 
     async getCommands(): Promise<cheApi.workspace.Command[]> {
-        const workspace = await this.getCurrentWorkspace();
+        const workspace: cheApi.workspace.Workspace = await this.getCurrentWorkspace();
 
-        const config = workspace.config;
-        if (!config) {
+        const runtime: cheApi.workspace.Runtime = workspace.runtime;
+        if (!runtime) {
             return [];
         }
 
-        const commands = config.commands;
+        const commands = runtime.commands;
         return commands ? commands : [];
     }
 


### PR DESCRIPTION
### What does this PR do?
`machineName` is available in the `runtime` commands, not not the workspace config.
Fixing it to avoid user to choose a target container where component is already setted in devfile for a command.

### What issues does this PR fix or reference?
#154 
