### PR TITLE
Disable replacing ffmpeg for electron

### DIFF
--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -35,7 +35,8 @@ ENV HOME=/home/theia-dev \
     # Specify the directory of git (avoid to search at init of Theia)
     USE_LOCAL_GIT=true \
     LOCAL_GIT_DIRECTORY=/usr \
-    GIT_EXEC_PATH=/usr/libexec/git-core
+    GIT_EXEC_PATH=/usr/libexec/git-core \
+    THEIA_ELECTRON_SKIP_REPLACE_FFMPEG=true
 
 # Define package of the theia generator to use
 ARG THEIA_GENERATOR_PACKAGE=@eclipse-che/theia-generator@0.0.1-1556612396
@@ -66,8 +67,8 @@ RUN npm config set prefix "${HOME}/.npm-global" && \
     echo '{"optOut": true}' > ${HOME}/.config/insight-nodejs/insight-yo.json && \
     # Change permissions to let any arbitrary user
     for f in "${HOME}" "/etc/passwd" "/etc/group" "/projects"; do \
-        echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
-        chmod -R g+rwX ${f}; \
+    echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
+    chmod -R g+rwX ${f}; \
     done
 
 WORKDIR "/projects"

--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -67,8 +67,8 @@ RUN npm config set prefix "${HOME}/.npm-global" && \
     echo '{"optOut": true}' > ${HOME}/.config/insight-nodejs/insight-yo.json && \
     # Change permissions to let any arbitrary user
     for f in "${HOME}" "/etc/passwd" "/etc/group" "/projects"; do \
-    echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
-    chmod -R g+rwX ${f}; \
+        echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
+        chmod -R g+rwX ${f}; \
     done
 
 WORKDIR "/projects"


### PR DESCRIPTION
To restore build on CI we need to disable replacing ffmpeg for electron

