### PR TITLE
Cache Che commands

### DIFF
--- a/plugins/task-plugin/src/che-workspace-client.ts
+++ b/plugins/task-plugin/src/che-workspace-client.ts
@@ -16,6 +16,7 @@ const TERMINAL_SERVER_TYPE = 'terminal';
 
 @injectable()
 export class CheWorkspaceClient {
+    private cachedCommands: cheApi.workspace.Command[] = [];
 
     async getMachines(): Promise<{ [attrName: string]: cheApi.workspace.Machine }> {
         const workspace = await this.getCurrentWorkspace();
@@ -32,6 +33,10 @@ export class CheWorkspaceClient {
     }
 
     async getCommands(): Promise<cheApi.workspace.Command[]> {
+        if (this.cachedCommands.length > 0) {
+            return this.cachedCommands;
+        }
+
         const workspace: cheApi.workspace.Workspace = await this.getCurrentWorkspace();
 
         const runtime: cheApi.workspace.Runtime = workspace.runtime;
@@ -40,7 +45,11 @@ export class CheWorkspaceClient {
         }
 
         const commands = runtime.commands;
-        return commands ? commands : [];
+        if (commands) {
+            this.cachedCommands = commands;
+            return commands;
+        }
+        return [];
     }
 
     getCurrentWorkspace(): Promise<cheApi.workspace.Workspace> {


### PR DESCRIPTION
### What does this PR do?
Che commands are not modified in runtime at the moment, so I think we can cache them.

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
