### PR TITLE
Fix plugins view

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-backend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-backend-module.ts
@@ -51,7 +51,8 @@ export default new ContainerModule(bind => {
         })
     ).inSingletonScope();
 
-    bind(ChePluginService).to(ChePluginServiceImpl).inSingletonScope();
+    bind(ChePluginServiceImpl).toSelf().inSingletonScope();
+    bind(ChePluginService).toService(ChePluginServiceImpl);
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler(CHE_PLUGIN_SERVICE_PATH, () =>
             ctx.container.get(ChePluginService)

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-backend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-backend-module.ts
@@ -51,8 +51,7 @@ export default new ContainerModule(bind => {
         })
     ).inSingletonScope();
 
-    // bind(ChePluginService).to(ChePluginServiceImpl).inSingletonScope();
-    bind(ChePluginService).toDynamicValue(ctx => new ChePluginServiceImpl(ctx.container)).inSingletonScope();
+    bind(ChePluginService).to(ChePluginServiceImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler(CHE_PLUGIN_SERVICE_PATH, () =>
             ctx.container.get(ChePluginService)

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -15,7 +15,7 @@ import {
     WorkspaceSettings
 } from '../common/che-protocol';
 
-import { injectable, interfaces } from 'inversify';
+import { injectable, inject } from 'inversify';
 import axios, { AxiosInstance } from 'axios';
 import { che as cheApi } from '@eclipse-che/api';
 import URI from '@theia/core/lib/common/uri';
@@ -44,15 +44,12 @@ export interface ChePluginMetadataInternal {
 @injectable()
 export class ChePluginServiceImpl implements ChePluginService {
 
+    @inject(CheApiService)
+    protected readonly cheApiService: CheApiService;
+
     private axiosInstance: AxiosInstance = axios;
 
-    private cheApiService: CheApiService;
-
     private defaultRegistry: ChePluginRegistry;
-
-    constructor(container: interfaces.Container) {
-        this.cheApiService = container.get(CheApiService);
-    }
 
     async getDefaultRegistry(): Promise<ChePluginRegistry> {
         if (this.defaultRegistry) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Should fix problem with Che Plugins view which sometimes appeared from time to time and difficult to debug. When I tried to find for the message, I received only one place in the code from which it could be printed.

https://github.com/theia-ide/theia/blob/master/packages/core/src/common/messaging/proxy-factory.ts#L168

The error occurred when calling `getWorkspacePlugins` method and it's not clear whether something wrong with the method or with the accessing `getWorkspacePlugins` method of ChePluginService through RPC.

This PR
 - aligns binding of `ChePluginService` with other services
 - checks the workspace configuration when getting a list of installed plugins

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/13747
https://github.com/eclipse/che/issues/13669
