### PR TITLE
Revert "Run Che command in selected container if container doesn't specified in configuration"

### DIFF
--- a/plugins/containers-plugin/src/containers-tree-data-provider.ts
+++ b/plugins/containers-plugin/src/containers-tree-data-provider.ts
@@ -11,8 +11,6 @@
 import * as theia from '@theia/plugin';
 import { IContainer } from './containers-service';
 
-const CHE_TASK_TYPE = 'che';
-
 interface ITreeNodeItem {
     id: string;
     name: string;
@@ -21,7 +19,7 @@ interface ITreeNodeItem {
     parentId?: string;
     command?: {
         id: string;
-        arguments?: (string | Object)[]
+        arguments?: string[]
     },
     isExpanded?: boolean;
 }
@@ -108,7 +106,7 @@ export class ContainersTreeDataProvider implements theia.TreeDataProvider<ITreeN
                         name: commandName,
                         tooltip: 'execute the command',
                         iconPath: 'fa-cogs medium-yellow',
-                        command: { id: 'task:custom-run', arguments: [CHE_TASK_TYPE, commandName, this.overrideContainerName(container.name)] }
+                        command: { id: 'task:run', arguments: ['che', commandName] }
                     });
                 });
             }
@@ -226,23 +224,6 @@ export class ContainersTreeDataProvider implements theia.TreeDataProvider<ITreeN
         }
         this.ids.push(uniqueId);
         return uniqueId;
-    }
-
-    /**
-     * Builds object which has one time amend of machineName field for already defined task.
-     * Is used for tasks which should be executed inside specific container this time,
-     * but they do not have a container specified in persistent configuration.
-     * Return value is a subset of CheTaskDefinition.
-     *
-     * @param containerName name of the container in which the task should be executed
-     */
-    private overrideContainerName(containerName: string): object {
-        return {
-            type: CHE_TASK_TYPE,
-            target: {
-                machineName: containerName
-            }
-        };
     }
 
     dispose(): void {


### PR DESCRIPTION
Reverts eclipse/che-theia#253 because it depends on [this PR](https://github.com/theia-ide/theia/pull/5312) and do not work without that changes.

@monaka if you are not sure what and how a PR does, do not merge it please. If you are affected somehow, please ask about PR state.