### PR TITLE
Fix to run with Bash 4.3.

### DIFF
--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -24,7 +24,7 @@ skip_tests() {
 
 prepare_build_args() {
     IFS=',' read -r -a BUILD_ARGS_ARRAY <<< "$@"
-    for i in ${BUILD_ARGS_ARRAY[@]}; do
+    for i in ${BUILD_ARGS_ARRAY[@]+"${BUILD_ARGS_ARRAY[@]}"}; do
     BUILD_ARGS+="--build-arg $i "
     done
 }


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

Makes running `./build.sh` scripts with Bash version 4.3.x.
I checked the patch on both of  Ubuntu 16.04 (Bash 4.3) and Debian 9.8 (Bash  4.4.12).

### What issues does this PR fix or reference?

None.
(Reference: https://stackoverflow.com/a/34361807 )
