### PR TITLE
Install `sudo` for the vanilla K8s.

### DIFF
--- a/dockerfiles/theia/e2e/Dockerfile
+++ b/dockerfiles/theia/e2e/Dockerfile
@@ -15,7 +15,7 @@ ENV NOCDN=true
 
 RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
 RUN apt-get update && \
-    apt-get install -y libx11-dev libxkbfile-dev
+    apt-get install -y libx11-dev libxkbfile-dev sudo
 CMD /root/docker-run.sh
 RUN yarn global add typescript@2.9.2 node-gyp
 


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

Separated from #290.

### What does this PR do?

And sudo command is used in entrypoint.sh.
I see it won't be called on Openshift. But it will be on other K8s based.

### What issues does this PR fix or reference?

Partly #281 