### PR TITLE
Set GOCACHE to a writable existing directory, change GOPATH

### DIFF
--- a/dockerfiles/remote-plugin-go-1.10.7/Dockerfile
+++ b/dockerfiles/remote-plugin-go-1.10.7/Dockerfile
@@ -72,6 +72,7 @@ RUN set -eux; \
     go version && \
     apk add gcc g++ git
 
-ENV GOPATH /projects:/go
+ENV GOPATH /go
+ENV GOCACHE /.cache
 ENV GOROOT /usr/local/go
 ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH


### PR DESCRIPTION
### What does this PR do?
Sets `GOCACHE` explictly to a writable directory.

Removes the hardcoded location of /projects from the `GOPATH`. This is replaced by a dynamic resolution of `/projects` from the Che server done in https://github.com/eclipse/che-plugin-registry/pull/165.

This is to improve experience with the go plugin. The resetting of `GOCACHE` makes the warning about a directory not being writable disappear. `/projects` should not be hardcoded because it is actually configurable in the Che server.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13529
https://github.com/eclipse/che-plugin-registry/pull/165