### PR TITLE
Docker image for PHP Language Support and Debugger

### DIFF
--- a/dockerfiles/remote-plugin-php7/Dockerfile
+++ b/dockerfiles/remote-plugin-php7/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:${BUILD_TAG}
+
+RUN apk --update --no-cache add \
+        ca-certificates \
+        php7 php7-fpm php7-opcache \
+        php7-gd php7-mysqli php7-zlib php7-curl \
+    && apk --update --no-cache add \
+        php7-xdebug --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+    && echo "zend_extension=$(find /usr/lib/php7/modules/ -name xdebug.so)" > /etc/php7/php.ini \
+    && echo "xdebug.coverage_enable=0" >> /etc/php7/php.ini \
+    && echo "xdebug.remote_enable=1" >> /etc/php7/php.ini \
+    && echo "xdebug.remote_connect_back=1" >> /etc/php7/php.ini \
+    && echo "xdebug.remote_log=/tmp/xdebug.log" >> /etc/php7/php.ini \
+    && echo "xdebug.remote_autostart=true" >> /etc/php7/php.ini
+
+WORKDIR /projects

--- a/dockerfiles/remote-plugin-php7/build.sh
+++ b/dockerfiles/remote-plugin-php7/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
+
+init --name:remote-plugin-php7 "$@"
+build


### PR DESCRIPTION
Based on che-theia-endpoint-runtime image.

Includes the following php7 packages:

    php7 php7-fpm php7-opcache
    php7-gd php7-mysqli php7-zlib php7-curl
    php7-xdebug

In order to be used for VSCode PHP Language Support and Debugger extensions, it should be built using `--tag=next` which will add the support for node:10.15 and the latest VSCode API support required to run the mentioned VSCode extensions.

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Adds a docker image that is to be used in Che7 for PHP Language Support and Debugger and includes all the pre-requisite packages required to run the PHP plugins.

### What issues does this PR fix or reference?

- PHP Language Support #12772 - https://github.com/eclipse/che/issues/12772
- Che 7 plugin: PHP Language Server #12797 - https://github.com/eclipse/che/issues/12797
- Che 7 plugin: PHP Debugger #12795 - https://github.com/eclipse/che/issues/12795

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
