### PR TITLE
Add ability to track che tasks

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -75,8 +75,9 @@ export interface CheVariablesMain {
 
 export interface CheTask {
     registerTaskRunner(type: string, runner: che.TaskRunner): Promise<che.Disposable>;
-    fireTaskExited(taskId: number): Promise<void>;
+    fireTaskExited(event: che.TaskExitedEvent): Promise<void>;
     $runTask(id: number, config: che.TaskConfiguration, ctx?: string): Promise<void>;
+    $onTaskExited(id: number): Promise<void>;
     $killTask(id: number): Promise<void>;
     $getTaskInfo(id: number): Promise<che.TaskInfo | undefined>;
 }
@@ -85,6 +86,7 @@ export const CheTaskMain = Symbol('CheTaskMain');
 export interface CheTaskMain {
     $registerTaskRunner(type: string): Promise<void>;
     $disposeTaskRunner(type: string): Promise<void>;
+    $fireTaskExited(event: che.TaskExitedEvent): Promise<void>;
 }
 
 export interface Variable {
@@ -400,6 +402,7 @@ export interface CheTaskService extends JsonRpcServer<CheTaskClient> {
     registerTaskRunner(type: string): Promise<void>;
     disposeTaskRunner(type: string): Promise<void>;
     disconnectClient(client: CheTaskClient): void;
+    fireTaskExited(event: che.TaskExitedEvent): Promise<void>;
 }
 
 export const CheTaskClient = Symbol('CheTaskClient');
@@ -407,7 +410,9 @@ export interface CheTaskClient {
     runTask(id: number, taskConfig: che.TaskConfiguration, ctx?: string): Promise<void>;
     killTask(id: number): Promise<void>;
     getTaskInfo(id: number): Promise<che.TaskInfo | undefined>;
-    setTaskInfoHandler(func: (id: number) => Promise<che.TaskInfo | undefined>): void;
-    setRunTaskHandler(func: (id: number, config: che.TaskConfiguration, ctx?: string) => Promise<void>): void;
+    onTaskExited(id: number): Promise<void>;
+    addTaskInfoHandler(func: (id: number) => Promise<che.TaskInfo | undefined>): void;
+    addRunTaskHandler(func: (id: number, config: che.TaskConfiguration, ctx?: string) => Promise<void>): void;
+    addTaskExitedHandler(func: (id: number) => Promise<void>): void;
     onKillEvent: Event<number>
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-task-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-task-service.ts
@@ -12,6 +12,7 @@ import { injectable, interfaces } from 'inversify';
 import { Task, TaskManager, TaskOptions, TaskRunnerRegistry } from '@theia/task/lib/node';
 import { Disposable, ILogger } from '@theia/core';
 import { TaskConfiguration, TaskInfo } from '@theia/task/lib/common/task-protocol';
+import { TaskExitedEvent } from '@eclipse-che/plugin';
 
 @injectable()
 export class CheTaskServiceImpl implements CheTaskService {
@@ -19,6 +20,7 @@ export class CheTaskServiceImpl implements CheTaskService {
     private readonly taskManager: TaskManager;
     private readonly logger: ILogger;
     private readonly disposableMap: Map<string, Disposable>;
+    private readonly cheTasks: CheTask[] = [];
     private readonly clients: CheTaskClient[];
     private taskId: number;
     constructor(container: interfaces.Container) {
@@ -42,7 +44,9 @@ export class CheTaskServiceImpl implements CheTaskService {
             for (const client of this.clients) {
                 await client.runTask(id, config, ctx);
             }
-            return new CheTask(id, this.taskManager, this.logger, { label: config.label, config, context: ctx }, this.clients);
+            const cheTask = new CheTask(id, this.taskManager, this.logger, { label: config.label, config, context: ctx }, this.clients);
+            this.cheTasks.push(cheTask);
+            return cheTask;
         };
     }
 
@@ -67,6 +71,28 @@ export class CheTaskServiceImpl implements CheTaskService {
             this.clients.splice(idx, 1);
         }
     }
+
+    async fireTaskExited(event: TaskExitedEvent): Promise<void> {
+        for (const task of this.cheTasks) {
+            try {
+                const runtimeInfo = await task.getRuntimeInfo();
+                if (runtimeInfo.execId === event.execId || runtimeInfo.taskId === event.taskId) {
+
+                    task.fireTaskExited({ taskId: task.id, code: event.code, ctx: runtimeInfo.ctx });
+
+                    task.onTaskExited();
+
+                    const index = this.cheTasks.indexOf(task);
+                    if (index > -1) {
+                        this.cheTasks.splice(index, 1);
+                    }
+                    break;
+                }
+            } catch (e) {
+                // allow another handlers to handle request
+            }
+        }
+    }
 }
 
 class CheTask extends Task {
@@ -85,18 +111,44 @@ class CheTask extends Task {
         for (const client of this.clients) {
             const taskInfo = await client.getTaskInfo(this.taskId);
             if (taskInfo) {
-                return {
-                    taskId: this.taskId,
-                    terminalId: taskInfo.terminalId,
-                    ctx: taskInfo.ctx,
-                    config: taskInfo.config
-                };
+                return this.toTaskInfo(taskInfo);
             }
         }
-        throw new Error('Information not found');
+        throw new Error(`Runtime Information for task ${this.options.label} is not found`);
+    }
+
+    async onTaskExited(): Promise<void> {
+        for (const client of this.clients) {
+            await client.onTaskExited(this.taskId);
+        }
     }
 
     async kill(): Promise<void> {
         this.clients.forEach(client => client.killTask(this.taskId));
+    }
+
+    fireTaskExited(event: TaskExitedEvent): void {
+        super.fireTaskExited({ taskId: event.taskId, code: event.code, ctx: event.ctx });
+    }
+
+    private toTaskInfo(runtimeInfo: TaskInfo): TaskInfo {
+        const { taskId, terminalId, ctx, config, ...properties } = runtimeInfo;
+        const result = {
+            taskId: this.taskId,
+            terminalId,
+            ctx,
+            config
+        };
+
+        if (!properties) {
+            return result;
+        }
+
+        for (const key in properties) {
+            if (properties.hasOwnProperty(key)) {
+                result[key] = properties[key];
+            }
+        }
+        return result;
     }
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
@@ -119,8 +119,8 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
             registerTaskRunner(type: string, runner: che.TaskRunner): Promise<che.Disposable> {
                 return cheTaskImpl.registerTaskRunner(type, runner);
             },
-            fireTaskExited(id: number): Promise<void> {
-                return cheTaskImpl.fireTaskExited(id);
+            fireTaskExited(event: che.TaskExitedEvent): Promise<void> {
+                return cheTaskImpl.fireTaskExited(event);
             }
         };
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-task-impl.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-task-impl.ts
@@ -8,9 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 import { CheTask, CheTaskMain, PLUGIN_RPC_CONTEXT } from '../common/che-protocol';
-import { TaskRunner, Disposable, Task, TaskInfo } from '@eclipse-che/plugin';
+import { TaskRunner, Disposable, Task, TaskInfo, TaskExitedEvent, TaskConfiguration } from '@eclipse-che/plugin';
 import { RPCProtocol } from '@theia/plugin-ext/lib/api/rpc-protocol';
-import { TaskConfiguration } from '@theia/task/lib/common';
 
 export class CheTaskImpl implements CheTask {
     private readonly cheTaskMain: CheTaskMain;
@@ -54,15 +53,14 @@ export class CheTaskImpl implements CheTask {
         }
     }
 
-    async fireTaskExited(taskId: number): Promise<void> {
-        let id: number | undefined;
-        this.taskMap.forEach((value: Task, key: number) => {
-            if (value.getRuntimeInfo().taskId === taskId) {
-                id = key;
-            }
-        });
-        if (id) {
+    async $onTaskExited(id: number): Promise<void> {
+        const task = this.taskMap.get(id);
+        if (task) {
             this.taskMap.delete(id);
         }
+    }
+
+    async fireTaskExited(event: TaskExitedEvent): Promise<void> {
+        this.cheTaskMain.$fireTaskExited(event);
     }
 }

--- a/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
+++ b/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
@@ -106,7 +106,7 @@ declare module '@eclipse-che/plugin' {
     export namespace task {
         export function registerTaskRunner(type: string, runner: TaskRunner): Promise<Disposable>;
         /** Needs to be executed when the task is finished */
-        export function fireTaskExited(id: number): Promise<void>;
+        export function fireTaskExited(event: TaskExitedEvent): Promise<void>;
     }
 
     /** A Task Runner knows how to run a Task of a particular type. */
@@ -132,6 +132,19 @@ declare module '@eclipse-che/plugin' {
         readonly ctx?: string,
         /** task config used for launching a task */
         readonly config: TaskConfiguration
+        // tslint:disable-next-line:no-any
+        readonly [key: string]: any;
+    }
+
+    export interface TaskExitedEvent {
+        readonly taskId?: number;
+        readonly ctx?: string;
+
+        readonly code?: number;
+        readonly signal?: string;
+
+        // tslint:disable-next-line:no-any
+        readonly [key: string]: any;
     }
 
     export interface TaskConfiguration {

--- a/plugins/task-plugin/src/che-task-backend-module.ts
+++ b/plugins/task-plugin/src/che-task-backend-module.ts
@@ -15,6 +15,7 @@ import { ProjectPathVariableResolver } from './variable/project-path-variable-re
 import { CheTaskRunner } from './task/che-task-runner';
 import { ServerVariableResolver } from './variable/server-variable-resolver';
 import { MachineExecClient } from './machine/machine-exec-client';
+import { MachineExecWatcher } from './machine/machine-exec-watcher';
 import { CheTerminalWidget, CheTerminalWidgetOptions, TerminalWidgetFactory } from './machine/terminal-widget';
 import { CheTaskEventsHandler } from './preview/task-events-handler';
 import { TasksPreviewManager } from './preview/tasks-preview-manager';
@@ -32,6 +33,7 @@ container.bind(CheTaskRunner).toSelf().inSingletonScope();
 container.bind(MachinesPicker).toSelf().inSingletonScope();
 container.bind(AttachTerminalClient).toSelf().inSingletonScope();
 container.bind(MachineExecClient).toSelf().inSingletonScope();
+container.bind(MachineExecWatcher).toSelf().inSingletonScope();
 container.bind(ServerVariableResolver).toSelf().inSingletonScope();
 container.bind(ProjectPathVariableResolver).toSelf().inSingletonScope();
 container.bind(CheWorkspaceClient).toSelf().inSingletonScope();

--- a/plugins/task-plugin/src/machine/machine-exec-watcher.ts
+++ b/plugins/task-plugin/src/machine/machine-exec-watcher.ts
@@ -1,0 +1,70 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import * as rpc from 'vscode-ws-jsonrpc';
+import { injectable } from 'inversify';
+import * as theia from '@theia/plugin';
+
+const EXIT_METHOD_NAME: string = 'onExecExit';
+const ERROR_METHOD_NAME: string = 'onExecError';
+
+const EXIT_CODE_PATTERN = /exit code (\d+)/;
+const SUCCESS_EXIT_CODE = 0;
+const GENERAL_ERROR_EXIT_CODE = 1;
+
+interface ExecExitEvent {
+    id: number;
+    code: number;
+}
+
+interface ExecErrorEvent {
+    id: number;
+    stack: string;
+}
+
+@injectable()
+export class MachineExecWatcher {
+    readonly exitEmitter: theia.EventEmitter<ExecExitEvent>;
+
+    constructor() {
+        this.exitEmitter = new theia.EventEmitter<ExecExitEvent>();
+    }
+
+    init(connection: rpc.MessageConnection) {
+
+        const exitNotification = new rpc.NotificationType<ExecExitEvent, void>(EXIT_METHOD_NAME);
+        connection.onNotification(exitNotification, (event: ExecExitEvent) => {
+            this.exitEmitter.fire({ id: event.id, code: SUCCESS_EXIT_CODE });
+        });
+
+        const errorNotification = new rpc.NotificationType<ExecErrorEvent, void>(ERROR_METHOD_NAME);
+        connection.onNotification(errorNotification, (event: ExecErrorEvent) => {
+            this.exitEmitter.fire({ id: event.id, code: this.toErrorCode(event) });
+        });
+    }
+
+    get onExit(): theia.Event<ExecExitEvent> {
+        return this.exitEmitter.event;
+    }
+
+    private toErrorCode(event: ExecErrorEvent): number {
+        const stack = event.stack;
+        if (!stack) {
+            return GENERAL_ERROR_EXIT_CODE;
+        }
+
+        const matches = stack.match(EXIT_CODE_PATTERN);
+        if (matches && matches[1]) {
+            return parseInt(matches[1]);
+        }
+
+        return GENERAL_ERROR_EXIT_CODE;
+    }
+}

--- a/plugins/task-plugin/src/machine/websocket.ts
+++ b/plugins/task-plugin/src/machine/websocket.ts
@@ -77,7 +77,8 @@ export class ReconnectingWebSocket {
     }
 
     public close() {
-        this.ws.close();
+        this.ws.removeAllListeners();
+        this.ws.close(1000);
     }
 
     private reconnect(reason: string) {

--- a/plugins/task-plugin/src/preview/task-events-handler.ts
+++ b/plugins/task-plugin/src/preview/task-events-handler.ts
@@ -46,8 +46,7 @@ export class CheTaskEventsHandler {
             if (task.definition.type !== CHE_TASK_TYPE) {
                 return;
             }
-            // TODO handle stopped tasks, at the moment we can not track che task end events
-            console.log('Task is stopped ' + event.execution.task.name);
+            this.onDidEndTask(task);
         }, undefined, startPoint.getSubscriptions());
     }
 
@@ -58,7 +57,7 @@ export class CheTaskEventsHandler {
             return;
         }
 
-        this.tasksPreviewManager.showPreviews();
+        this.tasksPreviewManager.onTaskStarted(task);
 
         const mode = this.taskPreviewMode.get();
         switch (mode) {
@@ -79,6 +78,16 @@ export class CheTaskEventsHandler {
                 break;
             }
         }
+    }
+
+    onDidEndTask(task: theia.Task): void {
+        const cheTaskDefinition = task.definition as CheTaskDefinition;
+        const previewUrl = cheTaskDefinition.previewUrl;
+        if (!previewUrl) {
+            return;
+        }
+
+        this.tasksPreviewManager.onTaskCompleted(task);
     }
 
     async askUser(message: string, url: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6846,9 +6846,9 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
-"moxios@git://github.com/stoplightio/moxios.git#v1.3.0":
+"moxios@git://github.com/stoplightio/moxios#v1.3.0":
   version "1.3.0"
-  resolved "git://github.com/stoplightio/moxios.git#9d702c8eafee4b02917d6bc400ae15f1e835cf51"
+  resolved "git://github.com/stoplightio/moxios#9d702c8eafee4b02917d6bc400ae15f1e835cf51"
   dependencies:
     class-autobind "^0.1.4"
 


### PR DESCRIPTION
### What does this PR do?
TaskExitedEvent is fired when a che task is completed, so all interested entities have ability to:
- notify user when a che task is completed
- update UI
- clean up resources 

Please see a short demo https://youtu.be/-qafPjoU2dM

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12838

