### PR TITLE
Add context to notification when a che task is complete

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-task-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-task-service.ts
@@ -128,7 +128,7 @@ class CheTask extends Task {
     }
 
     fireTaskExited(event: TaskExitedEvent): void {
-        super.fireTaskExited({ taskId: event.taskId, code: event.code, ctx: event.ctx });
+        super.fireTaskExited({ taskId: event.taskId, code: event.code, ctx: event.ctx, config: this.options.config });
     }
 
     private toTaskInfo(runtimeInfo: TaskInfo): TaskInfo {


### PR DESCRIPTION
### What does this PR do?
Add context to event when a che task is complete.
It allows to use task name for notification when task is complete 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14125

### How to test
<details>
<summary>I used the following in my devfile for testing:</summary>

```
apiVersion: 1.0.0
metadata:
 name: wksp-tasks
projects:
  - name: che-theia
    source:
      type: git
      location: 'https://github.com/eclipse/che-theia.git'
  - name: theia
    source:
      type: git
      location: 'https://github.com/theia-ide/theia.git'

components:
  - 
    alias: che-dev
    type: dockerimage
    image: eclipse/che-theia-dev:next
    mountSources: true
    endpoints:
      - name: "theia-dev"
        port: 3130
        attributes:
          protocol: tcp
          public: 'true'
    memoryLimit: 4Gi
  - 
    alias: theia-editor
    reference: >-
      https://raw.githubusercontent.com/RomanNikitenko/che-plugin-registry/master/v3/plugins/eclipse/che-theia/next/meta.yaml
    type: cheEditor
  
  - 
    id: che-incubator/typescript/1.30.2
    alias: tsc
    type: chePlugin
    memoryLimit: 2048M

commands:
- name: theia:watch
  actions:
  - type: exec
    component: che-dev
    command: >
              yarn watch
    workdir: /projects/theia

- name: theia:build
  actions:
  - type: exec
    component: che-dev
    command: >
              yarn
    workdir: /projects/theia


```
</details>

The image contains:
- current master branch of theia repo
- current master branch of che-theia + changes from the PR

Try to run che command and stop this one by `Ctrl +c`, the notification should contain task name, not task id. 

Please see the short video: https://youtu.be/YLMZrjAlQOM

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
