### PR TITLE
Improve displaying output for che commands in output channel

### DIFF
--- a/plugins/task-plugin/src/task/che-task-runner.ts
+++ b/plugins/task-plugin/src/task/che-task-runner.ts
@@ -65,7 +65,7 @@ export class CheTaskRunner {
                 workspaceId: workspaceId
             },
             cmd: ['sh', '-c', "'" + taskConfig.command + "'"],
-            tty: true,
+            tty: false,
             cwd: target.workingDir
         };
 


### PR DESCRIPTION
### What does this PR do?
It was temporary solution to display output of a command to output channel. Within this [issue](https://github.com/eclipse/che/issues/11458) we depend on https://github.com/eclipse/che/issues/11442
So this PR is a workaround to improve displaying output for che commands in output channel
Then we switch task's output from output channel to terminal widget when https://github.com/eclipse/che/issues/11442  is resolved.

### What issues does this PR fix or reference?
https://github.com/eclipse/che-theia/issues/192

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

![output](https://user-images.githubusercontent.com/5676062/56744545-62f24f00-6781-11e9-8a53-517ef1e75910.png)

