### PR TITLE
Display non-tooling containers and add buton to display all containers

### DIFF
--- a/plugins/task-plugin/src/machine/machines-picker.ts
+++ b/plugins/task-plugin/src/machine/machines-picker.ts
@@ -24,7 +24,7 @@ export class MachinesPicker {
     protected readonly cheWorkspaceClient!: CheWorkspaceClient;
 
     async pick(): Promise<string> {
-        return await this.doPick(true);
+        return this.doPick(true);
     }
 
     protected async doPick(hideToolingContainers: boolean): Promise<string> {


### PR DESCRIPTION


<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This changes proposal filters containers to display non-tooling at first step and adds additional item into list to load all containers, including tooling.

![machine-picker](https://user-images.githubusercontent.com/1968177/61531672-3a9c8880-aa30-11e9-92ad-c11ad0070842.gif)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13390

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
Provide curated list of containers to run tasks
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
