### PR TITLE
Add missing publisher field and set it to 'Eclipse Che'

### DIFF
--- a/plugins/containers-plugin/package.json
+++ b/plugins/containers-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-che/theia-containers-plugin",
-  "publisher": "theia",
+  "publisher": "Eclipse Che",
   "keywords": [
     "theia-plugin"
   ],

--- a/plugins/factory-plugin/package.json
+++ b/plugins/factory-plugin/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@eclipse-che/theia-factory-plugin",
+    "publisher": "Eclipse Che",
     "keywords": [
         "theia-plugin"
     ],

--- a/plugins/ssh-plugin/package.json
+++ b/plugins/ssh-plugin/package.json
@@ -1,5 +1,6 @@
 {
       "name": "@eclipse-che/theia-ssh-plugin",
+      "publisher": "Eclipse Che",
       "keywords": [
         "theia-plugin"
       ],

--- a/plugins/task-plugin/package.json
+++ b/plugins/task-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "task-plugin",
-  "publisher": "theia",
+  "publisher": "Eclipse Che",
   "keywords": [
     "theia-plugin"
   ],


### PR DESCRIPTION
### What does this PR do?
Add missing publisher field and set it to 'Eclipse Che'
According to this commit
https://github.com/theia-ide/theia/commit/6021d795d61eafb214b234288f1568cae0cfa9f5
`publisher` field is mandatory.
### What issues does this PR fix or reference?
should fix https://github.com/eclipse/che/issues/13944
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->