### PR TITLE
Add ssh-plugin to che-theia by default

### DIFF
--- a/che-theia-init-sources.yml
+++ b/che-theia-init-sources.yml
@@ -17,4 +17,5 @@ sources:
     - plugins/ports-plugin
     - plugins/task-plugin
     - plugins/welcome-plugin
+    - plugins/ssh-plugin
   checkoutTo: master


### PR DESCRIPTION
Signed-off-by: Yevhen Vydolob <yvydolob@redhat.com>
### What does this PR do?
Add ssh-plugin to che-theia by default

### What issues does this PR fix or reference?
As part of https://github.com/eclipse/che/issues/13494