### PR TITLE
Badge displaying build status for 7.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <div id="badges" align="center">
 
-  [![Build Status](https://ci.codenvycorp.com/buildStatus/icon?job=che-theia-master-ci)](https://ci.codenvycorp.com/job/che-theia-master-ci)
+  [![Build Status](https://ci.codenvycorp.com/buildStatus/icon?job=che-theia-7.0.0-next)](https://ci.codenvycorp.com/job/che-theia-7.0.0-next)
   [![mattermost](https://img.shields.io/badge/chat-on%20mattermost-blue.svg)](https://mattermost.eclipse.org/eclipse/channels/eclipse-che-ide2-team)
   [![Open questions](https://img.shields.io/badge/Open-questions-blue.svg?style=flat-curved)](https://github.com/eclipse/che-theia/labels/kind%2Fquestion)
   [![Open bugs](https://img.shields.io/badge/Open-bugs-red.svg?style=flat-curved)](https://github.com/eclipse/che-theia/labels/kind%2Fbug)


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Updates the badge displaying build status of https://ci.codenvycorp.com/job/che-theia-7.0.0-next/
After renaming CI job `che-theia-latest-ci` to `che-theia-7.0.0-next` the badge become not working.

### What issues does this PR fix or reference?
Subtask of https://github.com/eclipse/che/issues/14053

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
The PR https://github.com/eclipse/che-theia/pull/381 has affected the badge
