### PR TITLE
Add remote plugins resource provider contribution

### DIFF
--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-backend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-backend-module.ts
@@ -8,22 +8,31 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import { ContainerModule } from 'inversify';
+import { ContainerModule, interfaces } from 'inversify';
 import { HostedPluginRemote } from './hosted-plugin-remote';
 import { ServerPluginProxyRunner } from './server-plugin-proxy-runner';
-import { MetadataProcessor, ServerPluginRunner } from '@theia/plugin-ext/lib/common';
+import { MetadataProcessor, ServerPluginRunner, PluginResourcesProvider } from '@theia/plugin-ext/lib/common';
 import { RemoteMetadataProcessor } from './remote-metadata-processor';
 import { HostedPluginMapping } from './plugin-remote-mapping';
 import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
+import { RemotePluginResourcesProvider } from './remote-plugin-resources-provider';
 
 const localModule = ConnectionContainerModule.create(({ bind }) => {
-    bind(HostedPluginRemote).toSelf().inSingletonScope();
+    bind(HostedPluginRemote).toSelf().inSingletonScope().onActivation((ctx: interfaces.Context, hostedPluginRemote: HostedPluginRemote) => {
+        const remotePluginResourcesProvider = ctx.container.parent.get(RemotePluginResourcesProvider);
+        remotePluginResourcesProvider.setRemotePluginConnection(hostedPluginRemote);
+        return hostedPluginRemote;
+    });
     bind(ServerPluginRunner).to(ServerPluginProxyRunner).inSingletonScope();
 });
 
 export default new ContainerModule(bind => {
     bind(HostedPluginMapping).toSelf().inSingletonScope();
     bind(MetadataProcessor).to(RemoteMetadataProcessor).inSingletonScope();
+
+    bind(RemotePluginResourcesProvider).toSelf().inSingletonScope();
+    bind(PluginResourcesProvider).toDynamicValue((ctx: interfaces.Context) =>
+        ctx.container.get(RemotePluginResourcesProvider)).inSingletonScope();
+
     bind(ConnectionContainerModule).toConstantValue(localModule);
-}
-);
+});

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/remote-plugin-resources-provider.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/remote-plugin-resources-provider.ts
@@ -1,0 +1,40 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { injectable } from 'inversify';
+import { PluginResourcesProvider } from '@theia/plugin-ext/lib/common/plugin-protocol';
+import { HostedPluginRemote } from './hosted-plugin-remote';
+
+@injectable()
+export class RemotePluginResourcesProvider implements PluginResourcesProvider {
+
+    // To be set on connection creation
+    // If there are more than one cnnection, the last one will be used.
+    private hostedPluginRemote: HostedPluginRemote;
+
+    hasResources(pluginId: string): boolean {
+        if (this.hostedPluginRemote) {
+            return this.hostedPluginRemote.hasEndpoint(pluginId);
+        }
+        return false;
+    }
+
+    getResource(pluginId: string, resourcePath: string): Promise<Buffer | undefined> {
+        if (this.hostedPluginRemote) {
+            return this.hostedPluginRemote.requestPluginResource(pluginId, resourcePath);
+        }
+        return undefined;
+    }
+
+    setRemotePluginConnection(hostedPluginRemote: HostedPluginRemote): void {
+        this.hostedPluginRemote = hostedPluginRemote;
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

Adds plugins resources provider which handles remote plugins resources.
This allows retrieving of remote plugins resources for plugin frontend part. The most often used use-case is images in contributes UI of the plugin. But any kind of resources is supported. 

Depends on: https://github.com/theia-ide/theia/pull/6070
Resolves: https://github.com/eclipse/che/issues/13750

Screenshot:
![remote-plugin-resources-kubernetes-plugin](https://user-images.githubusercontent.com/15607393/64022080-1909e300-cb3e-11e9-9ca6-31d3cd8c4008.png)

