### PR TITLE
Fix che-theia/generator tests inside container without git user.name and user.email

### DIFF
--- a/generator/tests/init-sources/init-sources.spec.ts
+++ b/generator/tests/init-sources/init-sources.spec.ts
@@ -65,8 +65,8 @@ describe("Test Extensions", () => {
 
     function initGit(path: string) {
         cp.execSync('git init', { cwd: path });
-        cp.execSync('git config --local user.name "test test"', { cwd: path });
-        cp.execSync('git config --local user.email example.com', { cwd: path });
+        cp.execSync('git config --local user.name "test user"', { cwd: path });
+        cp.execSync('git config --local user.email user@example.com', { cwd: path });
         cp.execSync(`git add ${path}`, { cwd: path });
         cp.execSync(`git commit -m "Init repo"`, { cwd: path });
 

--- a/generator/tests/init-sources/init-sources.spec.ts
+++ b/generator/tests/init-sources/init-sources.spec.ts
@@ -66,7 +66,7 @@ describe("Test Extensions", () => {
     function initGit(path: string) {
         cp.execSync('git init', { cwd: path });
         cp.execSync('git config --local user.name "test test"', { cwd: path });
-        cp.execSync('git config --local user.email test@gmail.com', { cwd: path });
+        cp.execSync('git config --local user.email example.com', { cwd: path });
         cp.execSync(`git add ${path}`, { cwd: path });
         cp.execSync(`git commit -m "Init repo"`, { cwd: path });
 

--- a/generator/tests/init-sources/init-sources.spec.ts
+++ b/generator/tests/init-sources/init-sources.spec.ts
@@ -65,6 +65,8 @@ describe("Test Extensions", () => {
 
     function initGit(path: string) {
         cp.execSync('git init', { cwd: path });
+        cp.execSync('git config --local user.name "test test"', { cwd: path });
+        cp.execSync('git config --local user.email test@gmail.com', { cwd: path });
         cp.execSync(`git add ${path}`, { cwd: path });
         cp.execSync(`git commit -m "Init repo"`, { cwd: path });
 


### PR DESCRIPTION
### What does this PR do?
Fix che-theia/generator tests inside container without git user.name and user.email

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14056

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>


