### PR TITLE
Run `node-gyp install` before rebuilds.

### DIFF
--- a/dockerfiles/remote-plugin-dotnet-2.2.105/Dockerfile
+++ b/dockerfiles/remote-plugin-dotnet-2.2.105/Dockerfile
@@ -54,7 +54,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
     # Install typescript@2.9.2 and node-gyp
 
-    &&  yarn global add typescript@2.9.2 node-gyp
+    &&  yarn global add typescript@2.9.2 node-gyp \
+    &&  node-gyp install
 
 ENV HOME=/home/theia
 COPY --from=endpoint /home/theia /home/theia

--- a/dockerfiles/theia/e2e/Dockerfile
+++ b/dockerfiles/theia/e2e/Dockerfile
@@ -17,7 +17,7 @@ RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://ar
 RUN apt-get update && \
     apt-get install -y libx11-dev libxkbfile-dev sudo iproute2
 CMD /root/docker-run.sh
-RUN yarn global add typescript@2.9.2 node-gyp
+RUN yarn global add typescript@2.9.2 node-gyp && node-gyp install
 
 # Add cypress scripts and grab dependencies
 COPY src /root/


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Calls `node-gyp install` before rebuilds.
It will reduce build failures in `node-gyp rebuild`.
This patch doesn't care packages built with `theia/package.json`. I expect such builds will fixed by theia-ide/theia#5592

### What issues does this PR fix or reference?

fixes #283 (won't fix but will reduce.)