### PR TITLE
Export configurations of Che tasks to config file

### DIFF
--- a/plugins/containers-plugin/src/containers-service.ts
+++ b/plugins/containers-plugin/src/containers-service.ts
@@ -91,7 +91,8 @@ export class ContainersService {
             }
             if (runtime.commands) {
                 container.commands = [];
-                runtime.commands.forEach(command => {
+                const cheCommands = runtime.commands.filter(command => command.type === 'exec');
+                cheCommands.forEach(command => {
                     if (command.attributes && command.attributes.machineName && command.attributes.machineName !== name) {
                         return;
                     }

--- a/plugins/containers-plugin/src/containers-tree-data-provider.ts
+++ b/plugins/containers-plugin/src/containers-tree-data-provider.ts
@@ -106,7 +106,7 @@ export class ContainersTreeDataProvider implements theia.TreeDataProvider<ITreeN
                         name: commandName,
                         tooltip: 'execute the command',
                         iconPath: 'fa-cogs medium-yellow',
-                        command: { id: 'task:run', arguments: ['che', commandName] }
+                        command: { id: 'task:run', arguments: [this.getRootPath(), commandName] }
                     });
                 });
             }
@@ -212,6 +212,14 @@ export class ContainersTreeDataProvider implements theia.TreeDataProvider<ITreeN
         this.treeNodeItems.push(pluginsGroup);
 
         this.onDidChangeTreeDataEmitter.fire();
+    }
+
+    private getRootPath(): string {
+        const workspaceFolders = theia.workspace.workspaceFolders;
+        if (!workspaceFolders || workspaceFolders.length < 1) {
+            return '/projects';
+        }
+        return workspaceFolders[0].uri.path;
     }
 
     private getRandId(): string {

--- a/plugins/task-plugin/src/che-task-backend-module.ts
+++ b/plugins/task-plugin/src/che-task-backend-module.ts
@@ -24,7 +24,12 @@ import { PreviewUrlOpenService } from './preview/preview-url-open-service';
 import { CheWorkspaceClient } from './che-workspace-client';
 import { LaunchConfigurationsExporter } from './export/launch-configs-exporter';
 import { TaskConfigurationsExporter } from './export/task-configs-exporter';
-import { ConfigurationsExporter, ExportConfigurationsManager } from './export/export-configs-manager';
+import { ExportConfigurationsManager, ConfigurationsExporter } from './export/export-configs-manager';
+import { CheTaskConfigsExtractor } from './extract/che-task-configs-extractor';
+import { ConfigFileLaunchConfigsExtractor } from './extract/config-file-launch-configs-extractor';
+import { ConfigFileTasksExtractor } from './extract/config-file-task-configs-extractor';
+import { VsCodeLaunchConfigsExtractor } from './extract/vscode-launch-configs-extractor';
+import { VsCodeTaskConfigsExtractor } from './extract/vscode-task-configs-extractor';
 
 const container = new Container();
 container.bind(CheTaskProvider).toSelf().inSingletonScope();
@@ -42,6 +47,11 @@ container.bind(PreviewUrlOpenService).toSelf().inSingletonScope();
 container.bind<ConfigurationsExporter>(ConfigurationsExporter).to(TaskConfigurationsExporter).inSingletonScope();
 container.bind<ConfigurationsExporter>(ConfigurationsExporter).to(LaunchConfigurationsExporter).inSingletonScope();
 container.bind(ExportConfigurationsManager).toSelf().inSingletonScope();
+container.bind(CheTaskConfigsExtractor).toSelf().inSingletonScope();
+container.bind(ConfigFileTasksExtractor).toSelf().inSingletonScope();
+container.bind(ConfigFileLaunchConfigsExtractor).toSelf().inSingletonScope();
+container.bind(VsCodeLaunchConfigsExtractor).toSelf().inSingletonScope();
+container.bind(VsCodeTaskConfigsExtractor).toSelf().inSingletonScope();
 
 container.bind(PreviewUrlsWidget).toSelf().inTransientScope();
 container.bind(PreviewUrlsWidgetFactory).toDynamicValue(ctx => ({

--- a/plugins/task-plugin/src/export/launch-configs-exporter.ts
+++ b/plugins/task-plugin/src/export/launch-configs-exporter.ts
@@ -8,57 +8,93 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import { injectable } from 'inversify';
+import { injectable, inject } from 'inversify';
 import * as theia from '@theia/plugin';
+import { che as cheApi } from '@eclipse-che/api';
 import { resolve } from 'path';
-import { readFileSync, writeFileSync, format, modify, parse } from '../utils';
+import { writeFileSync, modify } from '../utils';
 import { ConfigurationsExporter } from './export-configs-manager';
+import { ConfigFileLaunchConfigsExtractor } from '../extract/config-file-launch-configs-extractor';
+import { VsCodeLaunchConfigsExtractor } from '../extract/vscode-launch-configs-extractor';
 
 const CONFIG_DIR = '.theia';
 const LAUNCH_CONFIG_FILE = 'launch.json';
 const formattingOptions = { tabSize: 4, insertSpaces: true, eol: '' };
 
-export const VSCODE_LAUNCH_TYPE = 'vscode-launch';
-
 /** Exports content with launch configurations in the config file. */
 @injectable()
 export class LaunchConfigurationsExporter implements ConfigurationsExporter {
-    readonly type: string = VSCODE_LAUNCH_TYPE;
 
-    export(configsContent: string, workspaceFolder: theia.WorkspaceFolder): void {
+    @inject(ConfigFileLaunchConfigsExtractor)
+    protected readonly configFileLaunchConfigsExtractor: ConfigFileLaunchConfigsExtractor;
+
+    @inject(VsCodeLaunchConfigsExtractor)
+    protected readonly vsCodeLaunchConfigsExtractor: VsCodeLaunchConfigsExtractor;
+
+    export(workspaceFolder: theia.WorkspaceFolder, commands: cheApi.workspace.Command[]): void {
         const launchConfigFileUri = this.getConfigFileUri(workspaceFolder.uri.path);
-        const existingContent = readFileSync(launchConfigFileUri);
-        if (configsContent === existingContent) {
+        const configFileConfigs = this.configFileLaunchConfigsExtractor.extract(launchConfigFileUri);
+        const vsCodeConfigs = this.vsCodeLaunchConfigsExtractor.extract(commands);
+
+        const configFileContent = configFileConfigs.content;
+        if (configFileContent) {
+            this.saveConfigs(launchConfigFileUri, configFileContent, this.merge(configFileConfigs.configs, vsCodeConfigs.configs, this.getConsoleConflictLogger()));
             return;
         }
 
-        const configsJson = parse(configsContent);
-        if (!configsJson || !configsJson.configurations) {
-            return;
+        const vsCodeConfigsContent = vsCodeConfigs.content;
+        if (vsCodeConfigsContent) {
+            this.saveConfigs(launchConfigFileUri, vsCodeConfigsContent, vsCodeConfigs.configs);
         }
-
-        const existingJson = parse(existingContent);
-        if (!existingJson || !existingJson.configurations) {
-            writeFileSync(launchConfigFileUri, format(configsContent, formattingOptions));
-            return;
-        }
-
-        const mergedConfigs = this.merge(existingJson.configurations, configsJson.configurations);
-        const result = modify(configsContent, ['configurations'], mergedConfigs, formattingOptions);
-        writeFileSync(launchConfigFileUri, result);
     }
 
-    private merge(existingConfigs: theia.DebugConfiguration[], newConfigs: theia.DebugConfiguration[]): theia.DebugConfiguration[] {
-        const result: theia.DebugConfiguration[] = Object.assign([], newConfigs);
-        for (const existing of existingConfigs) {
-            if (!newConfigs.some(config => config.name === existing.name)) {
-                result.push(existing);
+    private merge(configurations1: theia.DebugConfiguration[],
+        configurations2: theia.DebugConfiguration[],
+        conflictHandler: (config1: theia.DebugConfiguration, config2: theia.DebugConfiguration) => void): theia.DebugConfiguration[] {
+
+        const result: theia.DebugConfiguration[] = Object.assign([], configurations1);
+
+        for (const config2 of configurations2) {
+            const conflict = configurations1.find(config1 => config1.name === config2.name);
+            if (!conflict) {
+                result.push(config2);
+                continue;
             }
+
+            if (this.areEqual(config2, conflict)) {
+                continue;
+            }
+
+            conflictHandler(conflict, config2);
         }
+
         return result;
+    }
+
+    private areEqual(config1: theia.DebugConfiguration, config2: theia.DebugConfiguration): boolean {
+        const { type: type1, name: name1, request: request1, ...properties1 } = config1;
+        const { type: type2, name: name2, request: request2, ...properties2 } = config2;
+
+        if (type1 !== type2 || name1 !== name2 || request1 !== request2) {
+            return false;
+        }
+
+        return JSON.stringify(properties1) === JSON.stringify(properties2);
     }
 
     private getConfigFileUri(rootDir: string): string {
         return resolve(rootDir.toString(), CONFIG_DIR, LAUNCH_CONFIG_FILE);
+    }
+
+    private saveConfigs(launchConfigFileUri: string, content: string, configurations: theia.DebugConfiguration[]) {
+        const result = modify(content, ['configurations'], configurations, formattingOptions);
+        writeFileSync(launchConfigFileUri, result);
+    }
+
+    private getConsoleConflictLogger(): (config1: theia.DebugConfiguration, config2: theia.DebugConfiguration) => void {
+        return (config1: theia.DebugConfiguration, config2: theia.DebugConfiguration) => {
+            console.warn(`Conflict at exporting launch configurations: ${JSON.stringify(config1)} and ${JSON.stringify(config2)}`,
+                `The configuration: ${JSON.stringify(config2)} is ignored`);
+        };
     }
 }

--- a/plugins/task-plugin/src/export/launch-configs-exporter.ts
+++ b/plugins/task-plugin/src/export/launch-configs-exporter.ts
@@ -86,7 +86,7 @@ export class LaunchConfigurationsExporter implements ConfigurationsExporter {
         return resolve(rootDir.toString(), CONFIG_DIR, LAUNCH_CONFIG_FILE);
     }
 
-    private saveConfigs(launchConfigFileUri: string, content: string, configurations: theia.DebugConfiguration[]) {
+    private saveConfigs(launchConfigFileUri: string, content: string, configurations: theia.DebugConfiguration[]): void {
         const result = modify(content, ['configurations'], configurations, formattingOptions);
         writeFileSync(launchConfigFileUri, result);
     }

--- a/plugins/task-plugin/src/export/task-configs-exporter.ts
+++ b/plugins/task-plugin/src/export/task-configs-exporter.ts
@@ -8,12 +8,17 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import { injectable } from 'inversify';
+import { injectable, inject } from 'inversify';
 import * as theia from '@theia/plugin';
+import * as startPoint from '../task-plugin-backend';
+import { che as cheApi } from '@eclipse-che/api';
 import { TaskConfiguration } from '@eclipse-che/plugin';
 import { resolve } from 'path';
-import { readFileSync, writeFileSync, format, modify, parse } from '../utils';
+import { writeFileSync, modify } from '../utils';
+import { CheTaskConfigsExtractor } from '../extract/che-task-configs-extractor';
+import { VsCodeTaskConfigsExtractor } from '../extract/vscode-task-configs-extractor';
 import { ConfigurationsExporter } from './export-configs-manager';
+import { ConfigFileTasksExtractor } from '../extract/config-file-task-configs-extractor';
 
 const CONFIG_DIR = '.theia';
 const TASK_CONFIG_FILE = 'tasks.json';
@@ -24,42 +29,97 @@ export const VSCODE_TASK_TYPE = 'vscode-task';
 /** Exports configurations of tasks in the config file. */
 @injectable()
 export class TaskConfigurationsExporter implements ConfigurationsExporter {
-    readonly type: string = VSCODE_TASK_TYPE;
 
-    export(tasksContent: string, workspaceFolder: theia.WorkspaceFolder): void {
+    @inject(ConfigFileTasksExtractor)
+    protected readonly configFileTasksExtractor: ConfigFileTasksExtractor;
+
+    @inject(CheTaskConfigsExtractor)
+    protected readonly cheTaskConfigsExtractor: CheTaskConfigsExtractor;
+
+    @inject(VsCodeTaskConfigsExtractor)
+    protected readonly vsCodeTaskConfigsExtractor: VsCodeTaskConfigsExtractor;
+
+    export(workspaceFolder: theia.WorkspaceFolder, commands: cheApi.workspace.Command[]): void {
         const tasksConfigFileUri = this.getConfigFileUri(workspaceFolder.uri.path);
-        const existingContent = readFileSync(tasksConfigFileUri);
-        if (tasksContent === existingContent) {
+        const configFileTasks = this.configFileTasksExtractor.extract(tasksConfigFileUri);
+
+        const cheTasks = this.cheTaskConfigsExtractor.extract(commands);
+        const vsCodeTasks = this.vsCodeTaskConfigsExtractor.extract(commands);
+        const devfileConfigs = this.merge(cheTasks, vsCodeTasks.configs, this.getOutputChannelConflictLogger());
+
+        const configFileContent = configFileTasks.content;
+        if (configFileContent) {
+            this.saveConfigs(tasksConfigFileUri, configFileContent, this.merge(configFileTasks.configs, devfileConfigs, this.getConsoleConflictLogger()));
             return;
         }
 
-        const tasksJson = parse(tasksContent);
-        if (!tasksJson || !tasksJson.tasks) {
+        const vsCodeTasksContent = vsCodeTasks.content;
+        if (vsCodeTasksContent) {
+            this.saveConfigs(tasksConfigFileUri, vsCodeTasksContent, devfileConfigs);
             return;
         }
 
-        const existingJson = parse(existingContent);
-        if (!existingJson || !existingJson.tasks) {
-            writeFileSync(tasksConfigFileUri, format(tasksContent, formattingOptions));
-            return;
+        if (cheTasks) {
+            this.saveConfigs(tasksConfigFileUri, '', cheTasks);
         }
-
-        const mergedConfigs = this.merge(existingJson.tasks, tasksJson.tasks);
-        const result = modify(tasksContent, ['tasks'], mergedConfigs, formattingOptions);
-        writeFileSync(tasksConfigFileUri, result);
     }
 
-    private merge(existingConfigs: TaskConfiguration[], newConfigs: TaskConfiguration[]): TaskConfiguration[] {
-        const result: TaskConfiguration[] = Object.assign([], newConfigs);
-        for (const existing of existingConfigs) {
-            if (!newConfigs.some(config => config.label === existing.label)) {
-                result.push(existing);
+    private merge(configurations1: TaskConfiguration[],
+        configurations2: TaskConfiguration[],
+        conflictHandler: (config1: TaskConfiguration, config2: TaskConfiguration) => void): TaskConfiguration[] {
+
+        const result: TaskConfiguration[] = Object.assign([], configurations1);
+
+        for (const config2 of configurations2) {
+            const conflict = configurations1.find(config1 => config1.label === config2.label);
+            if (!conflict) {
+                result.push(config2);
+                continue;
             }
+
+            if (this.areEqual(config2, conflict)) {
+                continue;
+            }
+
+            conflictHandler(conflict, config2);
         }
+
         return result;
+    }
+
+    private areEqual(config1: TaskConfiguration, config2: TaskConfiguration): boolean {
+        const { type: type1, label: label1, ...properties1 } = config1;
+        const { type: type2, label: label2, ...properties2 } = config2;
+
+        if (type1 !== type2 || label1 !== label2) {
+            return false;
+        }
+
+        return JSON.stringify(properties1) === JSON.stringify(properties2);
     }
 
     private getConfigFileUri(rootDir: string): string {
         return resolve(rootDir.toString(), CONFIG_DIR, TASK_CONFIG_FILE);
+    }
+
+    private saveConfigs(tasksConfigFileUri: string, content: string, configurations: TaskConfiguration[]) {
+        const result = modify(content, ['tasks'], configurations, formattingOptions);
+        writeFileSync(tasksConfigFileUri, result);
+    }
+
+    private getOutputChannelConflictLogger(): (config1: TaskConfiguration, config2: TaskConfiguration) => void {
+        return (config1: TaskConfiguration, config2: TaskConfiguration) => {
+            const outputChannel = startPoint.getOutputChannel();
+            outputChannel.show();
+            outputChannel.appendLine(`Conflict at exporting task configurations: ${JSON.stringify(config1)} and ${JSON.stringify(config2)}`);
+            outputChannel.appendLine(`The configuration: ${JSON.stringify(config2)} is ignored`);
+        };
+    }
+
+    private getConsoleConflictLogger(): (config1: TaskConfiguration, config2: TaskConfiguration) => void {
+        return (config1: TaskConfiguration, config2: TaskConfiguration) => {
+            console.warn(`Conflict at exporting task configurations: ${JSON.stringify(config1)} and ${JSON.stringify(config2)}`,
+                `The configuration: ${JSON.stringify(config2)} is ignored`);
+        };
     }
 }

--- a/plugins/task-plugin/src/export/task-configs-exporter.ts
+++ b/plugins/task-plugin/src/export/task-configs-exporter.ts
@@ -102,7 +102,7 @@ export class TaskConfigurationsExporter implements ConfigurationsExporter {
         return resolve(rootDir.toString(), CONFIG_DIR, TASK_CONFIG_FILE);
     }
 
-    private saveConfigs(tasksConfigFileUri: string, content: string, configurations: TaskConfiguration[]) {
+    private saveConfigs(tasksConfigFileUri: string, content: string, configurations: TaskConfiguration[]): void {
         const result = modify(content, ['tasks'], configurations, formattingOptions);
         writeFileSync(tasksConfigFileUri, result);
     }

--- a/plugins/task-plugin/src/extract/che-task-configs-extractor.ts
+++ b/plugins/task-plugin/src/extract/che-task-configs-extractor.ts
@@ -1,0 +1,34 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { injectable } from 'inversify';
+import { che as cheApi } from '@eclipse-che/api';
+import { TaskConfiguration } from '@eclipse-che/plugin';
+import { toTaskConfiguration } from '../task/converter';
+import { VSCODE_TASK_TYPE } from './vscode-task-configs-extractor';
+import { VSCODE_LAUNCH_TYPE } from './vscode-launch-configs-extractor';
+
+/** Extracts CHE configurations of tasks. */
+@injectable()
+export class CheTaskConfigsExtractor {
+
+    extract(commands: cheApi.workspace.Command[]): TaskConfiguration[] {
+        // TODO filter should be changed according to task type after resolving https://github.com/eclipse/che/issues/12710
+        const filteredCommands = commands.filter(command =>
+            command.type !== VSCODE_TASK_TYPE &&
+            command.type !== VSCODE_LAUNCH_TYPE);
+
+        if (filteredCommands.length === 0) {
+            return [];
+        }
+
+        return filteredCommands.map(command => toTaskConfiguration(command));
+    }
+}

--- a/plugins/task-plugin/src/extract/config-file-launch-configs-extractor.ts
+++ b/plugins/task-plugin/src/extract/config-file-launch-configs-extractor.ts
@@ -1,0 +1,29 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { injectable } from 'inversify';
+import * as theia from '@theia/plugin';
+import { parse, readFileSync } from '../utils';
+import { Configurations } from '../export/export-configs-manager';
+
+/** Extracts launch configurations from config file by given uri. */
+@injectable()
+export class ConfigFileLaunchConfigsExtractor {
+
+    extract(launchConfigFileUri: string): Configurations<theia.DebugConfiguration> {
+        const configsContent = readFileSync(launchConfigFileUri);
+        const configsJson = parse(configsContent);
+        if (!configsJson || !configsJson.configurations) {
+            return { content: '', configs: [] };
+        }
+
+        return { content: configsContent, configs: configsJson.configurations };
+    }
+}

--- a/plugins/task-plugin/src/extract/config-file-task-configs-extractor.ts
+++ b/plugins/task-plugin/src/extract/config-file-task-configs-extractor.ts
@@ -1,0 +1,29 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { injectable } from 'inversify';
+import { parse, readFileSync } from '../utils';
+import { Configurations } from '../export/export-configs-manager';
+import { TaskConfiguration } from '@eclipse-che/plugin';
+
+/** Extracts configurations of tasks from config file by given uri. */
+@injectable()
+export class ConfigFileTasksExtractor {
+
+    extract(tasksConfigFileUri: string): Configurations<TaskConfiguration> {
+        const tasksContent = readFileSync(tasksConfigFileUri);
+        const tasksJson = parse(tasksContent);
+        if (!tasksJson || !tasksJson.tasks) {
+            return { content: '', configs: [] };
+        }
+
+        return { content: tasksContent, configs: tasksJson.tasks };
+    }
+}

--- a/plugins/task-plugin/src/extract/vscode-launch-configs-extractor.ts
+++ b/plugins/task-plugin/src/extract/vscode-launch-configs-extractor.ts
@@ -1,0 +1,48 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { injectable } from 'inversify';
+import * as theia from '@theia/plugin';
+import { che as cheApi } from '@eclipse-che/api';
+import { parse } from '../utils';
+import { Configurations } from '../export/export-configs-manager';
+
+export const VSCODE_LAUNCH_TYPE = 'vscode-launch';
+
+/** Extracts vscode launch configurations. */
+@injectable()
+export class VsCodeLaunchConfigsExtractor {
+
+    extract(commands: cheApi.workspace.Command[]): Configurations<theia.DebugConfiguration> {
+        const emptyContent: Configurations<theia.DebugConfiguration> = { content: '', configs: [] };
+
+        const configCommands = commands.filter(command => command.type === VSCODE_LAUNCH_TYPE);
+        if (configCommands.length === 0) {
+            return emptyContent;
+        }
+
+        if (configCommands.length > 1) {
+            console.warn(`Found duplicate entry with configurations for type ${VSCODE_LAUNCH_TYPE}`);
+        }
+
+        const configCommand = configCommands[0];
+        if (!configCommand || !configCommand.attributes || !configCommand.attributes.actionReferenceContent) {
+            return emptyContent;
+        }
+
+        const launchConfigsContent = configCommand.attributes.actionReferenceContent;
+        const configsJson = parse(launchConfigsContent);
+        if (!configsJson || !configsJson.configurations) {
+            return emptyContent;
+        }
+
+        return { content: launchConfigsContent, configs: configsJson.configurations };
+    }
+}

--- a/plugins/task-plugin/src/extract/vscode-task-configs-extractor.ts
+++ b/plugins/task-plugin/src/extract/vscode-task-configs-extractor.ts
@@ -1,0 +1,48 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { injectable } from 'inversify';
+import { che as cheApi } from '@eclipse-che/api';
+import { parse } from '../utils';
+import { Configurations } from '../export/export-configs-manager';
+import { TaskConfiguration } from '@eclipse-che/plugin';
+
+export const VSCODE_TASK_TYPE = 'vscode-task';
+
+/** Extracts vscode configurations of tasks. */
+@injectable()
+export class VsCodeTaskConfigsExtractor {
+
+    extract(commands: cheApi.workspace.Command[]): Configurations<TaskConfiguration> {
+        const emptyContent = { content: '', configs: [] } as Configurations<TaskConfiguration>;
+
+        const configCommands = commands.filter(command => command.type === VSCODE_TASK_TYPE);
+        if (configCommands.length === 0) {
+            return emptyContent;
+        }
+
+        if (configCommands.length > 1) {
+            console.warn(`Found duplicate entry with configurations for type ${VSCODE_TASK_TYPE}`);
+        }
+
+        const configCommand = configCommands[0];
+        if (!configCommand || !configCommand.attributes || !configCommand.attributes.actionReferenceContent) {
+            return emptyContent;
+        }
+
+        const tasksContent = configCommand.attributes.actionReferenceContent;
+        const tasksJson = parse(tasksContent);
+        if (!tasksJson || !tasksJson.tasks) {
+            return emptyContent;
+        }
+
+        return { content: tasksContent, configs: tasksJson.tasks };
+    }
+}

--- a/plugins/task-plugin/src/task-plugin-backend.ts
+++ b/plugins/task-plugin/src/task-plugin-backend.ts
@@ -22,6 +22,7 @@ import { TasksPreviewManager } from './preview/tasks-preview-manager';
 import { ExportConfigurationsManager } from './export/export-configs-manager';
 
 let pluginContext: theia.PluginContext;
+let outputChannel: theia.OutputChannel | undefined;
 
 export async function start(context: theia.PluginContext) {
     pluginContext = context;
@@ -59,4 +60,13 @@ export function getContext(): theia.PluginContext {
 // tslint:disable-next-line:no-any
 export function getSubscriptions(): { dispose(): any }[] {
     return pluginContext.subscriptions;
+}
+
+export function getOutputChannel(): theia.OutputChannel {
+    if (outputChannel) {
+        return outputChannel;
+    }
+
+    outputChannel = theia.window.createOutputChannel('task-plugin-log');
+    return outputChannel;
 }

--- a/plugins/task-plugin/src/task/che-task-provider.ts
+++ b/plugins/task-plugin/src/task/che-task-provider.ts
@@ -10,13 +10,10 @@
 
 import { injectable, inject } from 'inversify';
 import * as che from '@eclipse-che/plugin';
-import { che as cheApi } from '@eclipse-che/api';
 import { Task } from '@theia/plugin';
-import { CHE_TASK_TYPE, MACHINE_NAME_ATTRIBUTE, PREVIEW_URL_ATTRIBUTE, WORKING_DIR_ATTRIBUTE, CheTaskDefinition, Target } from './task-protocol';
+import { CHE_TASK_TYPE, CheTaskDefinition, Target } from './task-protocol';
 import { MachinesPicker } from '../machine/machines-picker';
 import { CheWorkspaceClient } from '../che-workspace-client';
-import { VSCODE_LAUNCH_TYPE } from '../export/launch-configs-exporter';
-import { VSCODE_TASK_TYPE } from '../export/task-configs-exporter';
 
 /** Reads the commands from the current Che workspace and provides it as Task Configurations. */
 @injectable()
@@ -28,11 +25,7 @@ export class CheTaskProvider {
     protected readonly cheWorkspaceClient!: CheWorkspaceClient;
 
     async provideTasks(): Promise<Task[]> {
-        const commands = await this.cheWorkspaceClient.getCommands();
-        const filteredCommands = commands.filter(command =>
-            command.type !== VSCODE_TASK_TYPE &&
-            command.type !== VSCODE_LAUNCH_TYPE);
-        return filteredCommands.map(command => this.toTask(command));
+        return [];
     }
 
     async resolveTask(task: Task): Promise<Task> {
@@ -74,34 +67,5 @@ export class CheTaskProvider {
             source: task.source,
             execution: task.execution
         };
-    }
-
-    private toTask(command: cheApi.workspace.Command): Task {
-        return {
-            definition: {
-                type: CHE_TASK_TYPE,
-                command: command.commandLine,
-                target: {
-                    workingDir: this.getCommandAttribute(command, WORKING_DIR_ATTRIBUTE),
-                    machineName: this.getCommandAttribute(command, MACHINE_NAME_ATTRIBUTE)
-                },
-                previewUrl: this.getCommandAttribute(command, PREVIEW_URL_ATTRIBUTE)
-            },
-            name: `${command.name}`,
-            source: CHE_TASK_TYPE,
-        };
-    }
-
-    private getCommandAttribute(command: cheApi.workspace.Command, attrName: string): string | undefined {
-        if (!command.attributes) {
-            return undefined;
-        }
-
-        for (const attr in command.attributes) {
-            if (attr === attrName) {
-                return command.attributes[attr];
-            }
-        }
-        return undefined;
     }
 }

--- a/plugins/task-plugin/src/task/converter.ts
+++ b/plugins/task-plugin/src/task/converter.ts
@@ -1,0 +1,59 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { che as cheApi } from '@eclipse-che/api';
+import { Task } from '@theia/plugin';
+import { TaskConfiguration } from '@eclipse-che/plugin';
+import { CHE_TASK_TYPE, MACHINE_NAME_ATTRIBUTE, PREVIEW_URL_ATTRIBUTE, WORKING_DIR_ATTRIBUTE } from './task-protocol';
+
+/** Converts the Che command to Theia Task Configuration */
+export function toTaskConfiguration(command: cheApi.workspace.Command): TaskConfiguration {
+    const taskConfig: TaskConfiguration = {
+        type: CHE_TASK_TYPE,
+        label: command.name,
+        command: command.commandLine,
+        target: {
+            workingDir: this.getCommandAttribute(command, WORKING_DIR_ATTRIBUTE),
+            machineName: this.getCommandAttribute(command, MACHINE_NAME_ATTRIBUTE)
+        },
+        previewUrl: this.getCommandAttribute(command, PREVIEW_URL_ATTRIBUTE)
+    };
+    return taskConfig;
+}
+
+/** Converts the Che command to Task API object */
+export function toTask(command: cheApi.workspace.Command): Task {
+    return {
+        definition: {
+            type: CHE_TASK_TYPE,
+            command: command.commandLine,
+            target: {
+                workingDir: this.getCommandAttribute(command, WORKING_DIR_ATTRIBUTE),
+                machineName: this.getCommandAttribute(command, MACHINE_NAME_ATTRIBUTE)
+            },
+            previewUrl: this.getCommandAttribute(command, PREVIEW_URL_ATTRIBUTE)
+        },
+        name: `${command.name}`,
+        source: CHE_TASK_TYPE,
+    };
+}
+
+export function getCommandAttribute(command: cheApi.workspace.Command, attrName: string): string | undefined {
+    if (!command.attributes) {
+        return undefined;
+    }
+
+    for (const attr in command.attributes) {
+        if (attr === attrName) {
+            return command.attributes[attr];
+        }
+    }
+    return undefined;
+}


### PR DESCRIPTION
### What does this PR do?
The changes the same as in the PR https://github.com/eclipse/che-theia/pull/355
We need to cherry-pick https://github.com/eclipse/che-theia/pull/367 and https://github.com/eclipse/che-theia/pull/373 after merge this PR.

Export configurations of `Che` tasks to config file
`commands` section of `devfile` can contain actions with `che` commands, for example:
```
commands:
- name: task-plugin:watch
  actions:
  - type: exec
    component: che-dev
    command: >
              yarn watch
    workdir: /projects/che-theia/plugins/task-plugin

- name: che-theia:build
  actions:
  - type: exec
    component: che-dev
    command: >
              yarn
    workdir: /projects/che-theia

```

The PR allows to convert them to theia tasks format and copy to config file of current workspace folder. After that they are available for running from UI: `Terminal` => `Run Task` menu or using `My Workspace` panel. So now we consider `tasks.json` file as one source where user can find all `che` tasks, edit them or add a new task. 
 
The current implementation allows to merge existed configurations from config file and configs from devfile. So user can add new configurations to config file or edit existed ones - the changes are stored to config file.  

### What issues does this PR fix or reference?
The PR to 7.0.0 branch: https://github.com/eclipse/che-theia/pull/355
https://github.com/eclipse/che/issues/13392
https://github.com/eclipse/che-theia/issues/248

- fixes for `Che` commands the issue: https://github.com/theia-ide/theia/issues/5064
We provided `che` commands as detected `theia` tasks. The issue was caused by changes in theia project (the description contains reference to the code) and was reproduced at moving a task from `detected` to `configured` section. The issue is not relevant as now `che` tasks are citizens of `tasks.json` file and available for editing without moving from `detected` to `configured` section.

- fixes for `Che` commands the issue: https://github.com/theia-ide/theia/issues/5067
  The issue was manifested when user run a task after configuring from `recently` used section. The original configuration was run, not overrided. It’s not relevant anymore - `che` tasks have only one source now - `tasks.json` file.

- fixes for `Che` commands the issue: https://github.com/theia-ide/theia/issues/4928
The issue was relevant for `detected` tasks, according to the changes of this PR we consider `che` commands as configured `theia` tasks, so it’s not relevant for `che` commands anymore.

### How to test
Use the component in your devfile

```
- 
    alias: theia-editor
    reference: >-
      https://raw.githubusercontent.com/RomanNikitenko/che-plugin-registry/master/v3/plugins/eclipse/che-theia/next/meta.yaml
    type: cheEditor

``` 
You can use `commands` section above as example to provide some tasks in your config file.
Try to run `che` commands using `Terminal` => `Run Task` menu, edit a task configuration in `tasks.json `file. 
Note: `My Workspace` panel is not working at the moment: https://github.com/eclipse/che/issues/13956

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
