### PR TITLE
Add docker file to prepare PHP dev image

### DIFF
--- a/dockerfiles/php-dev/Dockerfile
+++ b/dockerfiles/php-dev/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+FROM php:7.1-apache
+
+RUN apt-get -y update \
+    && apt-get install -y libicu-dev\
+    	tree \
+        vim \
+        wget \
+        git \
+        libzip-dev \
+        zlib1g-dev \
+        zip \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install intl \
+    && docker-php-ext-configure zip --with-libzip \
+    && docker-php-ext-install zip mysqli pdo pdo_mysql \
+    && chmod -R 777 /etc/apache2  /var/www /var/lib/apache2 /var/log \
+    && chown -R www-data:www-data /var/www \
+    \
+	#change Apache configuration
+	\
+	&& sed -i "s/80/8080/g" /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf \
+    && sed -i 's/\/var\/www\/html/\/projects/g'  /etc/apache2/sites-available/000-default.conf \
+    && sed -i 's/\/var\/www/\/projects/g'  /etc/apache2/apache2.conf \
+    && sed -i 's/None/All/g' /etc/apache2/sites-available/000-default.conf \
+    && echo "ServerName localhost" | tee -a /etc/apache2/apache2.conf
+
+#add composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+WORKDIR /projects
+
+CMD sleep infinity

--- a/dockerfiles/php-dev/build.sh
+++ b/dockerfiles/php-dev/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
+
+init --name:php-dev "$@"
+build


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

### What does this PR do?
Adds a docker file to prepare an image that is to be used in Che7 for PHP stack inside dev container. This image includes all the pre-requisite packages required to run the PHP applications.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13307

