### PR TITLE
[Ports Plugin] excluding ports

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -94,7 +94,9 @@ ENV USE_LOCAL_GIT=true \
     THEIA_DEFAULT_PLUGINS=local-dir:///default-theia-plugins \
     # Specify the directory of git (avoid to search at init of Theia)
     LOCAL_GIT_DIRECTORY=/usr \
-    GIT_EXEC_PATH=/usr/libexec/git-core
+    GIT_EXEC_PATH=/usr/libexec/git-core \
+    # Ignore from port plugin the default hosted mode port
+    PORT_PLUGIN_EXCLUDE_3130=TRUE
 
 EXPOSE 3100 3130
 

--- a/plugins/ports-plugin/src/ports-plugin.ts
+++ b/plugins/ports-plugin/src/ports-plugin.ts
@@ -25,11 +25,14 @@ import { WorkspacePort } from './workspace-port';
 const LISTEN_ALL_IPV4 = '0.0.0.0';
 const LISTEN_ALL_IPV6 = '::';
 const SERVER_REDIRECT_PATTERN = 'theia-redirect-';
+const PORT_EXCLUDE_ENV_VAR_PREFIX: string = 'PORT_PLUGIN_EXCLUDE_';
 
 // variables
 let workspacePorts: WorkspacePort[];
 let redirectPorts: WorkspacePort[];
 let redirectListeners: Map<number, BusyPort>;
+const excludedPorts: number[] = [];
+let outputChannel: theia.OutputChannel;
 
 // map a listener and the workspace port used
 export interface BusyPort {
@@ -85,10 +88,17 @@ async function askRedirect(port: Port, redirectMessage: string, errorMessage: st
 // Callback when a new port is being opened in workspace
 async function onOpenPort(port: Port) {
 
+    // skip excluded
+    if (excludedPorts.includes(port.portNumber)) {
+        // this port is excluded so just print a notice but does not propose a redirect
+        outputChannel.appendLine(`Ignoring excluded port ${port.portNumber}`);
+        return;
+    }
+
     // handle ephemeral ports
     if (port.portNumber >= 32000) {
         // this port is ephemeral so just print a notice but does not propose a redirect
-        await theia.window.showInformationMessage(`Ephemeral port now listening on port ${port.portNumber} (port range >= 32000). No redirect proposed for ephemerals.`);
+        outputChannel.appendLine(`Ephemeral port now listening on port ${port.portNumber} (port range >= 32000). No redirect proposed for ephemerals.`);
         return;
     }
 
@@ -151,12 +161,23 @@ function onClosedPort(port: Port) {
 
 export async function start(context: theia.PluginContext): Promise<void> {
 
+    outputChannel = theia.window.createOutputChannel('Ports Plug-in');
+
     // first, grab ports of workspace
     const workspaceHandler = new WorkspaceHandler();
     workspacePorts = await workspaceHandler.getWorkspacePorts();
 
     redirectListeners = new Map<number, BusyPort>();
     redirectPorts = workspacePorts.filter(port => port.serverName.startsWith(SERVER_REDIRECT_PATTERN));
+
+    // initiate excluded ports
+    const excludedPortProperties: string[] = Object.keys(process.env).filter(key => key.startsWith(PORT_EXCLUDE_ENV_VAR_PREFIX));
+    excludedPortProperties.forEach(key => {
+        const value = process.env[key].toLocaleLowerCase() || '';
+        if (value !== 'no') {
+            excludedPorts.push(parseInt(key.substring(PORT_EXCLUDE_ENV_VAR_PREFIX.length)));
+        }
+    });
 
     const portChangesDetector = new PortChangesDetector();
     portChangesDetector.onDidOpenPort(onOpenPort);

--- a/plugins/ports-plugin/src/ports-plugin.ts
+++ b/plugins/ports-plugin/src/ports-plugin.ts
@@ -174,7 +174,7 @@ export async function start(context: theia.PluginContext): Promise<void> {
     const excludedPortProperties: string[] = Object.keys(process.env).filter(key => key.startsWith(PORT_EXCLUDE_ENV_VAR_PREFIX));
     excludedPortProperties.forEach(key => {
         const value = process.env[key].toLocaleLowerCase() || '';
-        if (value !== 'no') {
+        if (value !== 'no' && value !== 'false') {
             excludedPorts.push(parseInt(key.substring(PORT_EXCLUDE_ENV_VAR_PREFIX.length)));
         }
     });


### PR DESCRIPTION
### What does this PR do?

Allow to exclude some ports for Ports Plugin

It will exclude for now 3130 port used in hosted mode of Theia
It fixes https://github.com/eclipse/che/issues/13300

Also move trace about ephemeral port to Ports Plugin output channel
It fixes https://github.com/eclipse/che-theia/issues/190

Change-Id: I50e4891028a7bacf60d7376fe05a99a835e429e9
Signed-off-by: Florent Benoit <fbenoit@redhat.com>



