### PR TITLE
Fix synchronization of the existing projects (#334)

### DIFF
--- a/plugins/factory-plugin/tests/projects.spec.ts
+++ b/plugins/factory-plugin/tests/projects.spec.ts
@@ -12,264 +12,229 @@ import { che as cheApi } from '@eclipse-che/api';
 import * as projecthelper from '../src/projects';
 
 describe('Devfile: Projects:', () => {
-    const CHE_REPOSITORY = 'https://github.com/eclipse/che.git';
-    const CHE_THEIA_REPOSITORY = 'https://github.com/eclipse/che-theia.git';
-    const BRANCH1 = 'che-13112';
-    const BRANCH2 = 'issue-12321';
-    const CUSTOM_PROJECT_PATH = 'theia/packages/che-theia';
+    describe('Testing basic functionality:', () => {
 
-    test('Should be able to create project if no projects defined', () => {
-        const projects: cheApi.workspace.devfile.Project[] = [];
+        test('Should be able to create project if no projects defined', () => {
+            const projects: cheApi.workspace.devfile.Project[] = [];
 
-        projecthelper.updateOrCreateGitProjectInDevfile(
-            projects,
-            'che',
-            CHE_REPOSITORY,
-            BRANCH1
-        );
+            projecthelper.updateOrCreateGitProjectInDevfile(
+                projects,
+                'che',
+                'https://github.com/eclipse/che.git',
+                'che-13112'
+            );
 
-        expect(projects.length).toBe(1);
-        expect(projects[0].name).toBe('che');
-        expect(projects[0].source.location).toBe(CHE_REPOSITORY);
-        expect(projects[0].source.branch).toBe(BRANCH1);
-    });
+            expect(projects.length).toBe(1);
+            expect(projects[0].name).toBe('che');
+            expect(projects[0].clonePath).toBe(undefined);
+            expect(projects[0].source.location).toBe('https://github.com/eclipse/che.git');
+            expect(projects[0].source.branch).toBe('che-13112');
+        });
 
-    test('Should be able to add project into existing projects list', () => {
-        const projects: cheApi.workspace.devfile.Project[] = [
-            {
-                name: 'che',
-                source: {
-                    type: 'git',
-                    location: CHE_REPOSITORY,
-                    branch: BRANCH1
+        test('Should be able to add project into existing projects list', () => {
+            const projects: cheApi.workspace.devfile.Project[] = [
+                {
+                    name: 'che',
+                    source: {
+                        type: 'git',
+                        location: 'https://github.com/eclipse/che.git',
+                        branch: 'che-13112'
+                    }
                 }
-            }
-        ];
+            ];
 
-        projecthelper.updateOrCreateGitProjectInDevfile(
-            projects,
-            'che-theia',
-            CHE_THEIA_REPOSITORY,
-            BRANCH2
-        );
+            projecthelper.updateOrCreateGitProjectInDevfile(
+                projects,
+                'che-theia',
+                'https://github.com/eclipse/che-theia.git',
+                'issue-12321'
+            );
 
-        expect(projects.length).toBe(2);
+            expect(projects.length).toBe(2);
+            expect(projects[0].name).toBe('che');
+            expect(projects[0].clonePath).toBe(undefined);
+            expect(projects[0].source.location).toBe('https://github.com/eclipse/che.git');
+            expect(projects[0].source.branch).toBe('che-13112');
+            expect(projects[1].name).toBe('che-theia');
+            expect(projects[1].clonePath).toBe(undefined);
+            expect(projects[1].source.location).toBe('https://github.com/eclipse/che-theia.git');
+            expect(projects[1].source.branch).toBe('issue-12321');
+        });
 
-        expect(projects[0].name).toBe('che');
-        expect(projects[0].source.location).toBe(CHE_REPOSITORY);
-        expect(projects[0].source.branch).toBe(BRANCH1);
-
-        expect(projects[1].name).toBe('che-theia');
-        expect(projects[1].source.location).toBe(CHE_THEIA_REPOSITORY);
-        expect(projects[1].source.branch).toBe(BRANCH2);
-    });
-
-    test('Should be able to delete existing project', () => {
-        const projects: cheApi.workspace.devfile.Project[] = [
-            {
-                name: 'che',
-                source: {
-                    type: 'git',
-                    location: CHE_REPOSITORY,
-                    branch: BRANCH1
-                }
-            },
-            {
-                name: 'che-theia',
-                source: {
-                    type: 'git',
-                    location: CHE_THEIA_REPOSITORY,
-                    branch: BRANCH2
-                }
-            }
-        ];
-
-        projecthelper.deleteProjectFromDevfile(
-            projects,
-            'che-theia'
-        );
-
-        expect(projects.length).toBe(1);
-
-        expect(projects[0].name).toBe('che');
-        expect(projects[0].source.location).toBe(CHE_REPOSITORY);
-        expect(projects[0].source.branch).toBe(BRANCH1);
-    });
-
-    test('Should be able to add project with custom location', () => {
-        const projects: cheApi.workspace.devfile.Project[] = [
-            {
-                name: 'che',
-                source: {
-                    type: 'git',
-                    location: CHE_REPOSITORY,
-                    branch: BRANCH1
-                }
-            }
-        ];
-
-        projecthelper.updateOrCreateGitProjectInDevfile(
-            projects,
-            CUSTOM_PROJECT_PATH,
-            CHE_THEIA_REPOSITORY,
-            BRANCH2
-        );
-
-        expect(projects.length).toBe(2);
-
-        expect(projects[0].name).toBe('che');
-        expect(projects[0].source.location).toBe(CHE_REPOSITORY);
-        expect(projects[0].source.branch).toBe(BRANCH1);
-
-        expect(projects[1].name).toBe('che-theia');
-        expect(projects[1].clonePath).toBe(CUSTOM_PROJECT_PATH);
-        expect(projects[1].source.location).toBe(CHE_THEIA_REPOSITORY);
-        expect(projects[1].source.branch).toBe(BRANCH2);
-    });
-
-    test('Should be able to delete project with custom location', () => {
-        const projects: cheApi.workspace.devfile.Project[] = [
-            {
-                name: 'che',
-                source: {
-                    type: 'git',
-                    location: CHE_REPOSITORY,
-                    branch: BRANCH1
-                }
-            },
-            {
-                name: 'che-theia',
-                clonePath: CUSTOM_PROJECT_PATH,
-                source: {
-                    type: 'git',
-                    location: CHE_THEIA_REPOSITORY,
-                    branch: BRANCH2
-                }
-            }
-        ];
-
-        projecthelper.deleteProjectFromDevfile(
-            projects,
-            CUSTOM_PROJECT_PATH
-        );
-
-        expect(projects.length).toBe(1);
-
-        expect(projects[0].name).toBe('che');
-        expect(projects[0].source.location).toBe(CHE_REPOSITORY);
-        expect(projects[0].source.branch).toBe(BRANCH1);
-    });
-});
-
-describe('Workspace config: Testing projects updater when file is triggered', () => {
-
-    test('update and create project', async () => {
-        const projects: cheApi.workspace.ProjectConfig[] = [
-            {
-                'name': 'theia',
-                'attributes': {},
-                'source': {
-                    'location': 'https://github.com/theia-ide/theia.git',
-                    'type': 'git',
-                    'parameters': {}
+        test('Should be able to delete existing project', () => {
+            const projects: cheApi.workspace.devfile.Project[] = [
+                {
+                    name: 'che',
+                    source: {
+                        type: 'git',
+                        location: 'https://github.com/eclipse/che.git',
+                        branch: 'che-13112'
+                    }
                 },
-                'path': '/theia',
-                'description': '',
-                'mixins': [],
-                'problems': []
-            },
-            {
-                'links': [],
-                'name': 'che-theia-factory-extension',
-                'attributes': {},
-                'type': 'blank',
-                'source': {
-                    'location': 'https://github.com/eclipse/che-theia-factory-extension.git',
-                    'type': 'git',
-                    'parameters': {
+                {
+                    name: 'che-theia',
+                    source: {
+                        type: 'git',
+                        location: 'https://github.com/eclipse/che-theia.git',
+                        branch: 'issue-12321'
+                    }
+                }
+            ];
+
+            projecthelper.deleteProjectFromDevfile(
+                projects,
+                'che-theia'
+            );
+
+            expect(projects.length).toBe(1);
+            expect(projects[0].name).toBe('che');
+            expect(projects[0].source.location).toBe('https://github.com/eclipse/che.git');
+            expect(projects[0].source.branch).toBe('che-13112');
+        });
+
+        test('Should be able to add project with custom location', () => {
+            const projects: cheApi.workspace.devfile.Project[] = [
+                {
+                    name: 'che',
+                    source: {
+                        type: 'git',
+                        location: 'https://github.com/eclipse/che.git',
+                        branch: 'che-13112'
+                    }
+                }
+            ];
+
+            projecthelper.updateOrCreateGitProjectInDevfile(
+                projects,
+                'theia/packages/che-theia',
+                'https://github.com/eclipse/che-theia.git',
+                'issue-12321'
+            );
+
+            expect(projects.length).toBe(2);
+            expect(projects[0].name).toBe('che');
+            expect(projects[0].clonePath).toBe(undefined);
+            expect(projects[0].source.location).toBe('https://github.com/eclipse/che.git');
+            expect(projects[0].source.branch).toBe('che-13112');
+            expect(projects[1].name).toBe('che-theia');
+            expect(projects[1].clonePath).toBe('theia/packages/che-theia');
+            expect(projects[1].source.location).toBe('https://github.com/eclipse/che-theia.git');
+            expect(projects[1].source.branch).toBe('issue-12321');
+        });
+
+        test('Should be able to delete project with custom location', () => {
+            const projects: cheApi.workspace.devfile.Project[] = [
+                {
+                    name: 'che',
+                    source: {
+                        type: 'git',
+                        location: 'https://github.com/eclipse/che.git',
+                        branch: 'che-13112'
+                    }
+                },
+                {
+                    name: 'che-theia',
+                    clonePath: 'theia/packages/che-theia',
+                    source: {
+                        type: 'git',
+                        location: 'https://github.com/eclipse/che-theia.git',
+                        branch: 'issue-12321'
+                    }
+                }
+            ];
+
+            projecthelper.deleteProjectFromDevfile(
+                projects,
+                'theia/packages/che-theia'
+            );
+
+            expect(projects.length).toBe(1);
+            expect(projects[0].name).toBe('che');
+            expect(projects[0].source.location).toBe('https://github.com/eclipse/che.git');
+            expect(projects[0].source.branch).toBe('che-13112');
+        });
+    });
+
+    describe('Testing projects updater when file is triggered:', () => {
+        test('update and create project', async () => {
+            const projects: cheApi.workspace.devfile.Project[] = [
+                {
+                    'name': 'theia',
+                    'source': {
+                        'type': 'git',
+                        'location': 'https://github.com/theia-ide/theia.git'
+                    }
+                },
+                {
+                    'name': 'che-theia-factory-extension',
+                    'source': {
+                        'type': 'git',
+                        'location': 'https://github.com/eclipse/che-theia-factory-extension.git',
                         'branch': 'master',
                         'tag': 'v42.0'
                     }
-                },
-                'path': '/che-theia-factory-extension',
-                'description': '',
-                'mixins': [],
-                'problems': []
-            }
-        ];
-        expect(projects[0].source.location).toBe('https://github.com/theia-ide/theia.git');
-        expect(projects[1].source.location).toBe('https://github.com/eclipse/che-theia-factory-extension.git');
+                }
+            ];
+            expect(projects[0].source.location).toBe('https://github.com/theia-ide/theia.git');
+            expect(projects[1].source.location).toBe('https://github.com/eclipse/che-theia-factory-extension.git');
 
-        projecthelper.updateOrCreateGitProjectInWorkspaceConfig(projects,
-                                               '/che-theia-factory-extension',
-                                               'https://github.com/sunix/che-theia-factory-extension.git',
-                                               'wip-sunix');
-        expect(projects[1].source.location).toBe('https://github.com/sunix/che-theia-factory-extension.git');
-        expect(projects[1].source.parameters['branch']).toBe('wip-sunix');
-        expect(projects[1].source.parameters['tag']).toBe(undefined);
+            projecthelper.updateOrCreateGitProjectInDevfile(projects,
+                                                   'che-theia-factory-extension',
+                                                   'https://github.com/sunix/che-theia-factory-extension.git',
+                                                   'wip-sunix');
+            expect(projects[1].source.location).toBe('https://github.com/sunix/che-theia-factory-extension.git');
+            expect(projects[1].source['branch']).toBe('wip-sunix');
+            expect(projects[1].source['tag']).toBe(undefined);
 
-        projecthelper.updateOrCreateGitProjectInWorkspaceConfig(projects,
-                                               '/che/che-theia-factory-extension',
-                                               'https://github.com/sunix/che-theia-factory-extension.git',
-                                               'wip-theia');
-        expect(projects[2].source.location).toBe('https://github.com/sunix/che-theia-factory-extension.git');
-        expect(projects[2].source.parameters['branch']).toBe('wip-theia');
-        expect(projects[2].name).toBe('che-theia-factory-extension');
-    });
+            projecthelper.updateOrCreateGitProjectInDevfile(projects,
+                                                   '/che/che-theia-factory-extension',
+                                                   'https://github.com/sunix/che-theia-factory-extension.git',
+                                                   'wip-theia');
+            expect(projects[2].source.location).toBe('https://github.com/sunix/che-theia-factory-extension.git');
+            expect(projects[2].source['branch']).toBe('wip-theia');
+            expect(projects[2].name).toBe('che-theia-factory-extension');
+        });
 
-    test('delete project', async () => {
-        const projects: cheApi.workspace.ProjectConfig[] = [
-            {
-                'name': 'theia',
-                'attributes': {},
-                'source': {
-                    'location': 'https://github.com/theia-ide/theia.git',
-                    'type': 'git',
-                    'parameters': {}
-                },
-                'path': '/theia',
-                'description': '',
-                'mixins': [],
-                'problems': []
-            },
-            {
-                'links': [],
-                'name': 'che-theia-factory-extension',
-                'attributes': {},
-                'type': 'blank',
-                'source': {
-                    'location': 'https://github.com/eclipse/che-theia-factory-extension.git',
-                    'type': 'git',
-                    'parameters': {
-                        'branch': 'master'
+        test('delete project', async () => {
+            const projects: cheApi.workspace.devfile.Project[] = [
+                {
+                    'name': 'theia',
+                    'source': {
+                        'type': 'git',
+                        'location': 'https://github.com/theia-ide/theia.git'
                     }
                 },
-                'path': '/che-theia-factory-extension',
-                'description': '',
-                'mixins': [],
-                'problems': []
-            }
-        ];
-        expect(projects[0].source.location).toBe('https://github.com/theia-ide/theia.git');
-        expect(projects[1].source.location).toBe('https://github.com/eclipse/che-theia-factory-extension.git');
+                {
+                    'name': 'che-theia-factory-extension',
+                    'source': {
+                        'type': 'git',
+                        'location': 'https://github.com/eclipse/che-theia-factory-extension.git',
+                        'branch': 'master',
+                        'tag': 'v42.0'
+                    }
+                }
+            ];
+            expect(projects[0].source.location).toBe('https://github.com/theia-ide/theia.git');
+            expect(projects[1].source.location).toBe('https://github.com/eclipse/che-theia-factory-extension.git');
 
-        projecthelper.deleteProjectFromWorkspaceConfig(projects, '/che-theia-factory-extension');
-        expect(projects.length).toBe(1);
-        expect(projects[0].source.location).toBe('https://github.com/theia-ide/theia.git');
+            projecthelper.deleteProjectFromDevfile(projects, 'che-theia-factory-extension');
+            expect(projects.length).toBe(1);
+            expect(projects[0].source.location).toBe('https://github.com/theia-ide/theia.git');
 
-        projecthelper.deleteProjectFromWorkspaceConfig(projects, '/theia');
-        expect(projects.length).toBe(0);
+            projecthelper.deleteProjectFromDevfile(projects, 'theia');
+            expect(projects.length).toBe(0);
 
-        projecthelper.updateOrCreateGitProjectInWorkspaceConfig(projects,
-                                               '/che/che-theia-factory-extension',
-                                               'https://github.com/sunix/che-theia-factory-extension.git',
-                                               'wip-theia');
-        expect(projects.length).toBe(1);
-        expect(projects[0].source.location).toBe('https://github.com/sunix/che-theia-factory-extension.git');
-        expect(projects[0].source.parameters['branch']).toBe('wip-theia');
-        expect(projects[0].name).toBe('che-theia-factory-extension');
+            projecthelper.updateOrCreateGitProjectInDevfile(projects,
+                                                   'che/che-theia-factory-extension',
+                                                   'https://github.com/sunix/che-theia-factory-extension.git',
+                                                   'wip-theia');
+            expect(projects.length).toBe(1);
+            expect(projects[0].source.location).toBe('https://github.com/sunix/che-theia-factory-extension.git');
+            expect(projects[0].source.branch).toBe('wip-theia');
+            expect(projects[0].name).toBe('che-theia-factory-extension');
 
-        projecthelper.deleteProjectFromWorkspaceConfig(projects, '/che/che-theia-factory-extension');
-        expect(projects.length).toBe(0);
+            projecthelper.deleteProjectFromDevfile(projects, 'che/che-theia-factory-extension');
+            expect(projects.length).toBe(0);
+        });
     });
 });


### PR DESCRIPTION
* CHE-13621 fix synchronization of the existing projects

Signed-off-by: Oleksii Orel <oorel@redhat.com>

* fix project.clonePath only defined if different from project.name

Signed-off-by: Sun Tan <sutan@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add new tests for the project synchronization. Fix implementation.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13621