### PR TITLE
Make sure clone path is always relative 

### DIFF
--- a/plugins/factory-plugin/src/file-uri.ts
+++ b/plugins/factory-plugin/src/file-uri.ts
@@ -32,10 +32,17 @@ export function convertToFileURI(file: string, rootFolder?: string): string {
 
 }
 
+/**
+ * Returns path of the given project according projects directory.
+ * Given project should be in subtree of root projects directory.
+ *
+ * @param fileURI root folder of the project
+ * @param rootFolder root folder for all projects in workspace
+ */
 export function convertToCheProjectPath(fileURI: string, rootFolder: string): string {
     if (!rootFolder) {
         // default value
         rootFolder = '/projects';
     }
-    return `/${path.relative(rootFolder, fileURI)}`;
+    return path.relative(rootFolder, fileURI);
 }

--- a/plugins/factory-plugin/src/projects.ts
+++ b/plugins/factory-plugin/src/projects.ts
@@ -9,10 +9,18 @@
  **********************************************************************/
 
 import { che as cheApi } from '@eclipse-che/api';
-import * as path from 'path';
 
 // devfile projects handling
 
+/**
+ * Updates configuration of existing project or create new if such project doesn't exist.
+ *
+ * @param projects list of all projects in workspace
+ * @param projectPath relative path of the added/updated project according to projects root directory (no slash at the beginning).
+ *                    If project root directory is located directly in projects root directory it is the same as project name.
+ * @param projectGitLocation link to git project, the same as used for git clone
+ * @param projectGitRemoteBranch git branch of the project
+ */
 export function updateOrCreateGitProjectInDevfile(
     projects: cheApi.workspace.devfile.Project[],
     projectPath: string,
@@ -24,9 +32,8 @@ export function updateOrCreateGitProjectInDevfile(
         projects = [];
     }
 
-    for (let i = 0; i < projects.length; i++) {
-        const project = projects[i];
-        const currentProjectPath = project.clonePath ? project.clonePath : path.sep + project.name;
+    for (const project of projects) {
+        const currentProjectPath = project.clonePath ? project.clonePath : project.name;
         if (currentProjectPath === projectPath) {
             project.source.type = 'git';
             project.source.location = projectGitLocation;
@@ -59,6 +66,13 @@ export function updateOrCreateGitProjectInDevfile(
     return projects;
 }
 
+/**
+ * Deletes configuration of existing project.
+ * Does nothing if project doesn't exist.
+ *
+ * @param projects list of projects in workspace
+ * @param projectPath relative path of the project to delete according to projets root directory
+ */
 export function deleteProjectFromDevfile(
     projects: cheApi.workspace.devfile.Project[],
     projectPath: string
@@ -70,7 +84,7 @@ export function deleteProjectFromDevfile(
 
     for (let i = 0; i < projects.length; i++) {
         const project = projects[i];
-        const currentProjectPath = project.clonePath ? project.clonePath : path.sep + project.name;
+        const currentProjectPath = project.clonePath ? project.clonePath : project.name;
         if (currentProjectPath === projectPath) {
             projects.splice(i, 1);
             break;

--- a/plugins/factory-plugin/src/workspace-projects-manager.ts
+++ b/plugins/factory-plugin/src/workspace-projects-manager.ts
@@ -145,8 +145,6 @@ export class DevfileProjectsManager extends WorkspaceProjectsManager {
             fileUri.convertToCheProjectPath(projectFolderURI, this.projectsRoot),
             projectUpstreamBranch.remoteURL,
             projectUpstreamBranch.branch);
-
-        if (workspace.devfile) { delete workspace.config; } // TODO delete this temporary workaround
     }
 
     deleteProject(workspace: cheApi.workspace.Workspace, projectFolderURI: string): void {
@@ -154,8 +152,6 @@ export class DevfileProjectsManager extends WorkspaceProjectsManager {
             workspace.devfile.projects,
             fileUri.convertToCheProjectPath(projectFolderURI, this.projectsRoot)
         );
-
-        if (workspace.devfile) { delete workspace.config; } // TODO delete this temporary workaround
     }
 
 }
@@ -195,7 +191,7 @@ export class WorkspaceConfigProjectsManager extends WorkspaceProjectsManager {
 
         projectsHelper.updateOrCreateGitProjectInWorkspaceConfig(
             workspace.config.projects,
-            fileUri.convertToCheProjectPath(projectFolderURI, this.projectsRoot),
+            '/' + fileUri.convertToCheProjectPath(projectFolderURI, this.projectsRoot),
             projectUpstreamBranch.remoteURL,
             projectUpstreamBranch.branch);
     }
@@ -212,7 +208,7 @@ export class WorkspaceConfigProjectsManager extends WorkspaceProjectsManager {
 
         projectsHelper.deleteProjectFromWorkspaceConfig(
             workspace.config.projects,
-            fileUri.convertToCheProjectPath(projectFolderURI, this.projectsRoot)
+            '/' + fileUri.convertToCheProjectPath(projectFolderURI, this.projectsRoot)
         );
     }
 

--- a/plugins/factory-plugin/tests/file-uri.spec.ts
+++ b/plugins/factory-plugin/tests/file-uri.spec.ts
@@ -7,12 +7,12 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-import { TheiaCommand } from "../src/theia-commands";
-import { convertToFileURI, convertToCheProjectPath } from "../src/file-uri"
+import { TheiaCommand } from '../src/theia-commands';
+import { convertToFileURI, convertToCheProjectPath } from '../src/file-uri'
 
-describe("Test exec commands", () => {
+describe('Test exec commands', () => {
 
-    test("Convert a openfile file property to file URI", async () => {
+    test('Convert a openfile file property to file URI', async () => {
         expect(convertToFileURI('/che/README.md')).toBe('file:///projects/che/README.md');
         expect(convertToFileURI('che/README.md')).toBe('file:///projects/che/README.md');
         expect(convertToFileURI('file:///test-project/che/README.md')).toBe('file:///test-project/che/README.md');
@@ -26,12 +26,12 @@ describe("Test exec commands", () => {
     });
 });
 
-describe("Testing convertion of project paths to be stored in the workspace config", () => {
-    test("Converting fs project path to che project path", async () => {
-        expect(convertToCheProjectPath('/projects/che-factory-extension/', '/projects')).toBe('/che-factory-extension');
-        expect(convertToCheProjectPath('/projects/che-factory-extension', '/projects')).toBe('/che-factory-extension');
-        expect(convertToCheProjectPath('/projects/che/che-factory-extension/', '/projects')).toBe('/che/che-factory-extension');
-        expect(convertToCheProjectPath('/projects/theiadev_projects/blog.sunix.org/', '/projects/theiadev_projects')).toBe('/blog.sunix.org');
-        expect(convertToCheProjectPath('/projects/che/che-factory-extension/', undefined)).toBe('/che/che-factory-extension');
+describe('Testing convertion of project paths to be stored in the workspace config', () => {
+    test('Converting fs project path to che project path', async () => {
+        expect(convertToCheProjectPath('/projects/che-factory-extension/', '/projects')).toBe('che-factory-extension');
+        expect(convertToCheProjectPath('/projects/che-factory-extension', '/projects')).toBe('che-factory-extension');
+        expect(convertToCheProjectPath('/projects/che/che-factory-extension/', '/projects')).toBe('che/che-factory-extension');
+        expect(convertToCheProjectPath('/projects/theiadev_projects/blog.sunix.org/', '/projects/theiadev_projects')).toBe('blog.sunix.org');
+        expect(convertToCheProjectPath('/projects/che/che-factory-extension/', undefined)).toBe('che/che-factory-extension');
     });
 });

--- a/plugins/factory-plugin/tests/projects.spec.ts
+++ b/plugins/factory-plugin/tests/projects.spec.ts
@@ -16,14 +16,14 @@ describe('Devfile: Projects:', () => {
     const CHE_THEIA_REPOSITORY = 'https://github.com/eclipse/che-theia.git';
     const BRANCH1 = 'che-13112';
     const BRANCH2 = 'issue-12321';
-    const CUSTOM_PROJECT_PATH = '/theia/packages/che-theia';
+    const CUSTOM_PROJECT_PATH = 'theia/packages/che-theia';
 
     test('Should be able to create project if no projects defined', () => {
         const projects: cheApi.workspace.devfile.Project[] = [];
 
         projecthelper.updateOrCreateGitProjectInDevfile(
             projects,
-            '/che',
+            'che',
             CHE_REPOSITORY,
             BRANCH1
         );
@@ -48,7 +48,7 @@ describe('Devfile: Projects:', () => {
 
         projecthelper.updateOrCreateGitProjectInDevfile(
             projects,
-            '/che-theia',
+            'che-theia',
             CHE_THEIA_REPOSITORY,
             BRANCH2
         );
@@ -86,7 +86,7 @@ describe('Devfile: Projects:', () => {
 
         projecthelper.deleteProjectFromDevfile(
             projects,
-            '/che-theia'
+            'che-theia'
         );
 
         expect(projects.length).toBe(1);


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Make sure clone path is always relative and does not starts from slash as Che 6 project path.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13112