### PR TITLE
Add docker file to build clang image

### DIFF
--- a/docker_image_build.include
+++ b/docker_image_build.include
@@ -32,6 +32,7 @@ dockerfiles/remote-plugin-java8
 dockerfiles/remote-plugin-java11
 dockerfiles/remote-plugin-php7
 dockerfiles/remote-plugin-go-1.10.7
+dockerfiles/remote-plugin-clang-8
 dockerfiles/remote-plugin-python-3.7.3
 dockerfiles/remote-plugin-dotnet-2.2.105
 dockerfiles/remote-plugin-kubernetes-tooling-0.1.17
@@ -49,6 +50,7 @@ eclipse/che-remote-plugin-runner-java8
 eclipse/che-remote-plugin-runner-java11
 eclipse/che-remote-plugin-php7
 eclipse/che-remote-plugin-go-1.10.7
+eclipse/che-remote-plugin-clang-8
 eclipse/che-remote-plugin-python-3.7.3
 eclipse/che-remote-plugin-dotnet-2.2.105
 eclipse/che-remote-plugin-kubernetes-tooling-0.1.17
@@ -64,7 +66,7 @@ buildImages() {
         do
             GITHUB_TOKEN_ARG="GITHUB_TOKEN="${GITHUB_TOKEN}
             if [ "$image_dir" == "dockerfiles/theia" ]; then
-                bash $(pwd)/$image_dir/build.sh --build-args:${GITHUB_TOKEN_ARG},THEIA_VERSION=${THEIA_VERSION} --tag:${IMAGE_TAG} --branch:${THEIA_BRANCH} --git-ref:${THEIA_GIT_REFS} 
+                bash $(pwd)/$image_dir/build.sh --build-args:${GITHUB_TOKEN_ARG},THEIA_VERSION=${THEIA_VERSION} --tag:${IMAGE_TAG} --branch:${THEIA_BRANCH} --git-ref:${THEIA_GIT_REFS}
             elif [ "$image_dir" == "dockerfiles/theia-dev" ]; then
                 bash $(pwd)/$image_dir/build.sh --build-arg:${GITHUB_TOKEN_ARG} --tag:${IMAGE_TAG}
             else

--- a/dockerfiles/remote-plugin-clang-8/Dockerfile
+++ b/dockerfiles/remote-plugin-clang-8/Dockerfile
@@ -32,6 +32,7 @@ COPY --from=endpoint /projects /projects
 COPY --from=endpoint /etc/passwd  /etc/passwd
 COPY --from=endpoint /etc/group   /etc/group
 COPY --from=endpoint /entrypoint.sh /entrypoint.sh
+
 RUN chmod -R 777 ${HOME}
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/dockerfiles/remote-plugin-clang-8/Dockerfile
+++ b/dockerfiles/remote-plugin-clang-8/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:${BUILD_TAG} as endpoint
+
+FROM debian:10-slim
+
+ENV HOME=/home/theia
+
+RUN apt-get update && \
+    apt-get install wget gnupg -y && \
+    echo 'deb http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main' >> /etc/apt/sources.list && \
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    wget -O - https://deb.nodesource.com/setup_10.x | bash - && \
+    apt-get update && \
+    apt-get install nodejs clang-8 clang-tools-8 clang-format-8 gdb -y && \
+    apt-get clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/* && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 100 && \
+    update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-8 100 && \
+    update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-8 100
+
+COPY --from=endpoint /home/theia /home/theia
+COPY --from=endpoint /projects /projects
+COPY --from=endpoint /etc/passwd  /etc/passwd
+COPY --from=endpoint /etc/group   /etc/group
+COPY --from=endpoint /entrypoint.sh /entrypoint.sh
+RUN chmod -R 777 ${HOME}
+
+ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/dockerfiles/remote-plugin-clang-8/build.sh
+++ b/dockerfiles/remote-plugin-clang-8/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
+
+init --name:remote-plugin-clang-8 "$@"
+build


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

### What does this PR do?
It adds the docker file to build a clang image

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13698
