### PR TITLE
Update link to download ODO since the repo is moved

### DIFF
--- a/dockerfiles/remote-plugin-openshift-connector-0.0.17/Dockerfile
+++ b/dockerfiles/remote-plugin-openshift-connector-0.0.17/Dockerfile
@@ -11,6 +11,7 @@
 FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:${BUILD_TAG}
 
 ENV GLIBC_VERSION 2.29-r0
+ENV ODO_VERSION v0.0.19
 ENV OC_VERSION v3.11.0
 ENV OC_TAG 0cbc58b
 
@@ -20,7 +21,7 @@ RUN wget -O glibc-${GLIBC_VERSION}.apk https://github.com/andyshinn/alpine-pkg-g
     apk --update --allow-untrusted add glibc-${GLIBC_VERSION}.apk && \
     rm -f glibc-${GLIBC_VERSION}.apk && \
     # install ODO
-    wget -O /usr/local/bin/odo https://github.com/redhat-developer/odo/releases/download/v0.0.19/odo-linux-amd64 && \
+    wget -O /usr/local/bin/odo https://github.com/openshift/odo/releases/download/${ODO_VERSION}/odo-linux-amd64 && \
     chmod +x /usr/local/bin/odo && \
     # install OC
     wget -O- https://github.com/openshift/origin/releases/download/${OC_VERSION}/openshift-origin-client-tools-${OC_VERSION}-${OC_TAG}-linux-64bit.tar.gz | tar xvz -C /usr/local/bin --strip 1

--- a/dockerfiles/remote-plugin-openshift-connector-0.0.21/Dockerfile
+++ b/dockerfiles/remote-plugin-openshift-connector-0.0.21/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --no-cache bash && \
     apk --update --allow-untrusted add glibc-${GLIBC_VERSION}.apk && \
     rm -f glibc-${GLIBC_VERSION}.apk && \
     # install odo
-    wget -O /usr/local/bin/odo https://github.com/redhat-developer/odo/releases/download/${ODO_VERSION}/odo-linux-amd64 && \
+    wget -O /usr/local/bin/odo https://github.com/openshift/odo/releases/download/${ODO_VERSION}/odo-linux-amd64 && \
     chmod +x /usr/local/bin/odo && \
     # install oc
     wget -O- https://github.com/openshift/origin/releases/download/${OC_VERSION}/openshift-origin-client-tools-${OC_VERSION}-${OC_TAG}-linux-64bit.tar.gz | tar xvz -C /usr/local/bin --strip 1


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

The PR updates the links to download ODO for Openshift Connector Plugin image since the ODO repo has been recently moved from `redhat-developer` to `openshift` GitHub organization.
