### PR TITLE
[k8s plugin] fix Kubernetes: Run command

### DIFF
--- a/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/Dockerfile
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/Dockerfile
@@ -9,7 +9,7 @@
 #   Red Hat, Inc. - initial API and implementation
 
 FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:${BUILD_TAG} as endpoint
-FROM quay.io/buildah/upstream:v1.8.2
+FROM quay.io/buildah/stable:v1.9.0
 
 ENV KUBECTL_VERSION v1.14.1
 ENV HELM_VERSION v2.13.1
@@ -23,12 +23,15 @@ RUN curl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VER
     # set up local Helm configuration skipping Tiller installation
     helm init --client-only && \
     # 'which' utility is used by VS Code Kubernetes extension to find the binaries, e.g. 'kubectl'
-    dnf install -y which nodejs
+    # Install Buildah 1.9 since the image contains Buildah 1.8.2. See https://github.com/containers/buildah/issues/1687 for the details
+    dnf install -y which nodejs buildah-1.9.0
 
 COPY --from=endpoint /home/theia /home/theia
 COPY --from=endpoint /projects /projects
 COPY --from=endpoint /etc/passwd /etc/passwd
 COPY --from=endpoint /etc/group /etc/group
 COPY --from=endpoint /entrypoint.sh /entrypoint.sh
+
+RUN chmod g+w /home/theia
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/Dockerfile
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-1.0.0/Dockerfile
@@ -23,8 +23,7 @@ RUN curl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VER
     # set up local Helm configuration skipping Tiller installation
     helm init --client-only && \
     # 'which' utility is used by VS Code Kubernetes extension to find the binaries, e.g. 'kubectl'
-    # Install Buildah 1.9 since the image contains Buildah 1.8.2. See https://github.com/containers/buildah/issues/1687 for the details
-    dnf install -y which nodejs buildah-1.9.0
+    dnf install -y which nodejs
 
 COPY --from=endpoint /home/theia /home/theia
 COPY --from=endpoint /projects /projects


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Updates Dockerfile for the Kubernetes Tooling Che Plugin:
- buildah 1.8.2 -> 1.9.0
- adds g+w permissions to user home dir

### What issues does this PR fix or reference?
closes https://github.com/eclipse/che/issues/13537
also fixes https://github.com/eclipse/che/issues/13536
