### PR TITLE
remove 'latest' tag from '7.0.0-next' images

### DIFF
--- a/docker_image_build.include
+++ b/docker_image_build.include
@@ -10,11 +10,11 @@
 set -e
 set -u
 
-IMAGE_TAG="latest"
+IMAGE_TAG="7.0.0-next"
 THEIA_VERSION="che-7.0.0"
 THEIA_BRANCH="che-7.0.0"
 THEIA_GIT_REFS="refs\\/heads\\/che-7.0.0"
-THEIA_DOCKER_IMAGE_VERSION="7.0.0-next"
+THEIA_DOCKER_IMAGE_VERSION=
 
 # KEEP RIGHT ORDER!!!
 PR_IMAGES=(


### PR DESCRIPTION
### What does this PR do?
remove 'latest' tag from '7.0.0-next' images, we mark `latest` tag only release images i.e. `7.0.0-rc-4.0`
