### PR TITLE
Move user containers from root to 'User Runtimes' node. 

### DIFF
--- a/plugins/containers-plugin/package.json
+++ b/plugins/containers-plugin/package.json
@@ -14,16 +14,16 @@
     "viewsContainers": {
       "right": [
         {
-          "id": "containers",
-          "title": "Containers",
+          "id": "my-workspace",
+          "title": "My Workspace",
           "icon": "resources/cube.svg"
         }
       ]
     },
     "views": {
-      "containers": [
+      "my-workspace": [
         {
-          "id": "containers",
+          "id": "workspace",
           "name": "Workspace"
         }
       ]

--- a/plugins/containers-plugin/src/containers-plugin.ts
+++ b/plugins/containers-plugin/src/containers-plugin.ts
@@ -19,7 +19,7 @@ export function start(context: theia.PluginContext) {
     });
     context.subscriptions.push(treeDataDisposableFn);
 
-    theia.window.createTreeView('containers', { treeDataProvider });
+    theia.window.createTreeView('workspace', { treeDataProvider });
 
     const containersService = new ContainersService();
     containersService.updateContainers().then(() => {

--- a/plugins/containers-plugin/src/containers-service.ts
+++ b/plugins/containers-plugin/src/containers-service.ts
@@ -75,7 +75,7 @@ export class ContainersService {
                 Object.keys(machine.servers).forEach((serverName: string) => {
                     const server = machine.servers[serverName];
                     if (server && server.url) {
-                        container!.servers![serverName] = { url: server!.url };
+                        container.servers[serverName] = { url: server.url };
                     }
                 });
             }

--- a/plugins/containers-plugin/src/containers-tree-data-provider.ts
+++ b/plugins/containers-plugin/src/containers-tree-data-provider.ts
@@ -42,9 +42,15 @@ export class ContainersTreeDataProvider implements theia.TreeDataProvider<ITreeN
     updateContainersTreeData(containers: IContainer[]): void {
         this.ids.length = 0;
         this.treeNodeItems.length = 0;
-        const pluginsDir = {
+        const runtimesGroup = {
             id: this.getRandId(),
-            name: 'plugins',
+            name: 'User Runtimes',
+            tooltip: 'user defined containers',
+            isExpanded: true
+        };
+        const pluginsGroup = {
+            id: this.getRandId(),
+            name: 'Plugins',
             tooltip: 'che-plugin containers',
             isExpanded: false
         };
@@ -75,10 +81,11 @@ export class ContainersTreeDataProvider implements theia.TreeDataProvider<ITreeN
             }
             if (container.isDev) {
                 treeItem.tooltip = 'dev ' + treeItem.tooltip;
+                treeItem.parentId = runtimesGroup.id;
             } else {
                 hasPlugin = true;
                 treeItem.tooltip = 'che-plugin ' + treeItem.tooltip;
-                treeItem.parentId = pluginsDir.id;
+                treeItem.parentId = pluginsGroup.id;
             }
             this.treeNodeItems.push(treeItem);
             this.treeNodeItems.push({
@@ -197,9 +204,12 @@ export class ContainersTreeDataProvider implements theia.TreeDataProvider<ITreeN
                 });
             }
         });
+
+        this.treeNodeItems.push(runtimesGroup);
         if (hasPlugin) {
-            this.treeNodeItems.push(pluginsDir);
+            this.treeNodeItems.push(pluginsGroup);
         }
+
         this.onDidChangeTreeDataEmitter.fire();
     }
 

--- a/plugins/containers-plugin/src/containers-tree-data-provider.ts
+++ b/plugins/containers-plugin/src/containers-tree-data-provider.ts
@@ -55,6 +55,7 @@ export class ContainersTreeDataProvider implements theia.TreeDataProvider<ITreeN
             isExpanded: false
         };
         let hasPlugin = false;
+        let hasRuntimeContainers = false;
 
         containers.forEach((container: IContainer) => {
             const treeItem: ITreeNodeItem = {
@@ -80,6 +81,7 @@ export class ContainersTreeDataProvider implements theia.TreeDataProvider<ITreeN
                     treeItem.iconPath = 'fa-circle-o';
             }
             if (container.isDev) {
+                hasRuntimeContainers = true;
                 treeItem.tooltip = 'dev ' + treeItem.tooltip;
                 treeItem.parentId = runtimesGroup.id;
             } else {
@@ -205,10 +207,25 @@ export class ContainersTreeDataProvider implements theia.TreeDataProvider<ITreeN
             }
         });
 
-        this.treeNodeItems.push(runtimesGroup);
-        if (hasPlugin) {
-            this.treeNodeItems.push(pluginsGroup);
+        if (!hasRuntimeContainers) {
+            this.treeNodeItems.push({
+                id: this.getRandId(),
+                parentId: runtimesGroup.id,
+                name: 'No runtime containers',
+                tooltip: 'No runtime containers are specified in workspace configuration'
+            });
         }
+        this.treeNodeItems.push(runtimesGroup);
+
+        if (!hasPlugin) {
+            this.treeNodeItems.push({
+                id: this.getRandId(),
+                parentId: pluginsGroup.id,
+                name: 'No plugins defined',
+                tooltip: 'No plugins are specified in workspace configuration'
+            });
+        }
+        this.treeNodeItems.push(pluginsGroup);
 
         this.onDidChangeTreeDataEmitter.fire();
     }


### PR DESCRIPTION
### What does this PR do?
Renames `Containers` panel into `My Workspace`.
Moves user defined containers from root node to `User Runtimes` node, so root has only two nodes: `User Runtimes` and `Plugins`

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12984

#### Release Notes
`Containers` panel is renamed into `My workspace`

#### Screenshots
![che-12984](https://user-images.githubusercontent.com/15607393/56135107-b3ef8f80-5f98-11e9-8adb-1af2cc7c3067.jpg)

For case, when no runtime containers are defined:
![che-12984-no-runtime](https://user-images.githubusercontent.com/15607393/56209077-540ded00-605b-11e9-9963-ad2fbaffc7e5.png)


