### PR TITLE
Fix connection failure in the e2e test for `che-theia`

### DIFF
--- a/dockerfiles/theia/e2e/Dockerfile
+++ b/dockerfiles/theia/e2e/Dockerfile
@@ -15,7 +15,7 @@ ENV NOCDN=true
 
 RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
 RUN apt-get update && \
-    apt-get install -y libx11-dev libxkbfile-dev sudo
+    apt-get install -y libx11-dev libxkbfile-dev sudo iproute2
 CMD /root/docker-run.sh
 RUN yarn global add typescript@2.9.2 node-gyp
 

--- a/dockerfiles/theia/e2e/src/docker-run.sh
+++ b/dockerfiles/theia/e2e/src/docker-run.sh
@@ -6,13 +6,32 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 
+# (5 + 2 * 30 = 65 seconds) is the default timeout.
+: "${WAIT_COUNT:=30}"
+
 echo "Starting Theia..."
 rm -rf /root/logs/*
 HOME=/home/theia /entrypoint.sh > /root/logs/theia.log 2>/root/logs/theia-error.log&
-sleep 10s
+
 echo "Cleaning videos folder..."
 # Cleanup previous videos
-rm -rf /root/cypress/videos
+rm -rf /root/cypress/videos/*
+
+# Find TCP 0.0.0.0:3100 that will be opened by Theia.
+sleep 5s
+while [ $WAIT_COUNT -gt 0 ]; do
+    # Check the listening port
+    ss -nlt | grep -Fq ':3100' && break
+    # not found
+    WAIT_COUNT=$((WAIT_COUNT-1));
+    echo "Waiting for booting up Theia..."
+    sleep 2s
+done
+
+if [ $WAIT_COUNT -eq 0 ]; then
+    echo "Timeout. Theia is dead?"
+    exit 1
+fi
 
 # Run tests
 echo "Run the tests"


### PR DESCRIPTION
### What does this PR do?

Some improvements to the e2e test for `che-theia`
The current test script wait booting Theia up by `sleep`.
But we can't estimate how long. So it's better to watch the status of TCP port.

### What issues does this PR fix or reference?

None.