### PR TITLE
[endpoint] Increase the number of retries to able to find like 100 ports for all endpoints on a pod

### DIFF
--- a/dockerfiles/theia-endpoint-runtime/src/node/plugin-remote-init.ts
+++ b/dockerfiles/theia-endpoint-runtime/src/node/plugin-remote-init.ts
@@ -40,7 +40,7 @@ export class PluginRemoteInit {
     /**
      * Max number of trying new port
      */
-    private static readonly MAX_RETRIES = 1;
+    private static readonly MAX_RETRIES = 100;
 
     /**
      *  number of retries for finding port


### PR DESCRIPTION
### What does this PR do?
For now it was allowing too many `random` ports while running on the same pod and sharing network and pid is implying we could have a lot of random ports.

Change-Id: Ia2de2a14dd81d4e15dd97826dc0ec4661a91eaf3
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
