### PR TITLE
Include vscode git extension to default plugins

### DIFF
--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -39,7 +39,7 @@ ENV HOME=/home/theia-dev \
     THEIA_ELECTRON_SKIP_REPLACE_FFMPEG=true
 
 # Define package of the theia generator to use
-ARG THEIA_GENERATOR_PACKAGE=@eclipse-che/theia-generator@0.0.1-1559634039
+ARG THEIA_GENERATOR_PACKAGE=@eclipse-che/theia-generator@0.0.1-1562229933
 
 WORKDIR ${HOME}
 

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -123,6 +123,8 @@ RUN adduser -D -S -u 1001 -G root -h ${HOME} -s /bin/sh theia \
     && mkdir /node_modules \
     # Download yeoman generator plug-in
     && curl -L -o /default-theia-plugins/theia_yeoman_plugin.theia https://github.com/eclipse/theia-yeoman-plugin/releases/download/untagged-04f28ee329e479cc465b/theia_yeoman_plugin.theia \
+    # Download vscode git plug-in
+    && curl -L -o /default-theia-plugins/vscode-git-1.3.0.1.vsix https://github.com/che-incubator/vscode-git/releases/download/1.30.1/vscode-git-1.3.0.1.vsix \
     && for f in "${HOME}" "/etc/passwd" "/etc/group /node_modules /default-theia-plugins /projects"; do\
            sudo chgrp -R 0 ${f} && \
            sudo chmod -R g+rwX ${f}; \


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* Downloads vscode git extension package to default plugins directory.

* Update `theia-generator` version to one without native theia git extension (https://github.com/ws-skeleton/che-theia-generator/pull/28)
https://github.com/eclipse/che-theia/blob/ffbef321470fff581c1fd78a45b1decf4124ecc5/dockerfiles/theia-dev/Dockerfile#L42

### What issues does this PR fix or reference?
Is needed for https://github.com/eclipse/che/issues/11867
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
