### PR TITLE
New 'build.sh' script, to build all repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,25 @@
 - [extensions](./extensions) contains Theia Extensions
 - [plugins](./plugins) contains Theia Plugins
 
+## How to build
+
+Run `yarn` to build Theia extensions and plugins.
+
+> Note: this build Theia extensions and plugins __ONLY__
+
+If you want to build all images also run `build.sh` script.
+
+CI for PR job in this repository will use `build.sh --pr`.
+> Note: `--pr` will build only limited set of docker images, see [PR_IMAGES variable](./docker_image_build.include)
+
+If you want to publish docker images use `build.sh --push`
+
 ## How to build own che-theia image
 
 First you need to build `che-theia-dev` image:
 
 Run in `dockerfiles/theia-dev` dir:
+
 ```bash
     ./build.sh --build-arg:${GITHUB_TOKEN_ARG} --tag:next
 ```

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# See: https://sipb.mit.edu/doc/safe-shell/
+. ./docker_image_build.include
+set -e
+set -o pipefail
+
+yarn
+
+if [ "${1:-}" = "--pr" ]; then
+    echo "Building PR images..."
+    buildImages "${PR_IMAGES[@]}"
+else
+    echo "Building ALL images..."
+    buildImages "${DOCKER_FILES_LOCATIONS[@]}"
+fi
+
+if [ "${1:-}" = "--push" ]; then 
+    echo "Pushing ALL images..."
+    publishImages "${IMAGES_LIST[@]}"
+fi

--- a/build_and_push_docker_images.sh
+++ b/build_and_push_docker_images.sh
@@ -12,37 +12,7 @@
 set -e
 set -o pipefail
 
-# KEEP RIGHT ORDER!!!
-DOCKER_FILES_LOCATIONS=(
-dockerfiles/theia-dev
-dockerfiles/theia
-dockerfiles/theia-endpoint-runtime
-dockerfiles/remote-plugin-java8
-dockerfiles/remote-plugin-java11
-dockerfiles/remote-plugin-go-1.10.7
-dockerfiles/remote-plugin-python-3.7.3
-dockerfiles/remote-plugin-dotnet-2.2.105
-dockerfiles/remote-plugin-kubernetes-tooling-0.1.17
-dockerfiles/remote-plugin-kubernetes-tooling-1.0.0
-dockerfiles/remote-plugin-openshift-connector-0.0.17
-dockerfiles/remote-plugin-openshift-connector-0.0.21
-)
-
-IMAGES_LIST=(
-eclipse/che-theia-dev
-eclipse/che-theia
-eclipse/che-theia-endpoint-runtime
-eclipse/che-remote-plugin-runner-java8
-eclipse/che-remote-plugin-runner-java11
-eclipse/che-remote-plugin-go-1.10.7
-eclipse/che-remote-plugin-python-3.7.3
-eclipse/che-remote-plugin-dotnet-2.2.105
-eclipse/che-remote-plugin-kubernetes-tooling-0.1.17
-eclipse/che-remote-plugin-kubernetes-tooling-1.0.0
-eclipse/che-remote-plugin-openshift-connector-0.0.17
-eclipse/che-remote-plugin-openshift-connector-0.0.21
-)
-
+printf "\033[0;31mThis script is deprecated, use build.sh instead\033[0m\n"
 
 # BUILD IMAGES
 for image_dir in "${DOCKER_FILES_LOCATIONS[@]}"

--- a/docker_image_build.include
+++ b/docker_image_build.include
@@ -15,3 +15,76 @@ THEIA_VERSION="master"
 THEIA_BRANCH="master"
 THEIA_GIT_REFS="refs\\/heads\\/master"
 THEIA_DOCKER_IMAGE_VERSION=
+
+# KEEP RIGHT ORDER!!!
+PR_IMAGES=(
+dockerfiles/theia-dev
+dockerfiles/theia
+dockerfiles/theia-endpoint-runtime
+)
+
+# KEEP RIGHT ORDER!!!
+DOCKER_FILES_LOCATIONS=(
+dockerfiles/theia-dev
+dockerfiles/theia
+dockerfiles/theia-endpoint-runtime
+dockerfiles/remote-plugin-java8
+dockerfiles/remote-plugin-java11
+dockerfiles/remote-plugin-go-1.10.7
+dockerfiles/remote-plugin-python-3.7.3
+dockerfiles/remote-plugin-dotnet-2.2.105
+dockerfiles/remote-plugin-kubernetes-tooling-0.1.17
+dockerfiles/remote-plugin-kubernetes-tooling-1.0.0
+dockerfiles/remote-plugin-openshift-connector-0.0.17
+dockerfiles/remote-plugin-openshift-connector-0.0.21
+)
+
+IMAGES_LIST=(
+eclipse/che-theia-dev
+eclipse/che-theia
+eclipse/che-theia-endpoint-runtime
+eclipse/che-remote-plugin-runner-java8
+eclipse/che-remote-plugin-runner-java11
+eclipse/che-remote-plugin-go-1.10.7
+eclipse/che-remote-plugin-python-3.7.3
+eclipse/che-remote-plugin-dotnet-2.2.105
+eclipse/che-remote-plugin-kubernetes-tooling-0.1.17
+eclipse/che-remote-plugin-kubernetes-tooling-1.0.0
+eclipse/che-remote-plugin-openshift-connector-0.0.17
+eclipse/che-remote-plugin-openshift-connector-0.0.21
+)
+
+buildImages() {
+    IMG_LIST=("$@")
+    for image_dir in "${IMG_LIST[@]}"
+        do
+            GITHUB_TOKEN_ARG="GITHUB_TOKEN="${GITHUB_TOKEN}
+            if [ "$image_dir" == "dockerfiles/theia" ]; then
+                bash $(pwd)/$image_dir/build.sh --build-args:${GITHUB_TOKEN_ARG},THEIA_VERSION=${THEIA_VERSION} --tag:${IMAGE_TAG} --branch:${THEIA_BRANCH} --git-ref:${THEIA_GIT_REFS} 
+            elif [ "$image_dir" == "dockerfiles/theia-dev" ]; then
+                bash $(pwd)/$image_dir/build.sh --build-arg:${GITHUB_TOKEN_ARG} --tag:${IMAGE_TAG}
+            else
+                bash $(pwd)/$image_dir/build.sh --build-arg:${GITHUB_TOKEN_ARG} --tag:${IMAGE_TAG}
+            fi
+            if [ $? -ne 0 ]; then
+                echo "ERROR:"
+                echo "build of '$image_dir' image is failed!"
+                exit 1
+            fi
+        done
+}
+
+publishImages() {
+    IMG_LIST=("$@")
+    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    for image in "${IMG_LIST[@]}"
+        do
+            if [ ! -z ${THEIA_DOCKER_IMAGE_VERSION} ]; then
+                docker tag ${image}:${IMAGE_TAG} ${image}:${THEIA_DOCKER_IMAGE_VERSION}
+                echo y | docker push ${image}:${IMAGE_TAG}
+                echo y | docker push ${image}:${THEIA_DOCKER_IMAGE_VERSION}
+            else
+                echo y | docker push ${image}:${IMAGE_TAG}
+            fi
+        done
+}


### PR DESCRIPTION
`build.sh` will execute `yarn` and build all docker images.
Also PR include list of docker images which are builded during CI PR check.
> Note: Currently it is only 3 images: `theia-dev`, `theia` and `theia-endpoint-runtime`

Signed-off-by: Yevhen Vydolob <yvydolob@redhat.com>
