### PR TITLE
Use current che-theia sources for docker image build

### DIFF
--- a/dockerfiles/theia-dev/.gitignore
+++ b/dockerfiles/theia-dev/.gitignore
@@ -1,0 +1,1 @@
+generator/

--- a/dockerfiles/theia-dev/.gitignore
+++ b/dockerfiles/theia-dev/.gitignore
@@ -1,1 +1,2 @@
 generator/
+.Dockerfile

--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -39,8 +39,7 @@ ENV HOME=/home/theia-dev \
     THEIA_ELECTRON_SKIP_REPLACE_FFMPEG=true
 
 # Define package of the theia generator to use
-#ARG THEIA_GENERATOR_PACKAGE=@eclipse-che/theia-generator@0.0.1-1564062477
-COPY generator/eclipse-che-theia-generator-v0.0.1.tgz ${HOME}/eclipse-che-theia-generator.tgz
+COPY generator/eclipse-che-theia-generator.tgz ${HOME}/eclipse-che-theia-generator.tgz
 
 WORKDIR ${HOME}
 

--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -67,8 +67,8 @@ RUN npm config set prefix "${HOME}/.npm-global" && \
     echo '{"optOut": true}' > ${HOME}/.config/insight-nodejs/insight-yo.json && \
     # Change permissions to let any arbitrary user
     for f in "${HOME}" "/etc/passwd" "/etc/group" "/projects"; do \
-    echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
-    chmod -R g+rwX ${f}; \
+        echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
+        chmod -R g+rwX ${f}; \
     done
 
 WORKDIR "/projects"

--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -39,7 +39,8 @@ ENV HOME=/home/theia-dev \
     THEIA_ELECTRON_SKIP_REPLACE_FFMPEG=true
 
 # Define package of the theia generator to use
-ARG THEIA_GENERATOR_PACKAGE=@eclipse-che/theia-generator@0.0.1-1562767926
+#ARG THEIA_GENERATOR_PACKAGE=@eclipse-che/theia-generator@0.0.1-1564062477
+COPY generator/eclipse-che-theia-generator-v0.0.1.tgz ${HOME}/eclipse-che-theia-generator.tgz
 
 WORKDIR ${HOME}
 
@@ -50,7 +51,7 @@ EXPOSE 3000 3030
 RUN npm config set prefix "${HOME}/.npm-global" && \
     echo "--global-folder \"${HOME}/.yarn-global\"" > ${HOME}/.yarnrc && \
     # add eclipse che theia generator
-    yarn global add yo @theia/generator-plugin@0.0.1-1540209403 ${THEIA_GENERATOR_PACKAGE} && \
+    yarn global add yo @theia/generator-plugin@0.0.1-1540209403 file:${HOME}/eclipse-che-theia-generator.tgz && \
     # Generate .passwd.template \
     cat /etc/passwd | \
     sed s#root:x.*#theia-dev:x:\${USER_ID}:\${GROUP_ID}::${HOME}:/bin/bash#g \
@@ -67,8 +68,8 @@ RUN npm config set prefix "${HOME}/.npm-global" && \
     echo '{"optOut": true}' > ${HOME}/.config/insight-nodejs/insight-yo.json && \
     # Change permissions to let any arbitrary user
     for f in "${HOME}" "/etc/passwd" "/etc/group" "/projects"; do \
-        echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
-        chmod -R g+rwX ${f}; \
+    echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
+    chmod -R g+rwX ${f}; \
     done
 
 WORKDIR "/projects"

--- a/dockerfiles/theia-dev/build.sh
+++ b/dockerfiles/theia-dev/build.sh
@@ -21,12 +21,12 @@ fi
 #in mac os 'cp' cannot create destination dir, so create it first
 mkdir ${LOCAL_ASSEMBLY_DIR}
 
-FILE="${base_dir}"/../../generator/eclipse-che-theia-generator-v0.0.1.tgz
+FILE="${base_dir}"/../../generator/eclipse-che-theia-generator.tgz
 if [ -f "$FILE" ]; then
     cp "${FILE}" "${LOCAL_ASSEMBLY_DIR}"
 else 
     echo "$FILE does not exist, trying to generate..."
-    cd "${base_dir}"/../../generator/ && yarn prepare && yarn pack
+    cd "${base_dir}"/../../generator/ && yarn prepare && yarn pack --filename eclipse-che-theia-generator.tgz
     cp "${FILE}" "${LOCAL_ASSEMBLY_DIR}"
 fi
 

--- a/dockerfiles/theia-dev/build.sh
+++ b/dockerfiles/theia-dev/build.sh
@@ -10,6 +10,26 @@
 base_dir=$(cd "$(dirname "$0")"; pwd)
 . "${base_dir}"/../build.include
 
+
+DIR=$(cd "$(dirname "$0")"; pwd)
+LOCAL_ASSEMBLY_DIR="${DIR}"/generator
+
+if [ -d "${LOCAL_ASSEMBLY_DIR}" ]; then
+  rm -r "${LOCAL_ASSEMBLY_DIR}"
+fi
+
+#in mac os 'cp' cannot create destination dir, so create it first
+mkdir ${LOCAL_ASSEMBLY_DIR}
+
+FILE="${base_dir}"/../../generator/eclipse-che-theia-generator-v0.0.1.tgz
+if [ -f "$FILE" ]; then
+    cp "${FILE}" "${LOCAL_ASSEMBLY_DIR}"
+else 
+    echo "$FILE does not exist, trying to generate..."
+    cd "${base_dir}"/../../generator/ && yarn prepare && yarn pack
+    cp "${FILE}" "${LOCAL_ASSEMBLY_DIR}"
+fi
+
 init --name:theia-dev "$@"
 build
 if ! skip_tests; then

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -64,7 +64,6 @@ ARG CDN_PREFIX=""
 ARG MONACO_CDN_PREFIX=""
 WORKDIR ${HOME}/theia-source-code
 
-#COPY che-theia/che-theia-init-sources.yml ${HOME}/che-theia-init-sources.yml
 COPY che-theia/che-theia.tar.gz ${HOME}/che-theia.tar.gz
 RUN mkdir ${HOME}/theia-source-code/che-theia && tar -xf ${HOME}/che-theia.tar.gz -C ${HOME}/theia-source-code/che-theia
 

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -68,9 +68,6 @@ WORKDIR ${HOME}/theia-source-code
 COPY che-theia/che-theia.tar.gz ${HOME}/che-theia.tar.gz
 RUN mkdir ${HOME}/theia-source-code/che-theia && tar -xf ${HOME}/che-theia.tar.gz -C ${HOME}/theia-source-code/che-theia
 
-#invalidate cache for che-theia extensions
-ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/eclipse/che-theia/git/${GIT_REF} /tmp/this_branch_info.json
-
 RUN che:theia init -c ${HOME}/theia-source-code/che-theia/che-theia-init-sources.yml --alias https://github.com/eclipse/che-theia=${HOME}/theia-source-code/che-theia
 
 RUN che:theia cdn --theia="${CDN_PREFIX}" --monaco="${MONACO_CDN_PREFIX}"

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -64,12 +64,14 @@ ARG CDN_PREFIX=""
 ARG MONACO_CDN_PREFIX=""
 WORKDIR ${HOME}/theia-source-code
 
-COPY che-theia/che-theia-init-sources.yml ${HOME}/che-theia-init-sources.yml
+#COPY che-theia/che-theia-init-sources.yml ${HOME}/che-theia-init-sources.yml
+COPY che-theia/che-theia.tar.gz ${HOME}/che-theia.tar.gz
+RUN mkdir ${HOME}/theia-source-code/che-theia && tar -xf ${HOME}/che-theia.tar.gz -C ${HOME}/theia-source-code/che-theia
 
 #invalidate cache for che-theia extensions
 ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/eclipse/che-theia/git/${GIT_REF} /tmp/this_branch_info.json
 
-RUN che:theia init -c ${HOME}/che-theia-init-sources.yml
+RUN che:theia init -c ${HOME}/theia-source-code/che-theia/che-theia-init-sources.yml --alias https://github.com/eclipse/che-theia=${HOME}/theia-source-code/che-theia
 
 RUN che:theia cdn --theia="${CDN_PREFIX}" --monaco="${MONACO_CDN_PREFIX}"
 
@@ -78,9 +80,6 @@ RUN yarn
 
 # Run into production mode
 RUN che:theia production
-
-# FIX ME, temporary fix to restore build
-RUN cd che/che-theia && git reset --hard
 
 # Compile plugins
 RUN cd plugins && ./foreach_yarn

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -64,9 +64,10 @@ ARG CDN_PREFIX=""
 ARG MONACO_CDN_PREFIX=""
 WORKDIR ${HOME}/theia-source-code
 
-COPY che-theia/che-theia.tar.gz ${HOME}/che-theia.tar.gz
-RUN mkdir ${HOME}/theia-source-code/che-theia && tar -xf ${HOME}/che-theia.tar.gz -C ${HOME}/theia-source-code/che-theia
+#add che-theia repository content
+ADD che-theia/che-theia.tar.gz ${HOME}/theia-source-code/che-theia
 
+# run che:theia init command and alias che-theia repository to use local sources insted of cloning
 RUN che:theia init -c ${HOME}/theia-source-code/che-theia/che-theia-init-sources.yml --alias https://github.com/eclipse/che-theia=${HOME}/theia-source-code/che-theia
 
 RUN che:theia cdn --theia="${CDN_PREFIX}" --monaco="${MONACO_CDN_PREFIX}"

--- a/dockerfiles/theia/build.sh
+++ b/dockerfiles/theia/build.sh
@@ -21,7 +21,7 @@ fi
 mkdir ${LOCAL_ASSEMBLY_DIR}
 
 echo "Compresing 'che-theia' --> ${LOCAL_ASSEMBLY_DIR}/che-theia.tar.gz"
-git ls-files -z -c -o --exclude-standard | xargs -0 tar rvf ${LOCAL_ASSEMBLY_DIR}/che-theia.tar.gz
+cd "${DIR}"/../.. && git ls-files -z -c -o --exclude-standard | xargs -0 tar rvf ${LOCAL_ASSEMBLY_DIR}/che-theia.tar.gz
 
 init --name:theia "$@"
 

--- a/dockerfiles/theia/build.sh
+++ b/dockerfiles/theia/build.sh
@@ -20,8 +20,8 @@ fi
 #in mac os 'cp' cannot create destination dir, so create it first
 mkdir ${LOCAL_ASSEMBLY_DIR}
 
-echo "Copying ${base_dir}/../../che-theia-init-sources.yml --> ${LOCAL_ASSEMBLY_DIR}/che-theia-init-sources.yml"
-cp "${base_dir}/../../che-theia-init-sources.yml" "${LOCAL_ASSEMBLY_DIR}/"
+echo "Compresing 'che-theia' --> ${LOCAL_ASSEMBLY_DIR}/che-theia.tar.gz"
+git ls-files -z -c -o --exclude-standard | xargs -0 tar rvf ${LOCAL_ASSEMBLY_DIR}/che-theia.tar.gz
 
 init --name:theia "$@"
 

--- a/generator/.gitignore
+++ b/generator/.gitignore
@@ -5,3 +5,4 @@ yarn-error.log
 .vscode
 exe
 /lib/
+*.tgz


### PR DESCRIPTION
### What does this PR do?
It use current che-theia source tree to build che-theia docker image, instead of cloning che-theia repo.
So now to build your custom che-theia images(with your changes in che-theia sources) just use `build.sh` script in root directory. You don't even need to commit your changes or modify some other files, just build docker images, build script automatically pick up your changes.

> Note: this PR also use che-theia generator(`che:theia init`) from che-theia sources, so if you change generator, you can easy test it, just call `build.sh` script and it will use your version of generator.
 
### What issues does this PR fix or reference?
Part of eclipse/che#13738 
