### PR TITLE
Fix the instruction for building images

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ First you need to build `che-theia-dev` image:
 
 Run in `dockerfiles/theia-dev` dir:
 ```bash
-    ./build.sh --build-arg:${GITHUB_TOKEN_ARG}
+    ./build.sh --build-arg:${GITHUB_TOKEN_ARG} --tag:next
 ```
 
 Then in `dockerfiles/theia` run:


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

Adds a command line option to the build instruction.
`theia-dev` and `theia` should have same tag.

### What issues does this PR fix or reference?

None.
