### PR TITLE
Add volume for Theia data directory of the current user

### DIFF
--- a/che-plugins/che-editor-theia/etc/che-plugin.yaml
+++ b/che-plugins/che-editor-theia/etc/che-plugin.yaml
@@ -53,6 +53,8 @@ containers:
    volumes:
        - mountPath: "/plugins"
          name: plugins
+       - mountPath: "/home/theia/.theia"
+         name: theia-data
        - mountPath: "/projects"
          name: projects
    ports:


### PR DESCRIPTION
### What does this PR do?
Adds volume to persist global data of Theia, which includes (for all plugins):
- global state 
- workspace state 
- data directory
- Theia workspaces configuration (unless user defines another location for it)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12260