### PR TITLE
Fix reloading Che Theia within iframe

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
@@ -284,9 +284,7 @@ export class ChePluginManager {
 
             try {
                 await this.cheApiService.stop();
-                setTimeout(() => {
-                    window.location.reload();
-                }, 1000);
+                window.location.href = document.referrer;
             } catch (error) {
                 this.messageService.error(`Unable to restart your workspace. ${error.message}`);
             }


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes ability for Che Plugin extension to reload the IDE in iframe when it's necessary, i.e. after a Che Plugin has been installed.

### What issues does this PR fix or reference?

fix https://github.com/eclipse/che/issues/13912
