### PR TITLE
Show warning message after generating an SSH key

### DIFF
--- a/plugins/ssh-plugin/src/ssh-plugin-backend.ts
+++ b/plugins/ssh-plugin/src/ssh-plugin-backend.ts
@@ -82,6 +82,10 @@ const writeKey = async (name: string, key: string) => {
     await chmod(keyFile, '600');
 };
 
+const showWarning = async () => {
+    theia.window.showWarningMessage('Che Git plugin can leverage the generated keys now. To make them available in every workspace containers please restart your workspace.');
+};
+
 const generateKeyPair = async (sshkeyManager: SshKeyManager) => {
     const keyName = `default-${Date.now()}`;
     const key = await sshkeyManager.generate('vcs', keyName);
@@ -93,6 +97,7 @@ const generateKeyPair = async (sshkeyManager: SshKeyManager) => {
         const document = await theia.workspace.openTextDocument({ content: key.publicKey });
         await theia.window.showTextDocument(document);
     }
+    showWarning();
 };
 
 const generateKeyPairForHost = async (sshkeyManager: SshKeyManager) => {
@@ -106,6 +111,7 @@ const generateKeyPairForHost = async (sshkeyManager: SshKeyManager) => {
         const document = await theia.workspace.openTextDocument({ content: key.publicKey });
         await theia.window.showTextDocument(document);
     }
+    showWarning();
 };
 
 const createKeyPair = async (sshkeyManager: SshKeyManager) => {
@@ -115,9 +121,10 @@ const createKeyPair = async (sshkeyManager: SshKeyManager) => {
 
     try {
         await sshkeyManager.create({ name: hostName, service: 'vcs', publicKey: publicKey, privateKey });
-        theia.window.showInformationMessage(`Key pair for ${hostName} successfully created`);
         await updateConfig(hostName);
         await writeKey(hostName, privateKey);
+        await theia.window.showInformationMessage(`Key pair for ${hostName} successfully created`);
+        showWarning();
     } catch (error) {
         theia.window.showErrorMessage(error);
     }


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Show's a warning message that SSH key will be available in all containers (not only in `theia-ide` container) only after restarting the workspace. Workspace restart will mount the new SSH keys to all containers.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14073
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
