### PR TITLE
Replace '*/src/*' to '*/lib/*' in imports

### DIFF
--- a/dockerfiles/theia-endpoint-runtime/src/node/server-plugin-proxy-runner.ts
+++ b/dockerfiles/theia-endpoint-runtime/src/node/server-plugin-proxy-runner.ts
@@ -9,7 +9,7 @@
  **********************************************************************/
 
 import { injectable, inject } from 'inversify';
-import { HostedPluginClient, ServerPluginRunner, PluginMetadata } from '@theia/plugin-ext/src/common/plugin-protocol';
+import { HostedPluginClient, ServerPluginRunner, PluginMetadata } from '@theia/plugin-ext/lib/common/plugin-protocol';
 import { HostedPluginRemote } from './hosted-plugin-remote';
 
 /**

--- a/dockerfiles/theia-endpoint-runtime/src/node/terminal-container-aware.ts
+++ b/dockerfiles/theia-endpoint-runtime/src/node/terminal-container-aware.ts
@@ -9,7 +9,7 @@
  **********************************************************************/
 
 import * as theia from '@theia/plugin';
-import { TerminalServiceExtImpl } from '@theia/plugin-ext/src/plugin/terminal-ext';
+import { TerminalServiceExtImpl } from '@theia/plugin-ext/lib/plugin/terminal-ext';
 import { DebugExtImpl } from '@theia/plugin-ext/lib/plugin/node/debug/debug';
 
 /**


### PR DESCRIPTION
### What does this PR do?
Replace '*/src/*' to '*/lib/*' in imports, to restore CI.
