### PR TITLE
Fix preview URL panel to show the resolved URL instead of a server name.

### DIFF
--- a/plugins/task-plugin/resources/preview-urls-view.css
+++ b/plugins/task-plugin/resources/preview-urls-view.css
@@ -352,3 +352,7 @@ html, body {
     color: var(--theia-ui-font-color2);
     font-size: var(--theia-ui-font-size1);
 }
+
+.task-link {
+    color: var(--theia-accent-color1)
+}

--- a/plugins/task-plugin/src/preview/preview-url-open-service.ts
+++ b/plugins/task-plugin/src/preview/preview-url-open-service.ts
@@ -20,20 +20,18 @@ export class PreviewUrlOpenService {
 
     /**
      * Open the given URL to preview it in a separate browser's tab.
-     * Method also tries to resolve the variables in the given URL.
-     * @param previewURL a URL to go to
+     * @param url a URL to go to
      */
-    async previewExternally(previewURL: string): Promise<void> {
-        return this.preview(previewURL, EXTERNAL_COMMAND_ID);
+    async previewExternally(url: string): Promise<void> {
+        return this.preview(url, EXTERNAL_COMMAND_ID);
     }
 
     /**
      * Open the given URL to preview it in the embedded mini-browser.
-     * Method also tries to resolve the variables in the given URL.
-     * @param previewURL a URL to preview
+     * @param url a URL to preview
      */
-    async previewInternally(previewURL: string): Promise<void> {
-        return this.preview(previewURL, INTERNAL_COMMAND_ID);
+    async previewInternally(url: string): Promise<void> {
+        return this.preview(url, INTERNAL_COMMAND_ID);
     }
 
     /**
@@ -44,8 +42,7 @@ export class PreviewUrlOpenService {
         return await che.variables.resolve(previewURL);
     }
 
-    private async preview(previewURL: string, commandId: string): Promise<void> {
-        const url = await this.resolve(previewURL);
+    private async preview(url: string, commandId: string): Promise<void> {
         return theia.commands.executeCommand<void>(commandId, url);
     }
 }

--- a/plugins/task-plugin/src/preview/preview-url-open-service.ts
+++ b/plugins/task-plugin/src/preview/preview-url-open-service.ts
@@ -36,8 +36,16 @@ export class PreviewUrlOpenService {
         return this.preview(previewURL, INTERNAL_COMMAND_ID);
     }
 
+    /**
+     * Tries to resolve the variable in the given URL.
+     * @param previewURL an URL to resolve
+     */
+    async resolve(previewURL: string): Promise<string> {
+        return await che.variables.resolve(previewURL);
+    }
+
     private async preview(previewURL: string, commandId: string): Promise<void> {
-        const url = await che.variables.resolve(previewURL);
+        const url = await this.resolve(previewURL);
         return theia.commands.executeCommand<void>(commandId, url);
     }
 }

--- a/plugins/task-plugin/src/preview/previews-widget.ts
+++ b/plugins/task-plugin/src/preview/previews-widget.ts
@@ -84,8 +84,8 @@ export class PreviewUrlsWidget {
 
                     const server = `<a class="task-link" href="${url}" target="_blank">${url}</a>`;
                     const taskLabel = `<label>${cheTask.name}</label>`;
-                    const previewButton = `<button class='button' type="button" onclick="preview('${INTERNALLY_CHOICE}', '${previewUrl}')">${PREVIEW_BUTTON_NAME}</button>`;
-                    const goToButton = `<button class='button' type="button" onclick="preview('${EXTERNALLY_CHOICE}', '${previewUrl}')">${GO_TO_BUTTON_NAME}</button>`;
+                    const previewButton = `<button class='button' type="button" onclick="preview('${INTERNALLY_CHOICE}', '${url}')">${PREVIEW_BUTTON_NAME}</button>`;
+                    const goToButton = `<button class='button' type="button" onclick="preview('${EXTERNALLY_CHOICE}', '${url}')">${GO_TO_BUTTON_NAME}</button>`;
 
                     return this.renderTemplate(server, taskLabel, previewButton, goToButton);
                 }

--- a/plugins/task-plugin/src/preview/previews-widget.ts
+++ b/plugins/task-plugin/src/preview/previews-widget.ts
@@ -13,6 +13,7 @@ import * as path from 'path';
 import * as startPoint from '../task-plugin-backend';
 import { injectable, inject } from 'inversify';
 import { EXTERNALLY_CHOICE, INTERNALLY_CHOICE, PREVIEW_URL_TITLE } from './tasks-preview-manager';
+import { PreviewUrlOpenService } from './preview-url-open-service';
 
 const GO_TO_BUTTON_NAME = 'Go To';
 const PREVIEW_BUTTON_NAME = 'Preview';
@@ -34,7 +35,10 @@ export class PreviewUrlsWidget {
     @inject(PreviewUrlsWidgetOptions)
     private readonly options!: PreviewUrlsWidgetOptions;
 
-    getHtml(): string {
+    @inject(PreviewUrlOpenService)
+    private readonly previewUrlOpenService: PreviewUrlOpenService;
+
+    async getHtml(): Promise<string> {
         const context = startPoint.getContext();
         const scriptPathOnDisk = theia.Uri.file(path.join(context.extensionPath, 'resources', 'preview-urls.js'));
         const scriptUri = scriptPathOnDisk.with({ scheme: 'theia-resource' });
@@ -42,7 +46,7 @@ export class PreviewUrlsWidget {
         const cssPathOnDisk = theia.Uri.file(path.join(context.extensionPath, 'resources', 'preview-urls-view.css'));
         const cssUri = cssPathOnDisk.with({ scheme: 'theia-resource' });
 
-        const rendering = this.render();
+        const rendering = await this.render();
         return `<!DOCTYPE html>
                 <html lang="en">
                 <head>
@@ -62,26 +66,31 @@ export class PreviewUrlsWidget {
                 </html>`;
     }
 
-    private render(): string {
+    private async render(): Promise<string> {
         if (this.options.tasks.length < 1) {
             return `<div class='previews-placeholder'>${PLACEHOLDER}</div>`;
         }
 
-        const previews = this.renderPreviews().join('');
+        const previews = (await this.renderPreviews()).join('');
         return `<div class='previews-container'>${previews}</div>`;
     }
 
-    private renderPreviews(): Array<string> {
-        return this.options.tasks.map(cheTask => {
-            const previewUrl = cheTask.definition.previewUrl;
+    private async renderPreviews(): Promise<Array<string>> {
+        return await Promise.all(
+            this.options.tasks.map(
+                async (cheTask: theia.Task) => {
+                    const previewUrl = cheTask.definition.previewUrl;
+                    const url = await this.previewUrlOpenService.resolve(previewUrl);
 
-            const server = `<lable>${previewUrl}</label>`;
-            const taskLabel = `<lable>${cheTask.name}</label>`;
-            const previewButton = `<button class='button' type="button" onclick="preview('${INTERNALLY_CHOICE}', '${previewUrl}')">${PREVIEW_BUTTON_NAME}</button>`;
-            const goToButton = `<button class='button' type="button" onclick="preview('${EXTERNALLY_CHOICE}', '${previewUrl}')">${GO_TO_BUTTON_NAME}</button>`;
+                    const server = `<a class="task-link" href="${url}" target="_blank">${url}</a>`;
+                    const taskLabel = `<label>${cheTask.name}</label>`;
+                    const previewButton = `<button class='button' type="button" onclick="preview('${INTERNALLY_CHOICE}', '${previewUrl}')">${PREVIEW_BUTTON_NAME}</button>`;
+                    const goToButton = `<button class='button' type="button" onclick="preview('${EXTERNALLY_CHOICE}', '${previewUrl}')">${GO_TO_BUTTON_NAME}</button>`;
 
-            return this.renderTemplate(server, taskLabel, previewButton, goToButton);
-        });
+                    return this.renderTemplate(server, taskLabel, previewButton, goToButton);
+                }
+            )
+        );
     }
 
     private renderTemplate(server: string, taskLabel: string, previewButton: string, goToButton: string) {


### PR DESCRIPTION
### What does this PR do?

Currently, Preview URL panel's view is a bit confusing because it doesn't show any URL at all. This PR modifies it in the way to replace a server name with a resolved URL. In same way it updates a task preview notification which appears on top of Theia's page once a task is started.

#### Screenshots

 
<img width="1161" alt="Screenshot 2019-07-01 16 42 49" src="https://user-images.githubusercontent.com/16220722/60446117-f5e7b380-9c20-11e9-8880-ee2ebc44c544.png">

<img width="1161" alt="Screenshot 2019-07-01 16 44 39" src="https://user-images.githubusercontent.com/16220722/60446132-fda75800-9c20-11e9-84cc-4eea1ba45548.png">




### What issues does this PR fix or reference?

fix https://github.com/eclipse/che/issues/13357

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>