### PR TITLE
Add Host Key checking policy attribute to the ssh config

### DIFF
--- a/plugins/ssh-plugin/src/ssh-plugin-backend.ts
+++ b/plugins/ssh-plugin/src/ssh-plugin-backend.ts
@@ -66,7 +66,7 @@ const updateConfig = async (hostName: string) => {
     const configFile = resolve(os.homedir(), '.ssh', 'config');
     await ensureFile(configFile);
     await chmod(configFile, '644');
-    const keyConfig = `\nHost ${hostName.startsWith('default-') ? '*' : hostName}\nIdentityFile ${getKeyFilePath(hostName)}\n`;
+    const keyConfig = `\nHost ${hostName.startsWith('default-') ? '*' : hostName}\nIdentityFile ${getKeyFilePath(hostName)}\nStrictHostKeyChecking = no\n`;
     const configContentBuffer = await readFile(configFile);
     if (configContentBuffer.indexOf(keyConfig) >= 0) {
         const newConfigContent = configContentBuffer.toString().replace(keyConfig, '');


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
When executing a `clone` command via SSH url from the git plugin, the `clone` process fails if there is no related host in the `known_hosts` file. In order to this attribute host will be added automatically to the `known_hosts` file. SSH clone ends successfuly in this case.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14403
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
