### PR TITLE
Allow Kubernetes Tooling Che Plugin use Buildah as an image builder instead of Docker daemon

### DIFF
--- a/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/Dockerfile
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/Dockerfile
@@ -11,15 +11,15 @@
 FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:next as endpoint
 FROM quay.io/buildah/upstream:v1.8.2
 
+ENV KUBECTL_VERSION v1.14.1
+ENV HELM_VERSION v2.13.1
 ENV HOME=/home/theia
+
 COPY --from=endpoint /home/theia /home/theia
 COPY --from=endpoint /projects /projects
 COPY --from=endpoint /etc/passwd /etc/passwd
 COPY --from=endpoint /etc/group /etc/group
 COPY --from=endpoint /entrypoint.sh /entrypoint.sh
-
-ENV KUBECTL_VERSION v1.14.1
-ENV HELM_VERSION v2.13.1
 
 ADD etc/docker.sh /usr/local/bin/docker
 

--- a/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/Dockerfile
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/Dockerfile
@@ -23,13 +23,12 @@ ENV HELM_VERSION v2.13.1
 
 ADD etc/docker.sh /usr/local/bin/docker
 
-RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash - && \
-    # 'which' utility is used by VS Code Kubernetes extension to find the binaries, e.g. 'kubectl'
-    dnf install -y which nodejs && \
-    curl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
+RUN curl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl && \
     curl -o- -L https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar xvz -C /usr/local/bin --strip 1 && \
     # set up local Helm configuration skipping Tiller installation
-    helm init --client-only
+    helm init --client-only && \
+    # 'which' utility is used by VS Code Kubernetes extension to find the binaries, e.g. 'kubectl'
+    dnf install -y which nodejs
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/Dockerfile
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/Dockerfile
@@ -15,12 +15,6 @@ ENV KUBECTL_VERSION v1.14.1
 ENV HELM_VERSION v2.13.1
 ENV HOME=/home/theia
 
-COPY --from=endpoint /home/theia /home/theia
-COPY --from=endpoint /projects /projects
-COPY --from=endpoint /etc/passwd /etc/passwd
-COPY --from=endpoint /etc/group /etc/group
-COPY --from=endpoint /entrypoint.sh /entrypoint.sh
-
 ADD etc/docker.sh /usr/local/bin/docker
 
 RUN curl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
@@ -30,5 +24,11 @@ RUN curl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VER
     helm init --client-only && \
     # 'which' utility is used by VS Code Kubernetes extension to find the binaries, e.g. 'kubectl'
     dnf install -y which nodejs
+
+COPY --from=endpoint /home/theia /home/theia
+COPY --from=endpoint /projects /projects
+COPY --from=endpoint /etc/passwd /etc/passwd
+COPY --from=endpoint /etc/group /etc/group
+COPY --from=endpoint /entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/Dockerfile
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:next as endpoint
+FROM quay.io/buildah/upstream:v1.8.2
+
+ENV HOME=/home/theia
+COPY --from=endpoint /home/theia /home/theia
+COPY --from=endpoint /projects /projects
+COPY --from=endpoint /etc/passwd /etc/passwd
+COPY --from=endpoint /etc/group /etc/group
+COPY --from=endpoint /entrypoint.sh /entrypoint.sh
+
+ENV KUBECTL_VERSION v1.14.1
+ENV HELM_VERSION v2.13.1
+
+ADD etc/docker.sh /usr/local/bin/docker
+
+RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash - && \
+    # 'which' utility is used by VS Code Kubernetes extension to find the binaries, e.g. 'kubectl'
+    dnf install -y which nodejs && \
+    curl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    curl -o- -L https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar xvz -C /usr/local/bin --strip 1 && \
+    # set up local Helm configuration skipping Tiller installation
+    helm init --client-only
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/build.sh
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
+
+init --name:remote-plugin-kubernetes-tooling-1.0.0 "$@"
+build

--- a/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/etc/docker.sh
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/etc/docker.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+CMD=$1
+if [[ $1 = build ]]; then
+    CMD="bud"
+fi
+
+buildah $CMD $2 $3 $4 $5 $6 $7 $8 $9

--- a/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/etc/docker.sh
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/etc/docker.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
 
 set -e
 
@@ -6,5 +14,5 @@ CMD=$1
 if [[ $1 = build ]]; then
     CMD="bud"
 fi
-
-buildah $CMD $2 $3 $4 $5 $6 $7 $8 $9
+shift
+buildah $CMD $@


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

### What does this PR do?
Allows the [Kubernetes Tooling Che Plugin](https://github.com/eclipse/che-plugin-registry/tree/master/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools) use [Buildah](https://github.com/containers/buildah) as an image builder instead of Docker daemon.
Currently, it's implemented with the `docker.sh` wrapper script that calls `buildah`.
In the future, we can add support for Buildah by [VS Code Kubernetes extension](https://github.com/Azure/vscode-kubernetes-tools/) natively and the wrapper script is not needed.

### What issues does this PR fix or reference?
closes https://github.com/eclipse/che/issues/13316
