### PR TITLE
Expose some methods of CheApiService to Che Plugin API

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-api-provider.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-api-provider.ts
@@ -18,6 +18,7 @@ import { CheVariablesMainImpl } from './che-variables-main';
 import { CheTaskMainImpl } from './che-task-main';
 import { CheSshMainImpl } from './che-ssh-main';
 import { CheDevfileMainImpl } from './che-devfile-main';
+import { CheUserMainImpl } from './che-user-main';
 
 @injectable()
 export class CheApiProvider implements MainPluginApiProvider {
@@ -29,6 +30,7 @@ export class CheApiProvider implements MainPluginApiProvider {
         rpc.set(PLUGIN_RPC_CONTEXT.CHE_VARIABLES_MAIN, new CheVariablesMainImpl(container, rpc));
         rpc.set(PLUGIN_RPC_CONTEXT.CHE_TASK_MAIN, new CheTaskMainImpl(container, rpc));
         rpc.set(PLUGIN_RPC_CONTEXT.CHE_SSH_MAIN, new CheSshMainImpl(container));
+        rpc.set(PLUGIN_RPC_CONTEXT.CHE_USER_MAIN, new CheUserMainImpl(container));
     }
 
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-user-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-user-main.ts
@@ -1,0 +1,38 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { interfaces } from 'inversify';
+import { CheApiService, CheUserMain } from '../common/che-protocol';
+import { Preferences } from '@eclipse-che/plugin';
+
+export class CheUserMainImpl implements CheUserMain {
+
+    private readonly cheApiService: CheApiService;
+
+    constructor(container: interfaces.Container) {
+        this.cheApiService = container.get(CheApiService);
+    }
+
+    $getUserPreferences(filter?: string): Promise<Preferences> {
+        return this.cheApiService.getUserPreferences(filter);
+    }
+
+    $updateUserPreferences(preferences: Preferences): Promise<Preferences> {
+        return this.cheApiService.updateUserPreferences(preferences);
+    }
+
+    $replaceUserPreferences(preferences: Preferences): Promise<Preferences> {
+        return this.cheApiService.replaceUserPreferences(preferences);
+    }
+
+    $deleteUserPreferences(list?: string[]): Promise<void> {
+        return this.cheApiService.deleteUserPreferences(list);
+    }
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -366,6 +366,9 @@ export const PLUGIN_RPC_CONTEXT = {
 
     CHE_SSH: <ProxyIdentifier<CheSsh>>createProxyIdentifier<CheSsh>('CheSsh'),
     CHE_SSH_MAIN: <ProxyIdentifier<CheSshMain>>createProxyIdentifier<CheSshMain>('CheSshMain'),
+
+    CHE_USER: <ProxyIdentifier<CheUser>>createProxyIdentifier<CheUser>('CheUser'),
+    CHE_USER_MAIN: <ProxyIdentifier<CheUserMain>>createProxyIdentifier<CheUserMain>('CheUserMain'),
 };
 
 // Theia RPC protocol
@@ -485,4 +488,13 @@ export interface ChePluginService {
      */
     removePlugin(pluginKey: string): Promise<void>;
 
+}
+
+export interface CheUser { }
+
+export interface CheUserMain {
+    $getUserPreferences(filter?: string): Promise<Preferences>;
+    $updateUserPreferences(preferences: Preferences): Promise<Preferences>;
+    $replaceUserPreferences(preferences: Preferences): Promise<Preferences>;
+    $deleteUserPreferences(list?: string[]): Promise<void>;
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
@@ -19,6 +19,7 @@ import { CheFactoryImpl } from './che-factory';
 import { CheDevfileImpl } from './che-devfile';
 import { CheTaskImpl } from './che-task-impl';
 import { CheSshImpl } from './che-ssh';
+import { CheUserImpl } from './che-user';
 
 export interface CheApiFactory {
     (plugin: Plugin): typeof che;
@@ -31,6 +32,7 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
     const cheVariablesImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_VARIABLES, new CheVariablesImpl(rpc));
     const cheTaskImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_TASK, new CheTaskImpl(rpc));
     const cheSshImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_SSH, new CheSshImpl(rpc));
+    const cheUserImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_USER, new CheUserImpl(rpc));
 
     return function (plugin: Plugin): typeof che {
         const workspace: typeof che.workspace = {
@@ -124,13 +126,29 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
             }
         };
 
+        const user: typeof che.user = {
+            getUserPreferences(filter?: string): Promise<che.Preferences> {
+                return cheUserImpl.getUserPreferences(filter);
+            },
+            updateUserPreferences(update: che.Preferences): Promise<che.Preferences> {
+                return cheUserImpl.updateUserPreferences(update);
+            },
+            replaceUserPreferences(preferences: che.Preferences): Promise<che.Preferences> {
+                return cheUserImpl.replaceUserPreferences(preferences);
+            },
+            deleteUserPreferences(list?: string[]): Promise<void> {
+                return cheUserImpl.deleteUserPreferences(list);
+            }
+        };
+
         return <typeof che>{
             workspace,
             factory,
             devfile,
             variables,
             task,
-            ssh
+            ssh,
+            user
         };
     };
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-user.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-user.ts
@@ -1,0 +1,43 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { RPCProtocol } from '@theia/plugin-ext/lib/api/rpc-protocol';
+import { Preferences } from '@eclipse-che/plugin';
+import {
+    CheUser,
+    CheUserMain,
+    PLUGIN_RPC_CONTEXT,
+} from '../common/che-protocol';
+
+export class CheUserImpl implements CheUser {
+
+    private readonly userMain: CheUserMain;
+
+    constructor(rpc: RPCProtocol) {
+        this.userMain = rpc.getProxy(PLUGIN_RPC_CONTEXT.CHE_USER_MAIN);
+    }
+
+    getUserPreferences(filter?: string): Promise<Preferences> {
+        return this.userMain.$getUserPreferences(filter);
+    }
+
+    updateUserPreferences(update: Preferences): Promise<Preferences> {
+        return this.userMain.$updateUserPreferences(update);
+    }
+
+    replaceUserPreferences(preferences: Preferences): Promise<Preferences> {
+        return this.userMain.$replaceUserPreferences(preferences);
+    }
+
+    deleteUserPreferences(list?: string[]): Promise<void> {
+        return this.userMain.$deleteUserPreferences(list);
+    }
+
+}

--- a/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
+++ b/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
@@ -156,4 +156,17 @@ declare module '@eclipse-che/plugin' {
         /** Additional task type specific properties. */
         readonly [key: string]: any;
     }
+
+    export namespace user {
+        export function getUserPreferences(): Promise<Preferences>;
+        export function getUserPreferences(filter: string | undefined): Promise<Preferences>;
+        export function updateUserPreferences(update: Preferences): Promise<Preferences>;
+        export function replaceUserPreferences(preferences: Preferences): Promise<Preferences>;
+        export function deleteUserPreferences(): Promise<void>;
+        export function deleteUserPreferences(list: string[] | undefined): Promise<void>;
+    }
+
+    export interface Preferences {
+        [key: string]: string;
+    }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR adds `user` namespace to Che Plugin API and exposes there some methods of CheApiService.

### What issues does this PR fix or reference?

fix https://github.com/eclipse/che/issues/13518

