### PR TITLE
[docker image] Add ssh utility as before to allow ssh usage of git

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -110,7 +110,9 @@ COPY --from=builder /home/theia-dev/theia-source-code/production/plugins /defaul
 # Install bzip2 to unpack files
 # Install which tool in order to search git
 # Install curl and bash
-RUN apk add --update --no-cache sudo git bzip2 which bash curl
+# Install ssh for cloning ssh-repositories
+# Install less for handling git diff properly
+RUN apk add --update --no-cache sudo git bzip2 which bash curl openssh openssh-keygen less
 RUN adduser -D -S -u 1001 -G root -h ${HOME} -s /bin/sh theia \
     && echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
     # Create /projects for Che


### PR DESCRIPTION
### What does this PR do?
Add ssh utility as before (when image was inside che repo) to allow ssh usage of git
Also as before, add less utility to better git diff output


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12850

Change-Id: I1d1b7b83f02f5ebfc9957f3d5106c1ce13a080a6
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
