### PR TITLE
Updating codeowners for Che 7 endgame code reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global Owners
-* @evidolob
+* @evidolob @vparfonov @l0rd @rhopp
 
 # dockerfiles
 dockerfiles/** @benoitf @evidolob


### PR DESCRIPTION
Adding @l0rd @rhopp as global code reviewers as required by eclipse/che#13637