### PR TITLE
Change a command to populate local package cache for dotnet image

### DIFF
--- a/dockerfiles/remote-plugin-dotnet-2.2.105/Dockerfile
+++ b/dockerfiles/remote-plugin-dotnet-2.2.105/Dockerfile
@@ -93,5 +93,5 @@ ENV ASPNETCORE_URLS=http://+:80 \
     NUGET_XMLDOC_MODE=skip
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
-RUN dotnet --version
+RUN dotnet help
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Since `dotnet --version` doesn't populate local dotnet packages it was changed to `dotnet help` to do that. All local packages are located in `/usr/share/dotnet/sdk/NuGetFallbackFolder` directory 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14370
https://github.com/eclipse/che/issues/14365
