### PR TITLE
Add example docker run command to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,12 @@ Then in `dockerfiles/theia` run:
 Where `${GITHUB_TOKEN_ARG}` is your GitHub API token, it's used for fetching some vscode library that placed on GitHub releases, without that token build may fail.
 
 That script will clone Theia from master branch and all Che related extensions from theirs master branches.
+
+Once the docker builds have completed, run the `che-theia` docker container:
+```bash
+docker run -it -p 3100:3100 -v "${THEIA_WORKSPACE}:/projects" eclipse/che-theia:next
+```
+
+where $THEIA_WORKSPACE is the directory you wish to be the root of your Theia workspace.
+
+You can then access che-theia at `http://localhost:3100`.


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds example `docker run` command to run `che-theia` locally. This shows developers:
1) It runs on port 3100, not 3000 like regular Theia.
2) How to mount the desired workspace.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
