### PR TITLE
Support checking out a specific tag/commit after cloning 

### DIFF
--- a/plugins/factory-plugin/src/projects.ts
+++ b/plugins/factory-plugin/src/projects.ts
@@ -48,6 +48,9 @@ export function updateOrCreateGitProject(
             project.source.parameters = {};
         }
         project.source.parameters['branch'] = projectGitRemoteBranch;
+        delete project.source.parameters['startPoint'];
+        delete project.source.parameters['tag'];
+        delete project.source.parameters['commitId'];
     });
 
     return projects;

--- a/plugins/factory-plugin/src/theia-commands.ts
+++ b/plugins/factory-plugin/src/theia-commands.ts
@@ -10,6 +10,7 @@
 import * as theia from '@theia/plugin';
 import { che as cheApi } from '@eclipse-che/api';
 import * as fileuri from './file-uri';
+import * as git from './git';
 
 const CHE_TASK_TYPE = 'che';
 
@@ -26,12 +27,21 @@ export class TheiaCloneCommand {
     private locationURI: string | undefined;
     private folder: string;
     private checkoutBranch?: string | undefined;
+    private checkoutTag?: string | undefined;
+    private checkoutStartPoint?: string | undefined;
+    private checkoutCommitId?: string | undefined;
 
     constructor(project: cheApi.workspace.ProjectConfig, projectsRoot: string) {
         this.locationURI = project.source && project.source.location ? project.source.location : undefined;
         this.folder = projectsRoot + project.path;
         this.checkoutBranch = project.source && project.source.parameters && project.source.parameters['branch'] ?
             project.source.parameters['branch'] : undefined;
+        this.checkoutStartPoint = project.source && project.source.parameters && project.source.parameters['startPoint'] ?
+            project.source.parameters['startPoint'] : undefined;
+        this.checkoutTag = project.source && project.source.parameters && project.source.parameters['tag'] ?
+            project.source.parameters['tag'] : undefined;
+        this.checkoutCommitId = project.source && project.source.parameters && project.source.parameters['commitId'] ?
+            project.source.parameters['commitId'] : undefined;
     }
 
     execute(): PromiseLike<void> {
@@ -41,10 +51,30 @@ export class TheiaCloneCommand {
 
         return theia.commands.executeCommand('git.clone', this.locationURI, this.folder, this.checkoutBranch)
             .then(repo => {
-                theia.window.showInformationMessage(`Project ${this.locationURI} cloned! to ${repo}`);
+                // Figure out what to reset to.
+                // The priority order is startPoint > tag > commitId
+
+                const treeish = this.checkoutStartPoint
+                    ? this.checkoutStartPoint
+                    : (this.checkoutTag ? this.checkoutTag : this.checkoutCommitId);
+
+                const branch = this.checkoutBranch ? this.checkoutBranch : 'default branch';
+                const messageStart = `Project ${this.locationURI} cloned to ${repo} and checked out ${branch}`;
+
+                if (treeish) {
+                    git.execGit(this.folder, 'reset', '--hard', treeish)
+                        .then(_ => {
+                            theia.window.showInformationMessage(`${messageStart} which has been reset to ${treeish}.`);
+                        }, e => {
+                            theia.window.showErrorMessage(`${messageStart} but resetting to ${treeish} failed with ${e.message}.`);
+                            console.log(`Couldn't reset to ${treeish} of ${repo} cloned from ${this.locationURI} and checked out to ${branch}.`, e);
+                        });
+                } else {
+                    theia.window.showInformationMessage(`${messageStart}.`);
+                }
             }, e => {
-                theia.window.showErrorMessage(`Couldnt clone ${this.locationURI}: ${e.message}`);
-                console.log(`Couldnt clone ${this.locationURI}`, e);
+                theia.window.showErrorMessage(`Couldn't clone ${this.locationURI}: ${e.message}`);
+                console.log(`Couldn't clone ${this.locationURI}`, e);
             });
     }
 

--- a/plugins/factory-plugin/tests/projects.spec.ts
+++ b/plugins/factory-plugin/tests/projects.spec.ts
@@ -36,7 +36,8 @@ describe("Testing projects updater when file is triggered", () => {
                     "location": "https://github.com/eclipse/che-theia-factory-extension.git",
                     "type": "git",
                     "parameters": {
-                        "branch": "master"
+                        "branch": "master",
+                        "tag": "v42.0"
                     }
                 },
                 "path": "/che-theia-factory-extension",
@@ -52,6 +53,7 @@ describe("Testing projects updater when file is triggered", () => {
         projecthelper.updateOrCreateGitProject(projects, '/che-theia-factory-extension', 'https://github.com/sunix/che-theia-factory-extension.git', 'wip-sunix');
         expect(projects[1].source.location).toBe("https://github.com/sunix/che-theia-factory-extension.git");
         expect(projects[1].source.parameters['branch']).toBe("wip-sunix");
+        expect(projects[1].source.parameters['tag']).toBe(undefined);
 
         projecthelper.updateOrCreateGitProject(projects, '/che/che-theia-factory-extension', 'https://github.com/sunix/che-theia-factory-extension.git', 'wip-theia');
         expect(projects[2].source.location).toBe("https://github.com/sunix/che-theia-factory-extension.git");


### PR DESCRIPTION
### What does this PR do?
This is a copy of #144 but in a branch of the main repo so that CI is able to run on it.

This PR adds the ability to reset the freshly cloned repository to a specified tag, commitId or generally a startPoint.

This PR is to implement eclipse/che#12775 on the Theia side.

### What issues does this PR fix or reference?

eclipse/che#12775
