### PR TITLE
Add e2e test for non root runtimes.

### DIFF
--- a/dockerfiles/theia/e2e/test.sh
+++ b/dockerfiles/theia/e2e/test.sh
@@ -20,10 +20,15 @@ fi
 # Runs E2E tests in a docker container.
 run_test_in_docker_container() {
   docker_exec run --rm ${DOCKER_RUN_OPTIONS} \
+       --user $1 \
        -v "${base_dir}/videos":/root/cypress/videos \
        -v "${base_dir}/logs":/root/logs \
        -v /var/run/docker.sock:/var/run/docker.sock \
            $IMAGE_NAME
 }
 
-run_test_in_docker_container
+# Run as root
+run_test_in_docker_container '0:0'
+
+# Run as non root
+run_test_in_docker_container '1234:5678'


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

Add e2e test under `uid:gid` is `1234:5678` (means non root).
At least Openshift will run `che-theia` under non root privilege.

### What issues does this PR fix or reference?

Related on https://github.com/eclipse/che-theia/issues/281
