### PR TITLE
Fix building clang docker image

### DIFF
--- a/dockerfiles/remote-plugin-clang-8/Dockerfile
+++ b/dockerfiles/remote-plugin-clang-8/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     wget -O - https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get update && \
-    apt-get install nodejs clang-8 clang-tools-8 clang-format-8 gdb -y && \
+    apt-get install nodejs clangd-8 clang-8 clang-format-8 gdb -y && \
     apt-get clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/* && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 100 && \


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes build for `eclipse/che-remote-plugin-clang-8` 
It replaces packages `clang-tools-8` -> `clangd-8`

