### PR TITLE
Add "activationEvents" field, for all plugins

### DIFF
--- a/plugins/containers-plugin/package.json
+++ b/plugins/containers-plugin/package.json
@@ -10,6 +10,9 @@
     "src",
     "resources"
   ],
+  "activationEvents": [
+    "*"
+  ],
   "contributes": {
     "viewsContainers": {
       "right": [

--- a/plugins/factory-plugin/package.json
+++ b/plugins/factory-plugin/package.json
@@ -56,6 +56,9 @@
         ],
         "testURL": "http://localhost/"
     },
+    "activationEvents": [
+        "*"
+    ],
     "contributes": {
         "menus": {
             "editor/context": [

--- a/plugins/ports-plugin/package.json
+++ b/plugins/ports-plugin/package.json
@@ -11,6 +11,9 @@
     "src",
     "resources"
   ],
+  "activationEvents": [
+    "*"
+  ],
   "dependencies": {},
   "devDependencies": {
     "@eclipse-che/plugin": "latest",

--- a/plugins/ssh-plugin/package.json
+++ b/plugins/ssh-plugin/package.json
@@ -22,6 +22,9 @@
       "files": [
         "src"
       ],
+      "activationEvents": [
+        "*"
+      ],
       "devDependencies": {
         "@eclipse-che/api": "latest",
         "@eclipse-che/plugin": "0.0.1",

--- a/plugins/task-plugin/package.json
+++ b/plugins/task-plugin/package.json
@@ -19,6 +19,9 @@
   "files": [
     "src"
   ],
+  "activationEvents": [
+    "*"
+  ],
   "contributes": {
     "configuration": {
       "type": "object",

--- a/plugins/welcome-plugin/package.json
+++ b/plugins/welcome-plugin/package.json
@@ -11,6 +11,9 @@
     "src",
     "resources"
   ],
+  "activationEvents": [
+    "*"
+  ],
   "contributes": {
     "configuration": {
       "type": "object",


### PR DESCRIPTION
### What does this PR do?
Add "activationEvents" field, for all plugins
After this commits in Theia:
https://github.com/theia-ide/theia/commit/906c4febfe2f9bab4342ae323dd68c68af9b07ae
https://github.com/theia-ide/theia/commit/4466a72bd44a64576a40108659c81f3885bed1a2
https://github.com/theia-ide/theia/commit/b39a852192256e333ed6f4e0a13bd48d127123ae
Plugins wont start without `activationEvents` field in `package.json`, see [VSCode doc](https://code.visualstudio.com/api/references/activation-events)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13779



#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
