### PR TITLE
Preparing next che:theia init generator model. Will move to the root …folder of the repo, rename root element and folders

### DIFF
--- a/che-theia-init-sources.yml
+++ b/che-theia-init-sources.yml
@@ -1,6 +1,6 @@
-extensions:
+sources:
 - source: https://github.com/eclipse/che-theia
-  folders:
+  extensions:
     - dockerfiles/theia-endpoint-runtime
     - extensions/eclipse-che-theia-plugin
     - extensions/eclipse-che-theia-plugin-ext
@@ -10,4 +10,10 @@ extensions:
     - extensions/eclipse-che-theia-dashboard
     - extensions/eclipse-che-theia-activity-tracker
     - extensions/eclipse-che-theia-about
+  plugins:
+    - plugins/containers-plugin
+    - plugins/factory-plugin
+    - plugins/ports-plugin
+    - plugins/task-plugin
+    - plugins/welcome-plugin
   checkoutTo: master


### PR DESCRIPTION
### What does this PR do?
Propose the next format of `extensions.yml`, following the discussion https://github.com/ws-skeleton/che-theia-generator/pull/20#issuecomment-483263490:

- moving `extensions/extensions.yml` to `che-theia-init-sources.yml`
- renamed root `extensions` item to `sources`
- rename `pluginFolders` to `plugins`
- rename `extensionFolders` to `extensions`

### What issues does this PR fix or reference?
https://github.com/eclipse/che-theia/issues/45

