### PR TITLE
Add ability to set up git user name and email in theia preferences

### DIFF
--- a/che-theia-init-sources.yml
+++ b/che-theia-init-sources.yml
@@ -11,6 +11,7 @@ sources:
     - extensions/eclipse-che-theia-activity-tracker
     - extensions/eclipse-che-theia-about
     - extensions/eclipse-che-theia-preferences-provider-extension
+    - extensions/eclipse-che-theia-git-provisioner
   plugins:
     - plugins/containers-plugin
     - plugins/factory-plugin

--- a/extensions/eclipse-che-theia-git-provisioner/.gitignore
+++ b/extensions/eclipse-che-theia-git-provisioner/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.browser_modules
+lib
+*.log
+*-app/*
+!*-app/package.json
+.idea

--- a/extensions/eclipse-che-theia-git-provisioner/package.json
+++ b/extensions/eclipse-che-theia-git-provisioner/package.json
@@ -1,0 +1,51 @@
+{
+    "name": "@eclipse-che/theia-git-provisioner",
+    "keywords": [
+      "theia-extension",
+      "che",
+      "preferences"
+    ],
+    "version": "0.0.1",
+    "license": "EPL-2.0",
+    "files": [
+      "lib",
+      "src"
+    ],
+    "dependencies": {
+      "@eclipse-che/theia-plugin-ext": "^0.0.1",
+      "@theia/core": "next",
+      "@theia/preferences": "next",
+      "ini": "^1.3.5",
+      "nsfw": "^1.2.2",
+      "@eclipse-che/theia-user-preferences-synchronizer": "0.0.1"
+    },
+    "scripts": {
+      "prepare": "yarn run clean && yarn run build",
+      "clean": "rimraf lib",
+      "format": "tsfmt -r --useTsfmt ../../configs/tsfmt.json",
+      "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
+      "compile": "tsc",
+      "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\"",
+      "test": "jest"
+    },
+    "theiaExtensions": [
+      {
+        "frontend": "lib/browser/git-frontend-module",
+        "backend": "lib/node/git-backend-module"
+      }
+    ],
+    "jest": {
+      "testEnvironment": "jsdom",
+      "transform": {
+        "^.+\\.tsx?$": "ts-jest"
+      },
+      "testMatch": [
+        "**/tests/*.(ts)"
+      ],
+      "moduleNameMapper": {
+        "\\.(css|less)$": "<rootDir>/tests/mock.js"
+      },
+      "moduleFileExtensions": ["js", "ts"]
+    }
+  }
+  

--- a/extensions/eclipse-che-theia-git-provisioner/src/browser/git-frontend-module.ts
+++ b/extensions/eclipse-che-theia-git-provisioner/src/browser/git-frontend-module.ts
@@ -1,0 +1,22 @@
+/********************************************************************************
+ * Copyright (C) 2018-2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { bindGitPreferences } from './git-preferences';
+
+export default new ContainerModule(bind => {
+    bindGitPreferences(bind);
+});

--- a/extensions/eclipse-che-theia-git-provisioner/src/browser/git-preferences.ts
+++ b/extensions/eclipse-che-theia-git-provisioner/src/browser/git-preferences.ts
@@ -1,0 +1,54 @@
+/********************************************************************************
+ * Copyright (C) 2018-2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces } from 'inversify';
+import { createPreferenceProxy, PreferenceProxy, PreferenceService, PreferenceContribution, PreferenceSchema } from '@theia/core/lib/browser';
+
+export const GitConfigSchema: PreferenceSchema = {
+    'type': 'object',
+    'properties': {
+        'git.user.name': {
+            'type': 'string',
+            'description': 'Your full name to be recorded in any newly created commits.',
+            'default': undefined
+        },
+        'git.user.email': {
+            'type': 'string',
+            'description': 'Your email address to be recorded in any newly created commits.',
+            'default': undefined
+        }
+    }
+};
+
+export interface GitConfiguration {
+    'git.user.name': string,
+    'git.user.email': string
+}
+
+export const GitPreferences = Symbol('GitPreferences');
+export type GitPreferences = PreferenceProxy<GitConfiguration>;
+
+export function createGitPreferences(preferences: PreferenceService): GitPreferences {
+    return createPreferenceProxy(preferences, GitConfigSchema);
+}
+
+export function bindGitPreferences(bind: interfaces.Bind): void {
+    bind(GitPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        return createGitPreferences(preferences);
+    });
+    bind(PreferenceContribution).toConstantValue({ schema: GitConfigSchema });
+}

--- a/extensions/eclipse-che-theia-git-provisioner/src/node/git-backend-module.ts
+++ b/extensions/eclipse-che-theia-git-provisioner/src/node/git-backend-module.ts
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (C) 2018-2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { GitConfigurationListenerContribution } from './git-configuration-contribution';
+import { GitConfigurationController } from './git-configuration-controller';
+import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
+
+export default new ContainerModule(bind => {
+    bind(GitConfigurationController).toSelf().inSingletonScope();
+    bind(GitConfigurationListenerContribution).toSelf().inSingletonScope();
+    bind(BackendApplicationContribution).toService(GitConfigurationListenerContribution);
+});

--- a/extensions/eclipse-che-theia-git-provisioner/src/node/git-configuration-contribution.ts
+++ b/extensions/eclipse-che-theia-git-provisioner/src/node/git-configuration-contribution.ts
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (C) 2018-2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
+import { GitConfigurationController } from './git-configuration-controller';
+
+@injectable()
+export class GitConfigurationListenerContribution implements BackendApplicationContribution {
+
+    @inject(GitConfigurationController)
+    gitConfigurationListener: GitConfigurationController;
+
+    public onStart(): void {
+        this.gitConfigurationListener.watchGitConfigChanges();
+        this.gitConfigurationListener.watchUserPreferencesChanges();
+    }
+}

--- a/extensions/eclipse-che-theia-git-provisioner/src/node/git-configuration-controller.ts
+++ b/extensions/eclipse-che-theia-git-provisioner/src/node/git-configuration-controller.ts
@@ -1,0 +1,129 @@
+/********************************************************************************
+ * Copyright (C) 2018-2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/// <reference types='@theia/core/src/typings/nsfw/index'/>
+
+import { injectable, inject } from 'inversify';
+
+import { homedir } from 'os';
+import { resolve } from 'path';
+import { CheTheiaUserPreferencesSynchronizer } from '@eclipse-che/theia-user-preferences-synchronizer/lib/node/che-theia-preferences-synchronizer';
+import { writeFile, pathExists, createFile, readFile } from 'fs-extra';
+import * as ini from 'ini';
+import * as nsfw from 'nsfw';
+import { Disposable } from '@theia/core';
+
+export const GIT_CONFIG_PATH = resolve(homedir(), '.gitconfig');
+export const GIT_USER_NAME = 'git.user.name';
+export const GIT_USER_EMAIL = 'git.user.email';
+
+export interface UserConfiguration {
+    name: string | undefined;
+    email: string | undefined;
+}
+
+@injectable()
+export class GitConfigurationController {
+
+    @inject(CheTheiaUserPreferencesSynchronizer)
+    protected preferencesService: CheTheiaUserPreferencesSynchronizer;
+
+    protected preferencesHandler: Disposable | undefined;
+
+    protected gitConfigWatcher: nsfw.NSFW | undefined;
+
+    public async watchGitConfigChanges(): Promise<void> {
+        if (this.gitConfigWatcher) {
+            return;
+        }
+
+        const gitConfigExists = await pathExists(GIT_CONFIG_PATH);
+        if (!gitConfigExists) {
+            await createFile(GIT_CONFIG_PATH);
+        }
+
+        this.gitConfigWatcher = await nsfw(GIT_CONFIG_PATH, async (events: nsfw.ChangeEvent[]) => {
+            for (const event of events) {
+                if (event.action === nsfw.actions.MODIFIED) {
+                    const userConfig = await this.getUserConfigurationFromGitConfig();
+                    const preferences = await this.preferencesService.getPreferences();
+
+                    preferences[GIT_USER_NAME] = userConfig.name;
+                    preferences[GIT_USER_EMAIL] = userConfig.email;
+
+                    await this.preferencesService.setPreferences(preferences);
+                }
+            }
+        });
+        await this.gitConfigWatcher.start();
+    }
+
+    protected async getUserConfigurationFromGitConfig(): Promise<UserConfiguration> {
+        const gitConfigExists = await pathExists(GIT_CONFIG_PATH);
+        if (!gitConfigExists) {
+            return {} as UserConfiguration;
+        }
+
+        const gitConfigContent = await readFile(GIT_CONFIG_PATH, 'utf-8');
+        const gitConfig = ini.parse(gitConfigContent);
+
+        if (gitConfig.user === undefined) {
+            return {} as UserConfiguration;
+        }
+
+        const { name, email } = gitConfig.user;
+
+        return { name, email };
+    }
+
+    public async watchUserPreferencesChanges(): Promise<void> {
+        if (this.preferencesHandler) {
+            return;
+        }
+
+        this.preferencesHandler = this.preferencesService.onUserPreferencesModify(preferences => {
+            const config = this.getUserConfiguration(preferences);
+            this.updateGlobalGitConfig(config);
+        });
+    }
+
+    protected getUserConfiguration(preferences: object): UserConfiguration {
+        return {
+            name: preferences[GIT_USER_NAME],
+            email: preferences[GIT_USER_EMAIL]
+        };
+    }
+
+    protected async updateGlobalGitConfig(config: UserConfiguration): Promise<void> {
+        if (config.name === undefined && config.email === undefined) {
+            return;
+        }
+
+        const gitConfig = { user: {} as UserConfiguration };
+
+        if (config.name) {
+            gitConfig.user.name = config.name;
+        }
+
+        if (config.email) {
+            gitConfig.user.email = config.email;
+        }
+
+        await this.gitConfigWatcher.stop();
+        await writeFile(GIT_CONFIG_PATH, ini.stringify(gitConfig));
+        await this.gitConfigWatcher.start();
+    }
+}

--- a/extensions/eclipse-che-theia-git-provisioner/tsconfig.json
+++ b/extensions/eclipse-che-theia-git-provisioner/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "extends": "../../configs/base.tsconfig.json",
+    "compilerOptions": {
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "rootDir": "src",
+        "outDir": "lib"
+    },
+    "include": [
+        "src"
+    ]
+}

--- a/extensions/eclipse-che-theia-user-preferences/tsconfig.json
+++ b/extensions/eclipse-che-theia-user-preferences/tsconfig.json
@@ -14,7 +14,8 @@
         ],
         "sourceMap": true,
         "rootDir": "src",
-        "outDir": "lib"
+        "outDir": "lib",
+        "declaration": true
     },
     "include": [
         "src"


### PR DESCRIPTION
### What does this PR do?
This changes proposal is addition to https://github.com/eclipse/che/pull/14402 and adds ability to configure git user name and email through Theia preferences.

Demo for this PR: https://www.youtube.com/watch?v=Q_XsUWR_mJY&feature=youtu.be

Signed-off-by: Vlad Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13959
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Add ability to set up git user name and email in theia preferences


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
