### PR TITLE
Run `node-gyp install` before run `node-gyp rebuild`.

### DIFF
--- a/dockerfiles/remote-plugin-dotnet-2.2.105/Dockerfile
+++ b/dockerfiles/remote-plugin-dotnet-2.2.105/Dockerfile
@@ -54,7 +54,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
     # Install typescript@2.9.2 and node-gyp
 
-    &&  yarn global add typescript@2.9.2 node-gyp
+    &&  yarn global add typescript@2.9.2 node-gyp \
+    &&  node-gyp install
 
 ENV HOME=/home/theia
 COPY --from=endpoint /home/theia /home/theia
@@ -63,7 +64,7 @@ COPY --from=endpoint /etc/passwd  /etc/passwd
 COPY --from=endpoint /etc/group   /etc/group
 COPY --from=endpoint /entrypoint.sh /entrypoint.sh
 
-RUN find /home/theia/ -name "binding.gyp" |  xargs -i sh -c 'cd $(dirname {}) && node-gyp rebuild' \
+RUN find /home/theia/ -name "binding.gyp" |  xargs -i sh -c 'cd $(dirname {}) && node-gyp rebuild --ensure' \
     && sed -i 's/SIGHUP SIGTERM SIGINT/HUP TERM INT/g' /entrypoint.sh
 
 # Install .NET Core SDK

--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -49,6 +49,8 @@ EXPOSE 3000 3030
 # Configure npm and yarn to use home folder for global dependencies
 RUN npm config set prefix "${HOME}/.npm-global" && \
     echo "--global-folder \"${HOME}/.yarn-global\"" > ${HOME}/.yarnrc && \
+    # Setup node-gyp. Yarn will be failed unless installing required files here.
+    yarn global add node-gyp && \
     # add eclipse che theia generator
     yarn global add yo @theia/generator-plugin@0.0.1-1540209403 ${THEIA_GENERATOR_PACKAGE} && \
     # Generate .passwd.template \

--- a/dockerfiles/theia-dev/src/entrypoint.sh
+++ b/dockerfiles/theia-dev/src/entrypoint.sh
@@ -26,4 +26,7 @@ if ! grep -Fq "${USER_ID}" /etc/passwd; then
     sed "s/\${GROUP_ID}/${GROUP_ID}/g" > /etc/group
 fi
 
+# Avlid build errors caused by Yarn's parallel build
+node-gyp install
+
 exec "$@"

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -72,7 +72,7 @@ RUN che:theia init -c ${HOME}/che-theia-init-sources.yml
 RUN che:theia cdn --theia="${CDN_PREFIX}" --monaco="${MONACO_CDN_PREFIX}"
 
 # Compile Theia
-RUN yarn
+RUN yarn global add node-gyp && node-gyp install && yarn
 
 # Run into production mode
 RUN che:theia production

--- a/dockerfiles/theia/e2e/Dockerfile
+++ b/dockerfiles/theia/e2e/Dockerfile
@@ -17,7 +17,7 @@ RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://ar
 RUN apt-get update && \
     apt-get install -y libx11-dev libxkbfile-dev sudo iproute2
 CMD /root/docker-run.sh
-RUN yarn global add typescript@2.9.2 node-gyp
+RUN yarn global add typescript@2.9.2 node-gyp && node-gyp install
 
 # Add cypress scripts and grab dependencies
 COPY src /root/
@@ -28,4 +28,4 @@ ADD cypress /root/cypress/
 
 COPY --from=theia /home/theia /home/theia
 COPY --from=theia /entrypoint.sh /entrypoint.sh
-RUN find /home/theia/ -name "binding.gyp" |  xargs -i sh -c 'cd $(dirname {}) && node-gyp rebuild'
+RUN find /home/theia/ -name "binding.gyp" |  xargs -i sh -c 'cd $(dirname {}) && node-gyp rebuild --ensure'


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

Runs `node-gyp install` before running `node-gyp rebuild`.
Referring to logs on my CI builds, node-gyp may start builds before extracting required header files.
As the issue #283 is less reproductive, I set this PR to draft for now.
I'm going to check this by some more CI builds.

### What issues does this PR fix or reference?

fixes #283 
