### PR TITLE
Resolve variables for che commands

### DIFF
--- a/plugins/task-plugin/src/task/che-task-provider.ts
+++ b/plugins/task-plugin/src/task/che-task-provider.ts
@@ -10,7 +10,7 @@
 
 import { injectable, inject } from 'inversify';
 import * as che from '@eclipse-che/plugin';
-import { Task } from '@theia/plugin';
+import { Task, ShellExecution } from '@theia/plugin';
 import { CHE_TASK_TYPE, CheTaskDefinition, Target } from './task-protocol';
 import { MachinesPicker } from '../machine/machines-picker';
 import { CheWorkspaceClient } from '../che-workspace-client';
@@ -52,20 +52,23 @@ export class CheTaskProvider {
         }
 
         if (target && target.workingDir) {
-            resultTarget.workingDir = target.workingDir;
+            resultTarget.workingDir = await che.variables.resolve(target.workingDir);
         }
 
-        const command = await che.variables.resolve(cheTaskDefinition.command);
+        const execution = task.execution as ShellExecution;
+        if (execution && execution.command) {
+            execution.command = await che.variables.resolve(execution.command as string);
+        }
+
         return {
             definition: {
                 type: taskType,
-                command: command,
                 target: resultTarget,
                 previewUrl: cheTaskDefinition.previewUrl
             },
             name: task.name,
             source: task.source,
-            execution: task.execution
+            execution: execution
         };
     }
 }

--- a/plugins/task-plugin/src/task/task-protocol.ts
+++ b/plugins/task-plugin/src/task/task-protocol.ts
@@ -17,7 +17,6 @@ export const WORKING_DIR_ATTRIBUTE: string = 'workingDir';
 
 export interface CheTaskDefinition extends TaskDefinition {
     readonly target?: Target,
-    readonly command: string,
     readonly previewUrl?: string
 }
 


### PR DESCRIPTION
The changes are the same as in the PR https://github.com/eclipse/che-theia/pull/373

### What does this PR do?
Allows to resolve variables for che commands before execution.
For example you can define command in your devfile:
```
- name: copy content
  actions:
  - type: exec
    component: che-dev
    command: >
              cp ${workspaceFolder}/.theia/tasks.json ${workspaceFolder}/cheCommands.json
    workdir: ${workspaceFolder}
```
and `${workspaceFolder}` will be replaced by `/projects` for example, or use `${file}` to get path to 
 the file opened in the current editor

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14031

### How to test
Use the component in your devfile

```
- 
    alias: theia-editor
    reference: >-
      https://raw.githubusercontent.com/RomanNikitenko/che-plugin-registry/master/v3/plugins/eclipse/che-theia/next/meta.yaml
    type: cheEditor

```
Use a command with variables in your devfile, the simple example you can see above.