### PR TITLE
Fixup: Hide Plugins view from upstream

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
@@ -15,13 +15,14 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
-import { CommandRegistry, CommandContribution } from '@theia/core/lib/common';
+import { MenuModelRegistry, CommandRegistry, CommandContribution } from '@theia/core/lib/common';
 import { MessageService, Command } from '@theia/core/lib/common';
 import { ChePluginRegistry } from '../../common/che-protocol';
 import { ChePluginManager } from './che-plugin-manager';
-import { QuickInputService } from '@theia/core/lib/browser';
+import { CommonMenus, QuickInputService } from '@theia/core/lib/browser';
 import { MonacoQuickOpenService } from '@theia/monaco/lib/browser/monaco-quick-open-service';
 import { QuickOpenModel, QuickOpenItem, QuickOpenMode } from '@theia/core/lib/browser/quick-open/quick-open-model';
+import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
 
 function cmd(id: string, label: string): Command {
     return {
@@ -58,6 +59,23 @@ export class ChePluginCommandContribution implements CommandContribution {
 
     @inject(ChePluginManager)
     protected readonly chePluginManager: ChePluginManager;
+
+    /**
+     * TEMPORARY SOLUTION
+     *
+     * Following code removes 'View/Plugins' menu item and the command that displays/hides Plugins view.
+     * In the future we will try to refactor Che Plugins view and move it to the 'plugin-ext'.
+     */
+    constructor(
+        @inject(MenuModelRegistry) menuModelRegistry: MenuModelRegistry,
+        @inject(CommandRegistry) commandRegistry: CommandRegistry,
+        @inject(FrontendApplicationStateService) stateService: FrontendApplicationStateService
+    ) {
+        stateService.reachedState('initialized_layout').then(() => {
+            menuModelRegistry.unregisterMenuAction('pluginsView:toggle', CommonMenus.VIEW_VIEWS);
+            commandRegistry.unregisterCommand('pluginsView:toggle');
+        });
+    }
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(ChePluginManagerCommands.CHANGE_REGISTRY, {

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-menu.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-menu.ts
@@ -20,8 +20,6 @@ import { CommandRegistry as PhosphorCommandRegistry } from '@phosphor/commands';
 import { Emitter, Event } from '@theia/core/lib/common';
 import { ChePluginManager } from './che-plugin-manager';
 import { ChePluginManagerCommands, ChePluginCommandContribution } from './che-plugin-command-contribution';
-import { MenuModelRegistry, CommandRegistry } from '@theia/core/lib/common';
-import { CommonMenus } from '@theia/core/lib/browser';
 
 @injectable()
 export class ChePluginMenu {
@@ -33,20 +31,6 @@ export class ChePluginMenu {
     protected readonly chePluginManager: ChePluginManager;
 
     protected readonly menuClosed = new Emitter<void>();
-
-    /**
-     * TEMPORARY SOLUTION
-     *
-     * Following code removes 'View/Plugins' menu item and the command that displays/hides Plugins view.
-     * In the future we will try to refactor Che Plugins view and move it to the 'plugin-ext'.
-     */
-    constructor(
-        @inject(MenuModelRegistry) menuModelRegistry: MenuModelRegistry,
-        @inject(CommandRegistry) commandRegistry: CommandRegistry
-    ) {
-        menuModelRegistry.unregisterMenuAction('pluginsView:toggle', CommonMenus.VIEW_VIEWS);
-        commandRegistry.unregisterCommand('pluginsView:toggle');
-    }
 
     get onMenuClosed(): Event<void> {
         return this.menuClosed.event;


### PR DESCRIPTION
Signed-off-by: Vitaliy Guliy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes appearing two `View > Plugins` items in top menu

![Screenshot from 2019-09-02 16-31-40](https://user-images.githubusercontent.com/1655894/64164248-262b1880-ce43-11e9-9378-a51f35da6911.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13670
