### PR TITLE
Workaround of "API rate limit exceeded" error

### DIFF
--- a/docker_image_build.include
+++ b/docker_image_build.include
@@ -68,7 +68,7 @@ buildImages() {
             if [ "$image_dir" == "dockerfiles/theia" ]; then
                 bash $(pwd)/$image_dir/build.sh --build-args:${GITHUB_TOKEN_ARG},THEIA_VERSION=${THEIA_VERSION} --tag:${IMAGE_TAG} --branch:${THEIA_BRANCH} --git-ref:${THEIA_GIT_REFS}
             elif [ "$image_dir" == "dockerfiles/theia-dev" ]; then
-                bash $(pwd)/$image_dir/build.sh --build-arg:${GITHUB_TOKEN_ARG} --tag:${IMAGE_TAG}
+                bash $(pwd)/$image_dir/build.sh --build-arg:${GITHUB_TOKEN_ARG},CACHEBUST=$(date +%s) --tag:${IMAGE_TAG}
             else
                 bash $(pwd)/$image_dir/build.sh --build-arg:${GITHUB_TOKEN_ARG} --tag:${IMAGE_TAG}
             fi

--- a/dockerfiles/theia-endpoint-runtime/Dockerfile
+++ b/dockerfiles/theia-endpoint-runtime/Dockerfile
@@ -14,9 +14,8 @@ FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-dev:${BUILD_TAG} as builder
 ARG GITHUB_TOKEN=''
 ENV GITHUB_TOKEN=$GITHUB_TOKEN
 
-# Invalidate cache if any source code has changed
-ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/theia-ide/theia/git/refs/head /tmp/branch_info.json
-ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/eclipse/che-theia/git/refs/head /tmp/branch_info.json
+# turn off caching; it's workaround to https://github.com/eclipse/che-theia/compare/che-14529
+ARG CACHEBUST=1
 
 # Grab dependencies
 COPY /docker-build/theia-plugin-remote/package.json /home/workspace/packages/theia-remote/

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -25,8 +25,8 @@ ARG THEIA_VERSION=master
 
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 
-# Invalidate cache if any source code has changed
-ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/${THEIA_GITHUB_REPO}/git/${GIT_REF} /tmp/branch_info.json
+# turn off caching; it's workaround to https://github.com/eclipse/che-theia/compare/che-14529
+ARG CACHEBUST=1
 
 # Clone theia
 RUN git clone --branch ${GIT_BRANCH_NAME} --single-branch --depth 1 https://github.com/${THEIA_GITHUB_REPO} ${HOME}/theia-source-code


### PR DESCRIPTION
### What does this PR do?
It's workaround of "API rate limit exceeded" error, which Dockerfile directives `ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/${THEIA_GITHUB_REPO}/git/refs/heads/master....` threw in time of build.
Workaround is based on http://dev.im-bot.com/docker-select-caching/ solution.

### What issues does this PR fix or reference?
It references https://github.com/eclipse/che/issues/14529