### PR TITLE
Change way of storage runtime info for che tasks

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-task-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-task-main.ts
@@ -20,11 +20,10 @@ export class CheTaskMainImpl implements CheTaskMain {
         const proxy: CheTask = rpc.getProxy(PLUGIN_RPC_CONTEXT.CHE_TASK);
         this.delegate = container.get(CheTaskService);
         this.cheTaskClient = container.get(CheTaskClient);
-        this.cheTaskClient.onKillEvent(id => proxy.$killTask(id));
-        this.cheTaskClient.addTaskInfoHandler(id => proxy.$getTaskInfo(id));
-        this.cheTaskClient.addTaskExitedHandler(id => proxy.$onTaskExited(id));
-        this.cheTaskClient.addRunTaskHandler((id, config, ctx) => proxy.$runTask(id, config, ctx));
+        this.cheTaskClient.onKillEvent(taskInfo => proxy.$killTask(taskInfo));
+        this.cheTaskClient.addRunTaskHandler((config, ctx) => proxy.$runTask(config, ctx));
     }
+
     $registerTaskRunner(type: string): Promise<void> {
         return this.delegate.registerTaskRunner(type);
     }

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -76,10 +76,8 @@ export interface CheVariablesMain {
 export interface CheTask {
     registerTaskRunner(type: string, runner: che.TaskRunner): Promise<che.Disposable>;
     fireTaskExited(event: che.TaskExitedEvent): Promise<void>;
-    $runTask(id: number, config: che.TaskConfiguration, ctx?: string): Promise<void>;
-    $onTaskExited(id: number): Promise<void>;
-    $killTask(id: number): Promise<void>;
-    $getTaskInfo(id: number): Promise<che.TaskInfo | undefined>;
+    $runTask(config: che.TaskConfiguration, ctx?: string): Promise<che.TaskInfo>;
+    $killTask(taskInfo: che.TaskInfo): Promise<void>;
 }
 
 export const CheTaskMain = Symbol('CheTaskMain');
@@ -416,14 +414,10 @@ export interface CheTaskService extends JsonRpcServer<CheTaskClient> {
 
 export const CheTaskClient = Symbol('CheTaskClient');
 export interface CheTaskClient {
-    runTask(id: number, taskConfig: che.TaskConfiguration, ctx?: string): Promise<void>;
-    killTask(id: number): Promise<void>;
-    getTaskInfo(id: number): Promise<che.TaskInfo | undefined>;
-    onTaskExited(id: number): Promise<void>;
-    addTaskInfoHandler(func: (id: number) => Promise<che.TaskInfo | undefined>): void;
-    addRunTaskHandler(func: (id: number, config: che.TaskConfiguration, ctx?: string) => Promise<void>): void;
-    addTaskExitedHandler(func: (id: number) => Promise<void>): void;
-    onKillEvent: Event<number>
+    runTask(taskConfig: che.TaskConfiguration, ctx?: string): Promise<che.TaskInfo>;
+    killTask(taskInfo: che.TaskInfo): Promise<void>;
+    addRunTaskHandler(func: (config: che.TaskConfiguration, ctx?: string) => Promise<che.TaskInfo>): void;
+    onKillEvent: Event<che.TaskInfo>
 }
 
 export interface ChePluginRegistry {

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-task-impl.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-task-impl.ts
@@ -8,17 +8,15 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 import { CheTask, CheTaskMain, PLUGIN_RPC_CONTEXT } from '../common/che-protocol';
-import { TaskRunner, Disposable, Task, TaskInfo, TaskExitedEvent, TaskConfiguration } from '@eclipse-che/plugin';
+import { TaskRunner, Disposable, TaskInfo, TaskExitedEvent, TaskConfiguration } from '@eclipse-che/plugin';
 import { RPCProtocol } from '@theia/plugin-ext/lib/common/rpc-protocol';
 
 export class CheTaskImpl implements CheTask {
     private readonly cheTaskMain: CheTaskMain;
     private readonly runnerMap: Map<string, TaskRunner>;
-    private readonly taskMap: Map<number, Task>;
     constructor(rpc: RPCProtocol) {
         this.cheTaskMain = rpc.getProxy(PLUGIN_RPC_CONTEXT.CHE_TASK_MAIN);
         this.runnerMap = new Map();
-        this.taskMap = new Map();
     }
     async registerTaskRunner(type: string, runner: TaskRunner): Promise<Disposable> {
         this.runnerMap.set(type, runner);
@@ -30,34 +28,20 @@ export class CheTaskImpl implements CheTask {
         };
     }
 
-    async $runTask(id: number, config: TaskConfiguration, ctx?: string): Promise<void> {
+    async $runTask(config: TaskConfiguration, ctx?: string): Promise<TaskInfo> {
         const runner = this.runnerMap.get(config.type);
         if (runner) {
-            const task = await runner.run(config, ctx);
-            this.taskMap.set(id, task);
+            return await runner.run(config, ctx);
         }
+        throw new Error(`Task Runner for type ${config.type} is not found.`);
     }
 
-    async $killTask(id: number): Promise<void> {
-        const task = this.taskMap.get(id);
-        if (task) {
-            await task.kill();
-            this.taskMap.delete(id);
+    async $killTask(taskInfo: TaskInfo): Promise<void> {
+        const runner = this.runnerMap.get(taskInfo.config.type);
+        if (runner) {
+            return await runner.kill(taskInfo);
         }
-    }
-
-    async $getTaskInfo(id: number): Promise<TaskInfo | undefined> {
-        const task = this.taskMap.get(id);
-        if (task) {
-            return task.getRuntimeInfo();
-        }
-    }
-
-    async $onTaskExited(id: number): Promise<void> {
-        const task = this.taskMap.get(id);
-        if (task) {
-            this.taskMap.delete(id);
-        }
+        throw new Error(`Failed to terminate Che command: ${taskInfo.config.label}: the corresponging executor is not found`);
     }
 
     async fireTaskExited(event: TaskExitedEvent): Promise<void> {

--- a/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
+++ b/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
@@ -112,14 +112,9 @@ declare module '@eclipse-che/plugin' {
     /** A Task Runner knows how to run a Task of a particular type. */
     export interface TaskRunner {
         /** Runs a task based on the given task configuration. */
-        run(taskConfig: TaskConfiguration, ctx?: string): Promise<Task>;
-    }
-
-    export interface Task {
-        /** Terminates the task. */
-        kill(): Promise<void>;
-        /** Returns runtime information about task. */
-        getRuntimeInfo(): TaskInfo;
+        run(taskConfig: TaskConfiguration, ctx?: string): Promise<TaskInfo>;
+        /** Terminates a task based on the given info. */
+        kill(taskInfo: TaskInfo): Promise<void>;
     }
 
     /** Runtime information about Task. */

--- a/plugins/task-plugin/src/task/che-task-runner.ts
+++ b/plugins/task-plugin/src/task/che-task-runner.ts
@@ -44,7 +44,7 @@ export class CheTaskRunner {
     /**
      * Runs a task from the given task configuration which must have a target property specified.
      */
-    async run(taskConfig: che.TaskConfiguration, ctx?: string): Promise<che.Task> {
+    async run(taskConfig: che.TaskConfiguration, ctx?: string): Promise<che.TaskInfo> {
         const { type, label, ...definition } = taskConfig;
         if (type !== CHE_TASK_TYPE) {
             throw new Error(`Unsupported task type: ${type}`);
@@ -77,20 +77,19 @@ export class CheTaskRunner {
             const execId = await terminal.processId;
 
             return {
-                kill: () => {
-                    throw new Error('Stopping a Che task currently is not supported.');
-                },
-                getRuntimeInfo: () =>
-                    ({
-                        taskId: STUB_TASK_ID,
-                        ctx: ctx,
-                        config: taskConfig,
-                        execId: execId
-                    })
+                taskId: STUB_TASK_ID,
+                ctx: ctx,
+                config: taskConfig,
+                execId: execId
             };
         } catch (error) {
             console.error('Failed to execute Che command:', error);
             throw new Error(`Failed to execute Che command: ${error.message}`);
         }
+    }
+
+    /** Terminates a task based on the given info. */
+    async kill(taskInfo: che.TaskInfo): Promise<void> {
+        throw new Error('Stopping a Che task currently is not supported.');
     }
 }


### PR DESCRIPTION
### What does this PR do?
Improves the way of storage runtime info for Che tasks.

We keep runtime info for Che tasks on plugin side. The problem is the plugin side is reloaded each time the browser refreshes and we lose runtime info at this step. For more details please see https://github.com/eclipse/che/issues/13722#issuecomment-520437999.

The changes suggest to store runtime info on node side of `eclipse-che/theia-plugin-ext`.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13722

### How to test
The changes are related to che tasks, so please try to run any che task from `My Workspace` panel and from `Terminal` -> `Run Task` menu as well

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
