### PR TITLE
Fixup: Fix syntax error in Che Theia image build script

### DIFF
--- a/dockerfiles/theia-dev/e2e/Dockerfile
+++ b/dockerfiles/theia-dev/e2e/Dockerfile
@@ -18,5 +18,5 @@ RUN git clone -b 'master' --single-branch --depth 1 https://github.com/theia-ide
 # Unset GITHUB_TOKEN environment variable if it is empty.
 # This is needed for some tools which use this variable and will fail with 401 Unauthorized error if it is invalid.
 # For example, vscode ripgrep downloading is an example of such case.
-RUN if [ -z $GITHUB_TOKEN]; then unset GITHUB_TOKEN; fi && \
+RUN if [ -z $GITHUB_TOKEN ]; then unset GITHUB_TOKEN; fi && \
     cd theia && yarn

--- a/dockerfiles/theia-endpoint-runtime/Dockerfile
+++ b/dockerfiles/theia-endpoint-runtime/Dockerfile
@@ -24,7 +24,7 @@ COPY /docker-build/theia-plugin-remote/package.json /home/workspace/packages/the
 # Unset GITHUB_TOKEN environment variable if it is empty.
 # This is needed for some tools which use this variable and will fail with 401 Unauthorized error if it is invalid.
 # For example, vscode ripgrep downloading is an example of such case.
-RUN if [ -z $GITHUB_TOKEN]; then unset GITHUB_TOKEN; fi && \
+RUN if [ -z $GITHUB_TOKEN ]; then unset GITHUB_TOKEN; fi && \
     cd /home/workspace/packages/theia-remote/ && yarn install --ignore-scripts
 
 # Compile
@@ -36,7 +36,7 @@ COPY /docker-build/theia-plugin /home/workspace/packages/theia-plugin
 COPY /docker-build/theia-plugin-remote/tsconfig.json /home/workspace/packages/theia-plugin/tsconfig.json
 
 COPY /etc/package.json /home/workspace
-RUN if [ -z $GITHUB_TOKEN]; then unset GITHUB_TOKEN; fi && \
+RUN if [ -z $GITHUB_TOKEN ]; then unset GITHUB_TOKEN; fi && \
     cd /home/workspace/ && yarn install
 
 FROM node:10.16-alpine

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -61,14 +61,14 @@ RUN che:theia cdn --theia="${CDN_PREFIX}" --monaco="${MONACO_CDN_PREFIX}"
 # Unset GITHUB_TOKEN environment variable if it is empty.
 # This is needed for some tools which use this variable and will fail with 401 Unauthorized error if it is invalid.
 # For example, vscode ripgrep downloading is an example of such case.
-RUN if [ -z $GITHUB_TOKEN]; then unset GITHUB_TOKEN; fi && \
+RUN if [ -z $GITHUB_TOKEN ]; then unset GITHUB_TOKEN; fi && \
     yarn
 
 # Run into production mode
 RUN che:theia production
 
 # Compile plugins
-RUN if [ -z $GITHUB_TOKEN]; then unset GITHUB_TOKEN; fi && \
+RUN if [ -z $GITHUB_TOKEN ]; then unset GITHUB_TOKEN; fi && \
     cd plugins && ./foreach_yarn
 
 # change permissions


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

Fixes syntax error in bash script of Che Theia image build. Fixup for https://github.com/eclipse/che-theia/pull/434