### PR TITLE
Implement remote plugin resources retrieving

### DIFF
--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-reader-extension.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-reader-extension.ts
@@ -1,0 +1,69 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import * as path from 'path';
+import * as express from 'express';
+import * as escape_html from 'escape-html';
+import { injectable, inject } from 'inversify';
+import { HostedPluginReader } from '@theia/plugin-ext/lib/hosted/node/plugin-reader';
+import { HostedPluginRemote } from './hosted-plugin-remote';
+
+/**
+ * Patches original plugin reader to be able to retrieve remote plugin resources.
+ */
+@injectable()
+export class PluginReaderExtension {
+
+    // To be set on connection creation
+    // If there are more than one cnnection, the last one will be used.
+    private hostedPluginRemote: HostedPluginRemote;
+
+    setRemotePluginConnection(hostedPluginRemote: HostedPluginRemote): void {
+        this.hostedPluginRemote = hostedPluginRemote;
+    }
+
+    // Map between a plugin id and its local resources storage
+    private pluginsStorage: Map<string, string>;
+
+    constructor(@inject(HostedPluginReader) hostedPluginReader: HostedPluginReader) {
+        // tslint:disable-next-line:no-any
+        const disclosedPluginReader = (hostedPluginReader as any);
+        // Get link to plugins storages info
+        this.pluginsStorage = disclosedPluginReader.pluginsIdsFiles;
+        // Replace handleMissingResource method, but preserve this of current class
+        const contextedHandleMissingResource = this.handleMissingResource.bind(this);
+        disclosedPluginReader.handleMissingResource = contextedHandleMissingResource;
+    }
+
+    // Handles retrieving of remote resource for plugins.
+    private async handleMissingResource(req: express.Request, res: express.Response): Promise<void> {
+        const pluginId = req.params.pluginId;
+        if (this.hostedPluginRemote) {
+            const resourcePath = req.params.path;
+            try {
+                const resource = await this.hostedPluginRemote.requestPluginResource(pluginId, resourcePath);
+                if (resource) {
+                    res.type(path.extname(resourcePath));
+                    res.send(resource);
+                    return;
+                }
+            } catch (e) {
+                console.error('Failed to get plugin resource from sidecar. Error:', e);
+            }
+        }
+
+        res.status(404).send(`The plugin with id '${escape_html(pluginId)}' does not exist.`);
+    }
+
+    // Exposes paths of plugin resources for other components.
+    public getPluginRootDirectory(pluginId: string): string | undefined {
+        return this.pluginsStorage.get(pluginId);
+    }
+}

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-backend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-backend-module.ts
@@ -8,22 +8,28 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import { ContainerModule } from 'inversify';
+import { ContainerModule, interfaces } from 'inversify';
 import { HostedPluginRemote } from './hosted-plugin-remote';
 import { ServerPluginProxyRunner } from './server-plugin-proxy-runner';
 import { MetadataProcessor, ServerPluginRunner } from '@theia/plugin-ext/lib/common';
 import { RemoteMetadataProcessor } from './remote-metadata-processor';
 import { HostedPluginMapping } from './plugin-remote-mapping';
 import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
+import { PluginReaderExtension } from './plugin-reader-extension';
 
 const localModule = ConnectionContainerModule.create(({ bind }) => {
-    bind(HostedPluginRemote).toSelf().inSingletonScope();
+    bind(HostedPluginRemote).toSelf().inSingletonScope().onActivation((ctx: interfaces.Context, hostedPluginRemote: HostedPluginRemote) => {
+        const pluginReaderExtension = ctx.container.parent.get(PluginReaderExtension);
+        pluginReaderExtension.setRemotePluginConnection(hostedPluginRemote);
+        return hostedPluginRemote;
+    });
     bind(ServerPluginRunner).to(ServerPluginProxyRunner).inSingletonScope();
 });
 
 export default new ContainerModule(bind => {
     bind(HostedPluginMapping).toSelf().inSingletonScope();
     bind(MetadataProcessor).to(RemoteMetadataProcessor).inSingletonScope();
+    bind(PluginReaderExtension).toSelf().inSingletonScope();
+
     bind(ConnectionContainerModule).toConstantValue(localModule);
-}
-);
+});


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Adds PluginReaderExtension class which handles case when requested resource is not found locally and in such cases sends request to corresponding sidecar where plugin resources are actually stored.

This PR does not handle resources for remote plugin webview because they are handles in a different way than usual plugin resources. Created issue for that problem: https://github.com/eclipse/che/issues/14444

#### Changelog
Added support for remote plugins resources on Che Theia frontend side.

#### Release Notes
Added support for remote plugins resources on Che Theia frontend side.

#### Screenshots
Two remote plugins are loaded: Kubernetes plugins and Git UI Tools plugin (last two items in left sidebar)

![remote-plugins](https://user-images.githubusercontent.com/15607393/64419300-465a1200-d0a5-11e9-8168-586b5acc0e76.png)
![gut-ui-tools-remote-resources](https://user-images.githubusercontent.com/15607393/64419463-a2bd3180-d0a5-11e9-9cad-0b0d987ee80d.png)

Fixes https://github.com/eclipse/che/issues/13750
Depends on: https://github.com/theia-ide/theia/pull/6126