### PR TITLE
Use theia-endpoint-runtime image tag from BUILD_TAG parameter

### DIFF
--- a/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/Dockerfile
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/Dockerfile
@@ -8,7 +8,7 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
-FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:next as endpoint
+FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:${BUILD_TAG} as endpoint
 FROM quay.io/buildah/upstream:v1.8.2
 
 ENV KUBECTL_VERSION v1.14.1


### PR DESCRIPTION
Use `che-theia-endpoint-runtime` image tag passed as an argument instead of always `next`.
Seems I've overlooked it in my previous PR.