### PR TITLE
Fix permissions on $GOPATH folder

### DIFF
--- a/dockerfiles/remote-plugin-go-1.10.7/Dockerfile
+++ b/dockerfiles/remote-plugin-go-1.10.7/Dockerfile
@@ -42,7 +42,7 @@ RUN set -eux; \
 		/usr/local/go/pkg/obj \
 	; \
     export GOPATH="/go"; \
-    mkdir -p "$GOPATH/src" "$GOPATH/bin" "$GOPATH/pkg" && chmod -R 777 "$GOPATH"; \
+    mkdir -p "$GOPATH/src" "$GOPATH/bin" "$GOPATH/pkg"; \
     export PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"; \
     go get -u -v github.com/ramya-rao-a/go-outline && \
     go get -u -v github.com/acroca/go-symbols &&  \
@@ -63,7 +63,8 @@ RUN set -eux; \
     go get -u -v github.com/davidrjenni/reftools/cmd/fillstruct && \
     go get -u -v github.com/alecthomas/gometalinter && \
     go get -u -v github.com/go-delve/delve/cmd/dlv && \
-    gometalinter --install \
+    gometalinter --install && \
+	chmod -R 777 "$GOPATH" \
     ; \
 	apk del .build-deps \
     ; \


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Set permissions for `/go` folder when all dependencies are installed.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13823

<!-- #### Changelog -->
