### PR TITLE
Fix yarn 'watch' command for che-theia/examples/assembly

### DIFF
--- a/generator/src/templates/assembly-package.mst
+++ b/generator/src/templates/assembly-package.mst
@@ -55,7 +55,7 @@
     "clean": "theia clean && rimraf errorShots",
     "build": "theia build --mode production --config cdn/webpack.config.js --env.cdn=./cdn.json --env.monacopkg={{ monacopkg }} --env.monacohtmlcontribpkg={{ monacohtmlcontribpkg }} --env.monacocsscontribpkg={{ monacocsscontribpkg }} && yarn run override-vs-loader",
     "override-vs-loader": "override-vs-loader",
-    "watch": "yarn build --watch",
+    "watch": "concurrently -n compile,bundle \"theiaext watch --preserveWatchOutput\" \"theia build --watch --mode development\"",
     "start": "theia start",
     "start:debug": "yarn start --log-level=debug",
     "test": "wdio wdio.conf.js",


### PR DESCRIPTION
### What does this PR do?
Fix yarn 'watch' command for che-theia/examples/assembly

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13124

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>