### PR TITLE
Increase the value of timeout on unit tests.

### DIFF
--- a/generator/tests/init-sources/init-sources.spec.ts
+++ b/generator/tests/init-sources/init-sources.spec.ts
@@ -19,6 +19,8 @@ import { CliError } from "../../src/cli-error";
 import * as yargs from 'yargs';
 import { YargsMockup } from "../cdn.spec";
 
+jest.setTimeout(10000);
+
 describe("Test Extensions", () => {
 
     // Increase timeout to 30 seconds

--- a/generator/tests/init/init.spec.ts
+++ b/generator/tests/init/init.spec.ts
@@ -14,6 +14,7 @@ import * as fs from 'fs-extra';
 import { Init } from "../../src/init";
 import { Command } from "../../src/command";
 
+jest.setTimeout(10000);
 jest.mock("../../src/command");
 
 describe("Test Init", () => {

--- a/generator/tests/production/production.spec.ts
+++ b/generator/tests/production/production.spec.ts
@@ -14,8 +14,8 @@ import * as path from 'path';
 import { Production } from "../../src/production";
 import { Yarn } from "../../src/yarn";
 
+jest.setTimeout(10000);
 jest.mock("../../src/yarn");
-
 
 describe("Test production", () => {
 

--- a/plugins/workspace-plugin/tests/git.spec.ts
+++ b/plugins/workspace-plugin/tests/git.spec.ts
@@ -11,7 +11,7 @@
 import * as git from '../src/git';
 const rimraf = require('rimraf');
 
-jest.setTimeout(20000);
+jest.setTimeout(30000);
 
 describe('Test git commands', () => {
 


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

Increases timeout for some unit tests.
On some poor environments (like Core i5/8GB RAM), it is too short the default value (5000ms) 

### What issues does this PR fix or reference?

None.
