### PR TITLE
Use node:10.15-alpine as a base image

### DIFF
--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -11,7 +11,7 @@
 ###
 # Builder Image
 #
-FROM node:10.2.1-alpine
+FROM node:10.15-alpine
 
 RUN apk add --update --no-cache \
     # Download some files

--- a/dockerfiles/theia-endpoint-runtime/Dockerfile
+++ b/dockerfiles/theia-endpoint-runtime/Dockerfile
@@ -50,7 +50,7 @@ COPY /tsconfig.json /home/workspace/packages/theia-plugin/tsconfig.json
 COPY /etc/package.json /home/workspace
 RUN cd /home/workspace/ && yarn install
 
-FROM node:10.2.1-alpine
+FROM node:10.15-alpine
 ENV HOME=/home/theia
 COPY --from=builder /home/workspace/node_modules /home/theia/node_modules
 RUN rm -rf /home/theia/node_modules/@eclipse-che/theia-plugin-ext /home/theia/node_modules/@eclipse-che/theia-remote

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -129,7 +129,7 @@ RUN mkdir -p ${HOME}/che-theia-plugins/ && \
 # Runtime Image
 #
 # Use node image
-FROM node:10.2.1-alpine as runtime
+FROM node:10.15-alpine as runtime
 ENV USE_LOCAL_GIT=true \
     HOME=/home/theia \
     THEIA_DEFAULT_PLUGINS=local-dir:///default-theia-plugins \


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

Since https://github.com/eclipse/che-theia/commit/009231cf97c9dc6c5cea65b8c222d08f013769af the version of Alpine was downgraded to 3.7.

This PR updates node to 10.15 with Alpine 3.8.