### PR TITLE
Use 'containerName' instead of 'machineName' for che tasks

### DIFF
--- a/plugins/task-plugin/src/task/che-task-provider.ts
+++ b/plugins/task-plugin/src/task/che-task-provider.ts
@@ -45,10 +45,10 @@ export class CheTaskProvider {
             resultTarget.workspaceId = await this.cheWorkspaceClient.getWorkspaceId();
         }
 
-        if (target && target.machineName) {
-            resultTarget.machineName = target.machineName;
+        if (target && target.containerName) {
+            resultTarget.containerName = target.containerName;
         } else {
-            resultTarget.machineName = await this.machinePicker.pick();
+            resultTarget.containerName = await this.machinePicker.pick();
         }
 
         if (target && target.workingDir) {

--- a/plugins/task-plugin/src/task/che-task-runner.ts
+++ b/plugins/task-plugin/src/task/che-task-runner.ts
@@ -10,7 +10,7 @@
 
 import { injectable, inject, postConstruct } from 'inversify';
 import * as che from '@eclipse-che/plugin';
-import { CHE_TASK_TYPE } from './task-protocol';
+import { CHE_TASK_TYPE, Target } from './task-protocol';
 import { MachineExecClient } from '../machine/machine-exec-client';
 import { ProjectPathVariableResolver } from '../variable/project-path-variable-resolver';
 import { MachineExecWatcher } from '../machine/machine-exec-watcher';
@@ -50,14 +50,14 @@ export class CheTaskRunner {
             throw new Error(`Unsupported task type: ${type}`);
         }
 
-        const target = definition.target;
+        const target: Target = definition.target;
         if (!target) {
             throw new Error("Che task config must have 'target' property specified");
         }
 
-        const machineName = target.machineName;
-        if (!machineName) {
-            throw new Error("Che task config must have 'target.machineName' property specified");
+        const containerName = target.containerName;
+        if (!containerName) {
+            throw new Error("Che task config must have 'target.containerName' property specified");
         }
 
         try {
@@ -68,7 +68,7 @@ export class CheTaskRunner {
                 shellArgs: ['-c', `${taskConfig.command}`],
 
                 attributes: {
-                    CHE_MACHINE_NAME: machineName,
+                    CHE_MACHINE_NAME: containerName,
                     closeWidgetExitOrError: 'false',
                 }
             };

--- a/plugins/task-plugin/src/task/converter.ts
+++ b/plugins/task-plugin/src/task/converter.ts
@@ -21,10 +21,11 @@ export function toTaskConfiguration(command: cheApi.workspace.Command): TaskConf
         command: command.commandLine,
         target: {
             workingDir: this.getCommandAttribute(command, WORKING_DIR_ATTRIBUTE),
-            machineName: this.getCommandAttribute(command, MACHINE_NAME_ATTRIBUTE)
+            containerName: this.getCommandAttribute(command, MACHINE_NAME_ATTRIBUTE)
         },
         previewUrl: this.getCommandAttribute(command, PREVIEW_URL_ATTRIBUTE)
     };
+
     return taskConfig;
 }
 
@@ -36,7 +37,7 @@ export function toTask(command: cheApi.workspace.Command): Task {
             command: command.commandLine,
             target: {
                 workingDir: this.getCommandAttribute(command, WORKING_DIR_ATTRIBUTE),
-                machineName: this.getCommandAttribute(command, MACHINE_NAME_ATTRIBUTE)
+                containerName: this.getCommandAttribute(command, MACHINE_NAME_ATTRIBUTE)
             },
             previewUrl: this.getCommandAttribute(command, PREVIEW_URL_ATTRIBUTE)
         },

--- a/plugins/task-plugin/src/task/task-protocol.ts
+++ b/plugins/task-plugin/src/task/task-protocol.ts
@@ -22,6 +22,6 @@ export interface CheTaskDefinition extends TaskDefinition {
 
 export interface Target {
     workspaceId?: string,
-    machineName?: string,
+    containerName?: string,
     workingDir?: string
 }


### PR DESCRIPTION
The changes are the same as in the PR https://github.com/eclipse/che-theia/pull/367

### What does this PR do?
Use 'containerName' instead of 'machineName' for che tasks

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13667

### How to test
Use the component in your devfile

```
- 
    alias: theia-editor
    reference: >-
      https://raw.githubusercontent.com/RomanNikitenko/che-plugin-registry/master/v3/plugins/eclipse/che-theia/next/meta.yaml
    type: cheEditor

```
 
Use some command in your devfile, for example:
```
- name: che-theia:build
  actions:
  - type: exec
    component: che-dev
    command: >
              yarn
    workdir: /projects/che-theia
```
The `component` field defined for a command in a devfile should be converted into `containerName` (not `machineName`) field for a task configuration in a `tasks.json` file when a workspace has started.

![containerName](https://user-images.githubusercontent.com/5676062/61733681-fa6b3c00-ad88-11e9-874a-bb3d5a571ef0.png)


Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
