### PR TITLE
Use `-z` for empty checks.

### DIFF
--- a/dockerfiles/theia/extract-for-cdn.sh
+++ b/dockerfiles/theia/extract-for-cdn.sh
@@ -13,7 +13,7 @@ help() {
 
 image="$1"
 destination="$2"
-if [ "${image}" == "" -o "${destination}" == "" ]; then
+if [ -z "${image}" -o -z "${destination}" ]; then
   help
   exit 1
 fi


### PR DESCRIPTION

### What does this PR do?

Fix the error in case lack of parameters.

```
$ sh -c '[ "${image}" == "" ] && echo $?'
sh: 1: [: unexpected operator
```

```
$ sh -c '[ -z "${image}" ] && echo $?'
0
```

### What issues does this PR fix or reference?

None.
