### PR TITLE
Fix README.md for task-plugin.

### DIFF
--- a/plugins/task-plugin/README.md
+++ b/plugins/task-plugin/README.md
@@ -21,7 +21,7 @@ The format of a Che task is the following:
     "command": "",
     "target": {
         "workspaceId": "",
-        "machineName": "",
+        "containerName": "",
         "workingDir": ""
     },
     "previewUrl": ""


### PR DESCRIPTION
### What does this PR do?
In the task plugin machineName was changed to containerName, let's do the same for README.md file.
