### PR TITLE
Fix permission issue with updating dependencies for C# projects

### DIFF
--- a/dockerfiles/remote-plugin-dotnet-2.2.105/Dockerfile
+++ b/dockerfiles/remote-plugin-dotnet-2.2.105/Dockerfile
@@ -79,7 +79,8 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && mkdir ${HOME}/.dotnet && chmod -R 777 ${HOME}/.dotnet \
     && mkdir /usr/share/dotnet/sdk/NuGetFallbackFolder && chmod 777 /usr/share/dotnet/sdk/NuGetFallbackFolder \
     && mkdir ${HOME}/.nuget && chmod -R 777 ${HOME}/.nuget \
-    && mkdir ${HOME}/.templateengine && chmod -R 777 ${HOME}/.templateengine
+    && mkdir ${HOME}/.templateengine && chmod -R 777 ${HOME}/.templateengine \
+    && chmod -R 777 ${HOME}
 
 # Configure web servers to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80 \


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

To update dependencies for C# projects we need to have access to write files into home directory

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13096
