### PR TITLE
Generate settings.xml if MAVEN_MIRROR_URL is set

### DIFF
--- a/dockerfiles/remote-plugin-java11/Dockerfile
+++ b/dockerfiles/remote-plugin-java11/Dockerfile
@@ -13,4 +13,5 @@ RUN apk --no-cache add openjdk11 --repository=http://dl-cdn.alpinelinux.org/alpi
     && apk add procps nss \
     && chmod 777 /home/theia
 ENV JAVA_HOME /usr/lib/jvm/default-jvm/
+ADD etc/before-start.sh /before-start.sh
 WORKDIR /projects

--- a/dockerfiles/remote-plugin-java11/etc/before-start.sh
+++ b/dockerfiles/remote-plugin-java11/etc/before-start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dockerfiles/remote-plugin-java11/etc/before-start.sh
+++ b/dockerfiles/remote-plugin-java11/etc/before-start.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+set_maven_mirror() {
+    local m2="$HOME"/.m2
+    local settingsXML="$m2"/settings.xml
+
+    [ ! -d "$m2" ] && mkdir -p "$m2"
+
+    if [ ! -f "$settingsXML" ]; then
+        echo "<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"" >> "$settingsXML"
+        echo "  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" >> "$settingsXML"
+        echo "  xsi:schemaLocation=\"http://maven.apache.org/SETTINGS/1.0.0" >> "$settingsXML"
+        echo "                      https://maven.apache.org/xsd/settings-1.0.0.xsd\">" >> "$settingsXML"
+        echo "  <mirrors>" >> "$settingsXML"
+        echo "    <mirror>" >> "$settingsXML"
+        echo "      <url>\${env.MAVEN_MIRROR_URL}</url>" >> "$settingsXML"
+        echo "      <mirrorOf>external:*</mirrorOf>" >> "$settingsXML"
+        echo "    </mirror>" >> "$settingsXML"
+        echo "  </mirrors>" >> "$settingsXML"
+        echo "</settings>" >> "$settingsXML"
+    else
+        if ! grep -q "<url>\${env.MAVEN_MIRROR_URL}</url>" "$settingsXML"; then
+            if grep -q "<mirrors>" "$settingsXML"; then
+                sed -i 's/<mirrors>/<mirrors>\n    <mirror>\n      <url>${env.MAVEN_MIRROR_URL}<\/url>\n      <mirrorOf>external:\*<\/mirrorOf>\n    <\/mirror>/' "$settingsXML"
+            else
+                sed -i 's/<\/settings>/  <mirrors>\n    <mirror>\n      <url>${env.MAVEN_MIRROR_URL}<\/url>\n      <mirrorOf>external:*<\/mirrorOf>\n    <\/mirror>\n  <\/mirrors>\n<\/settings>/' "$settingsXML"
+            fi
+        fi
+    fi
+}
+
+[ ! -z "$MAVEN_MIRROR_URL" ] && set_maven_mirror
+return 0

--- a/dockerfiles/remote-plugin-java8/Dockerfile
+++ b/dockerfiles/remote-plugin-java8/Dockerfile
@@ -11,4 +11,5 @@
 FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:${BUILD_TAG}
 RUN apk --update --no-cache add openjdk8 procps nss
 ENV JAVA_HOME /usr/lib/jvm/default-jvm/
+ADD etc/before-start.sh /before-start.sh
 WORKDIR /projects

--- a/dockerfiles/remote-plugin-java8/etc/before-start.sh
+++ b/dockerfiles/remote-plugin-java8/etc/before-start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dockerfiles/remote-plugin-java8/etc/before-start.sh
+++ b/dockerfiles/remote-plugin-java8/etc/before-start.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+set_maven_mirror() {
+    local m2="$HOME"/.m2
+    local settingsXML="$m2"/settings.xml
+
+    [ ! -d "$m2" ] && mkdir -p "$m2"
+
+    if [ ! -f "$settingsXML" ]; then
+        echo "<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"" >> "$settingsXML"
+        echo "  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" >> "$settingsXML"
+        echo "  xsi:schemaLocation=\"http://maven.apache.org/SETTINGS/1.0.0" >> "$settingsXML"
+        echo "                      https://maven.apache.org/xsd/settings-1.0.0.xsd\">" >> "$settingsXML"
+        echo "  <mirrors>" >> "$settingsXML"
+        echo "    <mirror>" >> "$settingsXML"
+        echo "      <url>\${env.MAVEN_MIRROR_URL}</url>" >> "$settingsXML"
+        echo "      <mirrorOf>external:*</mirrorOf>" >> "$settingsXML"
+        echo "    </mirror>" >> "$settingsXML"
+        echo "  </mirrors>" >> "$settingsXML"
+        echo "</settings>" >> "$settingsXML"
+    else
+        if ! grep -q "<url>\${env.MAVEN_MIRROR_URL}</url>" "$settingsXML"; then
+            if grep -q "<mirrors>" "$settingsXML"; then
+                sed -i 's/<mirrors>/<mirrors>\n    <mirror>\n      <url>${env.MAVEN_MIRROR_URL}<\/url>\n      <mirrorOf>external:\*<\/mirrorOf>\n    <\/mirror>/' "$settingsXML"
+            else
+                sed -i 's/<\/settings>/  <mirrors>\n    <mirror>\n      <url>${env.MAVEN_MIRROR_URL}<\/url>\n      <mirrorOf>external:*<\/mirrorOf>\n    <\/mirror>\n  <\/mirrors>\n<\/settings>/' "$settingsXML"
+            fi
+        fi
+    fi
+}
+
+[ ! -z "$MAVEN_MIRROR_URL" ] && set_maven_mirror
+return 0

--- a/dockerfiles/theia-endpoint-runtime/etc/entrypoint.sh
+++ b/dockerfiles/theia-endpoint-runtime/etc/entrypoint.sh
@@ -11,35 +11,6 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-set_maven_mirror() {
-    local m2="$HOME"/.m2
-    local settingsXML="$m2"/settings.xml
-
-    [ ! -d "$m2" ] && mkdir -p "$m2"
-
-    if [ ! -f "$settingsXML" ]; then
-        echo "<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"" >> "$settingsXML"
-        echo "  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" >> "$settingsXML"
-        echo "  xsi:schemaLocation=\"http://maven.apache.org/SETTINGS/1.0.0" >> "$settingsXML"
-        echo "                      https://maven.apache.org/xsd/settings-1.0.0.xsd\">" >> "$settingsXML"
-        echo "  <mirrors>" >> "$settingsXML"
-        echo "    <mirror>" >> "$settingsXML"
-        echo "      <url>\${env.MAVEN_MIRROR_URL}</url>" >> "$settingsXML"
-        echo "      <mirrorOf>external:*</mirrorOf>" >> "$settingsXML"
-        echo "    </mirror>" >> "$settingsXML"
-        echo "  </mirrors>" >> "$settingsXML"
-        echo "</settings>" >> "$settingsXML"
-    else
-        if ! grep -q "<url>\${env.MAVEN_MIRROR_URL}</url>" "$settingsXML"; then
-            if grep -q "<mirrors>" "$settingsXML"; then
-                sed -i 's/<mirrors>/<mirrors>\n    <mirror>\n      <url>${env.MAVEN_MIRROR_URL}<\/url>\n      <mirrorOf>external:\*<\/mirrorOf>\n    <\/mirror>/' "$settingsXML"
-            else
-                sed -i 's/<\/settings>/  <mirrors>\n    <mirror>\n      <url>${env.MAVEN_MIRROR_URL}<\/url>\n      <mirrorOf>external:*<\/mirrorOf>\n    <\/mirror>\n  <\/mirrors>\n<\/settings>/' "$settingsXML"
-            fi
-        fi
-    fi
-}
-
 export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
 
@@ -80,8 +51,7 @@ trap 'responsible_shutdown' SIGHUP SIGTERM SIGINT
 
 cd ${HOME}
 
-# generate settings.xml if needed
-[ ! -z "$MAVEN_MIRROR_URL" ] && set_maven_mirror
+[ -f "/before-start.sh" ] && . "/before-start.sh"
 
 # run theia endpoint
 node /home/theia/lib/node/plugin-remote.js &

--- a/dockerfiles/theia-endpoint-runtime/etc/entrypoint.sh
+++ b/dockerfiles/theia-endpoint-runtime/etc/entrypoint.sh
@@ -11,6 +11,35 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
+set_maven_mirror() {
+    local m2="$HOME"/.m2
+    local settingsXML="$m2"/settings.xml
+
+    [ ! -d "$m2" ] && mkdir -p "$m2"
+
+    if [ ! -f "$settingsXML" ]; then
+        echo "<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"" >> "$settingsXML"
+        echo "  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" >> "$settingsXML"
+        echo "  xsi:schemaLocation=\"http://maven.apache.org/SETTINGS/1.0.0" >> "$settingsXML"
+        echo "                      https://maven.apache.org/xsd/settings-1.0.0.xsd\">" >> "$settingsXML"
+        echo "  <mirrors>" >> "$settingsXML"
+        echo "    <mirror>" >> "$settingsXML"
+        echo "      <url>\${env.MAVEN_MIRROR_URL}</url>" >> "$settingsXML"
+        echo "      <mirrorOf>external:*</mirrorOf>" >> "$settingsXML"
+        echo "    </mirror>" >> "$settingsXML"
+        echo "  </mirrors>" >> "$settingsXML"
+        echo "</settings>" >> "$settingsXML"
+    else
+        if ! grep -q "<url>\${env.MAVEN_MIRROR_URL}</url>" "$settingsXML"; then
+            if grep -q "<mirrors>" "$settingsXML"; then
+                sed -i 's/<mirrors>/<mirrors>\n    <mirror>\n      <url>${env.MAVEN_MIRROR_URL}<\/url>\n      <mirrorOf>external:\*<\/mirrorOf>\n    <\/mirror>/' "$settingsXML"
+            else
+                sed -i 's/<\/settings>/  <mirrors>\n    <mirror>\n      <url>${env.MAVEN_MIRROR_URL}<\/url>\n      <mirrorOf>external:*<\/mirrorOf>\n    <\/mirror>\n  <\/mirrors>\n<\/settings>/' "$settingsXML"
+            fi
+        fi
+    fi
+}
+
 export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
 
@@ -50,6 +79,9 @@ set -e
 trap 'responsible_shutdown' SIGHUP SIGTERM SIGINT
 
 cd ${HOME}
+
+# generate settings.xml if needed
+[ ! -z "$MAVEN_MIRROR_URL" ] && set_maven_mirror
 
 # run theia endpoint
 node /home/theia/lib/node/plugin-remote.js &


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Generates  `/home/theia/.m2/settings.xml` if `MAVEN_MIRROR_URL` is set.

```xml
<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
  <mirrors>
    <mirror>
      <url>${env.MAVEN_MIRROR_URL}</url>
      <mirrorOf>external:*</mirrorOf>
    </mirror>
  </mirrors>
</settings>
```


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14391

