### PR TITLE
Use 'ctrl+shift+`' key for new terminal in MacOS

### DIFF
--- a/extensions/eclipse-che-theia-terminal/src/browser/contribution/exec-terminal-contribution.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/contribution/exec-terminal-contribution.ts
@@ -23,6 +23,7 @@ import { REMOTE_TERMINAL_WIDGET_FACTORY_ID, RemoteTerminalWidget, RemoteTerminal
 import { filterRecipeContainers } from './terminal-command-filter';
 import URI from '@theia/core/lib/common/uri';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { isOSX } from '@theia/core/lib/common/os';
 
 export const NewTerminalInSpecificContainer = {
     id: 'terminal-in-specific-container:new',
@@ -194,7 +195,7 @@ export class ExecTerminalFrontendContribution extends TerminalFrontendContributi
         if (serverUrl) {
             registry.registerKeybinding({
                 command: NewTerminalInSpecificContainer.id,
-                keybinding: 'ctrlcmd+`'
+                keybinding: isOSX ? 'ctrl+shift+`' : 'ctrl+`'
             });
             this.registerTerminalKeybindings(registry);
         } else {


### PR DESCRIPTION
Signed-off-by: Yevhen Vydolob <yvydolob@redhat.com>

### What does this PR do?
Use 'ctrl+shift+`' key for new terminal in MacOS

