### PR TITLE
Display list of built-in plugins

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-frontend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-frontend-module.ts
@@ -62,7 +62,8 @@ export default new ContainerModule(bind => {
     bindViewContribution(bind, ChePluginViewContribution);
 
     bind(ChePluginMenu).toSelf().inSingletonScope();
-    bind(ChePluginWidget).toSelf().inSingletonScope();
+
+    bind(ChePluginWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(ctx => ({
         id: ChePluginViewContribution.PLUGINS_WIDGET_ID,
         createWidget: () => ctx.container.get(ChePluginWidget)

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
@@ -83,6 +83,7 @@ export class ChePluginCommandContribution implements CommandContribution {
     // Displays a list of built in plugins provided inside Theia editor container.
     // Will be implemented soon.
     async showBuiltInPlugins() {
+        this.chePluginManager.changeFilter('@builtin', true);
     }
 
     /**

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-frontend-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-frontend-service.ts
@@ -49,6 +49,8 @@ export class ChePluginFrontentService {
 
             const description = meta.source.description;
 
+            // Temporary disabled.
+            // We don't have an ability for now to display icons from the file system.
             // tslint:disable-next-line:no-any
             // const icon = (meta.source as any).icon;
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-frontend-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-frontend-service.ts
@@ -25,14 +25,11 @@ export class ChePluginFrontentService {
     @inject(HostedPluginServer)
     protected readonly hostedPluginServer: HostedPluginServer;
 
-    async getDeployedPlugins(filter: string): Promise<ChePluginMetadata[]> {
-        if (PluginFilter.hasType(filter, '@installed')) {
-            let pluginList = await this.getAllDeployedPlugins();
-            pluginList = PluginFilter.filterPlugins(pluginList, filter);
-            return pluginList;
-        }
-
-        return [];
+    // returns a list of built-in plugins when filter contains '@builtin'
+    async getBuiltInPlugins(filter: string): Promise<ChePluginMetadata[]> {
+        let pluginList = await this.getAllDeployedPlugins();
+        pluginList = PluginFilter.filterPlugins(pluginList, filter);
+        return pluginList;
     }
 
     /**
@@ -53,7 +50,7 @@ export class ChePluginFrontentService {
             const description = meta.source.description;
 
             // tslint:disable-next-line:no-any
-            const icon = (meta.source as any).icon;
+            // const icon = (meta.source as any).icon;
 
             return {
                 publisher,
@@ -63,7 +60,7 @@ export class ChePluginFrontentService {
                 displayName,
                 title,
                 description,
-                icon,
+                icon: '',
                 url: '',
                 repository: '',
                 firstPublicationDate: '',
@@ -71,7 +68,8 @@ export class ChePluginFrontentService {
                 latestUpdateDate: '',
 
                 // Plugin KEY. Used to set in workspace configuration
-                key: `${publisher}/${name}/${version}`
+                key: `${publisher}/${name}/${version}`,
+                builtIn: true
             };
         });
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
@@ -30,6 +30,7 @@ import { ConfirmDialog } from '@theia/core/lib/browser';
 import { ChePluginPreferences } from './che-plugin-preferences';
 import { ChePluginFrontentService } from './che-plugin-frontend-service';
 import { PreferenceService, PreferenceScope } from '@theia/core/lib/browser/preferences';
+import { PluginFilter } from '../../common/plugin/plugin-filter';
 
 @injectable()
 export class ChePluginManager {
@@ -55,11 +56,6 @@ export class ChePluginManager {
      * Initialized by plugins received from workspace config.
      */
     private installedPlugins: string[];
-
-    /**
-     * List of plugins, currently available on active plugin registry.
-     */
-    private availablePlugins: ChePluginMetadata[] = [];
 
     @inject(ChePluginService)
     protected readonly chePluginService: ChePluginService;
@@ -180,11 +176,11 @@ export class ChePluginManager {
     async getPlugins(filter: string): Promise<ChePluginMetadata[]> {
         await this.initDefaults();
 
-        this.availablePlugins = await this.chePluginService.getPlugins(this.activeRegistry, filter);
-        // The code will be use soon
-        // const deployedPlugins = await this.pluginFrontentService.getDeployedPlugins(filter);
-        // this.availablePlugins = this.availablePlugins.concat(deployedPlugins);
-        return this.availablePlugins;
+        if (PluginFilter.hasType(filter, '@builtin')) {
+            return await this.pluginFrontentService.getBuiltInPlugins(filter);
+        }
+
+        return await this.chePluginService.getPlugins(this.activeRegistry, filter);
     }
 
     isPluginInstalled(plugin: ChePluginMetadata): boolean {
@@ -236,7 +232,7 @@ export class ChePluginManager {
             return input.substring('vscode:extension/'.length);
         }
 
-        return undefined;
+        return '';
     }
 
     /**

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-menu.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-menu.ts
@@ -59,19 +59,16 @@ export class ChePluginMenu {
 
         commands.addCommand(ChePluginManagerCommands.SHOW_AVAILABLE_PLUGINS.id, {
             label: ChePluginManagerCommands.SHOW_AVAILABLE_PLUGINS.label,
-            isEnabled: () => true,
             execute: () => this.chePluginCommandContribution.showAvailablePlugins()
         });
 
         commands.addCommand(ChePluginManagerCommands.SHOW_INSTALLED_PLUGINS.id, {
             label: ChePluginManagerCommands.SHOW_INSTALLED_PLUGINS.label,
-            isEnabled: () => true,
             execute: () => this.chePluginCommandContribution.showInstalledPlugins()
         });
 
         commands.addCommand(ChePluginManagerCommands.SHOW_BUILT_IN_PLUGINS.id, {
             label: ChePluginManagerCommands.SHOW_BUILT_IN_PLUGINS.label,
-            isEnabled: () => false,
             execute: () => this.chePluginCommandContribution.showBuiltInPlugins()
         });
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-widget.tsx
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-widget.tsx
@@ -388,9 +388,7 @@ export class ChePlugin extends React.Component<ChePlugin.Props, ChePlugin.State>
         // I'm not sure whether 'key' attribute is necessary here
         return <div key={plugin.key} className='che-plugin'>
             <div className='che-plugin-content'>
-                <div className='che-plugin-icon'>
-                    <img src={plugin.icon}></img>
-                </div>
+                {this.renderIcon()}
                 <div className='che-plugin-info'>
                     <div className='che-plugin-title'>
                         <div className='che-plugin-name'>{plugin.name}</div>
@@ -405,15 +403,30 @@ export class ChePlugin extends React.Component<ChePlugin.Props, ChePlugin.State>
                         {plugin.publisher}
                         <span className='che-plugin-type'>{plugin.type}</span>
                     </div>
-                    {this.renderPluginAction(plugin)}
+                    {this.renderAction()}
                 </div>
             </div>
         </div>;
     }
 
-    protected renderPluginAction(plugin: ChePluginMetadata): React.ReactNode {
-        // Don't show the button for 'Che Editor' plugins
-        if ('Che Editor' === plugin.type) {
+    protected renderIcon(): React.ReactNode {
+        if (this.props.plugin.icon) {
+            // return the icon
+            return <div className='che-plugin-icon'>
+                    <img src={this.props.plugin.icon}></img>
+                </div>;
+        }
+
+        // return default icon
+        return <div className='che-plugin-default-icon'>
+                <div className='fa fa-puzzle-piece fa-2x fa-fw'></div>
+            </div>;
+    }
+
+    protected renderAction(): React.ReactNode {
+        // Don't show the button for 'Che Editor' plugins and for built-in plugins
+        if ('Che Editor' === this.props.plugin.type ||
+            this.props.plugin.builtIn) {
             return undefined;
         }
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-widget.tsx
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-widget.tsx
@@ -164,12 +164,16 @@ export class ChePluginWidget extends ReactWidget {
     }
 
     protected async installExtension(extension: string): Promise<boolean> {
+        this.currentFilter = '';
+
         this.status = 'loading';
         this.update();
 
         const installed = await this.chePluginManager.installVSCodeExtension(extension);
         this.needToRestartWorkspace = true;
-        await this.clearFilter();
+
+        await this.updatePlugins();
+
         return installed;
     }
 
@@ -413,14 +417,14 @@ export class ChePlugin extends React.Component<ChePlugin.Props, ChePlugin.State>
         if (this.props.plugin.icon) {
             // return the icon
             return <div className='che-plugin-icon'>
-                    <img src={this.props.plugin.icon}></img>
-                </div>;
+                <img src={this.props.plugin.icon}></img>
+            </div>;
         }
 
         // return default icon
         return <div className='che-plugin-default-icon'>
-                <div className='fa fa-puzzle-piece fa-2x fa-fw'></div>
-            </div>;
+            <div className='fa fa-puzzle-piece fa-2x fa-fw'></div>
+        </div>;
     }
 
     protected renderAction(): React.ReactNode {

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-widget.tsx
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-widget.tsx
@@ -167,9 +167,10 @@ export class ChePluginWidget extends ReactWidget {
         this.status = 'loading';
         this.update();
 
-        await this.chePluginManager.installVSCodeExtension(extension);
+        const installed = await this.chePluginManager.installVSCodeExtension(extension);
+        this.needToRestartWorkspace = true;
         await this.clearFilter();
-        return true;
+        return installed;
     }
 
     protected render(): React.ReactNode {

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/style/che-plugins.css
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/style/che-plugins.css
@@ -198,7 +198,8 @@
     background: var(--theia-layout-color2);
 }
 
-.che-plugin-list .che-plugin-icon {
+.che-plugin-list .che-plugin-icon,
+.che-plugin-list .che-plugin-default-icon {
     position: absolute;
     display: block;
     overflow: hidden;
@@ -211,6 +212,14 @@
 .che-plugin-list .che-plugin-icon > img {
     width: 64px;
     height: 64px;
+}
+
+.che-plugin-list .che-plugin-default-icon > div {
+    font-size: 55px;
+    line-height: 64px;
+    width: 64px;
+    height: 64px;
+    color: gray;
 }
 
 .che-plugin-list .che-plugin-info {

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -447,7 +447,8 @@ export interface ChePluginMetadata {
     latestUpdateDate: string,
 
     // Plugin KEY. Used to set in workpsace configuration
-    key: string
+    key: string,
+    builtIn: boolean
 }
 
 export const CHE_PLUGIN_SERVICE_PATH = '/che-plugin-service';

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -290,7 +290,8 @@ export class ChePluginServiceImpl implements ChePluginService {
                 firstPublicationDate: props.firstPublicationDate,
                 category: props.category,
                 latestUpdateDate: props.latestUpdateDate,
-                key: key
+                key: key,
+                builtIn: false
             };
 
         } catch (error) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Makes it possible to view the list of built-in plugins

### What issues does this PR fix or reference?
https://github.com/eclipse/che-theia/issues/244

![Screenshot from 2019-06-12 16-00-38](https://user-images.githubusercontent.com/1655894/59353280-47d8a000-8d2b-11e9-872c-5c77dc77b5e0.png)

Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>
