### PR TITLE
Fix the default docker tag `nightly` to `next`.

### DIFF
--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -41,7 +41,7 @@ init() {
 
   ORGANIZATION="eclipse"
   PREFIX="che"
-  TAG="nightly"
+  TAG="next"
   SKIP_TESTS=false
   NAME="che"
   ARGS=""


### PR DESCRIPTION

### What does this PR do?

Fixes the default docker tag `nightly` to `next`. `nightly` has not been used.

### What issues does this PR fix or reference?

fixes #226
