### PR TITLE
Replace github.com/theia-ide/theia by github.com/eclipse-theia/theia.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <img src="https://raw.githubusercontent.com/eclipse/che-theia/master/extensions/eclipse-che-theia-about/src/browser/style/che-logo-light.svg?sanitize=true" alt="Che Logo" width="200" height="60" />
 
-<img src="https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo.svg?sanitize=true" alt="Theia Logo" width="150" height="60"/>
+<img src="https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia-logo.svg?sanitize=true" alt="Theia Logo" width="150" height="60"/>
 
 # Che Theia
 
@@ -26,7 +26,7 @@
 </div>
 
 ## What is Che-theia ?
-[Eclipse Che](https://eclipse.org/che/) provides a default web IDE for the workspaces which is based on the [Theia](https://github.com/theia-ide/theia) project. It’s a subtle different version than a plain  Theia(https://github.com/theia-ide/theia) as there are functionalities that have been added based on the nature of the Eclipse Che workspaces. We are calling this version of Eclipse Theia for Che: Che-Theia.
+[Eclipse Che](https://eclipse.org/che/) provides a default web IDE for the workspaces which is based on the [Theia](https://github.com/eclipse-theia/theia) project. It’s a subtle different version than a plain  Theia(https://github.com/eclipse-theia/theia) as there are functionalities that have been added based on the nature of the Eclipse Che workspaces. We are calling this version of Eclipse Theia for Che: Che-Theia.
 
 So, Che-Theia is the default `Che editor` provided with developer workspaces created in [Eclipse Che 7](https://eclipse.org/che/)([Github](https://github.com/eclipse/che)).
 
@@ -70,7 +70,7 @@ The che-plugin of this editor is defined in the plugin registry https://github.c
 
 [dockerfiles/theia](./dockerfiles/theia) folder contains the container image sources of `eclipse/che-theia`:
 - Using a Docker multistage build and [dockerfiles/theia-dev](./dockerfiles/theia-dev) as builder.
-- Cloning [Theia](https://github.com/theia-ide/theia)
+- Cloning [Theia](https://github.com/eclipse-theia/theia)
 - Using `che:theia init` command to decorate Theia with Che-theia plugins and extensions. All plugins and extensions are defined in [che-theia-init-sources.yml](./che-theia-init-sources.yml)
 - Using `yarn` to build theia + che-theia extensions + che-theia plugins
 - Assembling everything and using `che:theia production` to make the che-theia webapp.

--- a/devfiles/che-theia-all.devfile.yaml
+++ b/devfiles/che-theia-all.devfile.yaml
@@ -15,7 +15,7 @@ projects:
   - name: theia
     source:
       type: git
-      location: 'https://github.com/theia-ide/theia.git'
+      location: 'https://github.com/eclipse-theia/theia.git'
 
 components:
 

--- a/dockerfiles/theia-dev/e2e/Dockerfile
+++ b/dockerfiles/theia-dev/e2e/Dockerfile
@@ -13,7 +13,7 @@ ARG GITHUB_TOKEN=''
 ENV GITHUB_TOKEN=$GITHUB_TOKEN
 
 # Just try to build the latest theia with current image
-RUN git clone -b 'master' --single-branch --depth 1 https://github.com/theia-ide/theia theia
+RUN git clone -b 'master' --single-branch --depth 1 https://github.com/eclipse-theia/theia theia
 
 # Unset GITHUB_TOKEN environment variable if it is empty.
 # This is needed for some tools which use this variable and will fail with 401 Unauthorized error if it is invalid.

--- a/dockerfiles/theia-endpoint-runtime/Dockerfile
+++ b/dockerfiles/theia-endpoint-runtime/Dockerfile
@@ -15,7 +15,7 @@ ARG GITHUB_TOKEN=''
 ENV GITHUB_TOKEN=$GITHUB_TOKEN
 
 # Invalidate cache if any source code has changed
-ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/theia-ide/theia/git/refs/head /tmp/branch_info.json
+ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/eclipse-theia/theia/git/refs/head /tmp/branch_info.json
 ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/eclipse/che-theia/git/refs/head /tmp/branch_info.json
 
 # Grab dependencies

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR ${HOME}
 ARG GITHUB_TOKEN=''
 ENV GITHUB_TOKEN=$GITHUB_TOKEN
 
-ARG THEIA_GITHUB_REPO=theia-ide/theia
+ARG THEIA_GITHUB_REPO=eclipse-theia/theia
 
 # Define upstream version of theia to use
 ARG THEIA_VERSION=master

--- a/extensions/eclipse-che-theia-plugin-remote/devfile.yaml
+++ b/extensions/eclipse-che-theia-plugin-remote/devfile.yaml
@@ -5,7 +5,7 @@ projects:
   - name: theia
     source:
       type: git
-      location: 'https://github.com/theia-ide/theia.git'
+      location: 'https://github.com/eclipse-theia/theia.git'
 components:
   - type: cheEditor
     id: eclipse/che-theia/next

--- a/generator/README.md
+++ b/generator/README.md
@@ -33,7 +33,7 @@ Once the tool is installed, the following commands are available:
 This command needs to be launched inside a cloned directory of Eclipse Theia cloned directory
 
 ```
-$ git clone https://github.com/theia-ide/theia
+$ git clone https://github.com/eclipse-theia/theia
 $ cd theia
 $ che:theia init
 ```

--- a/generator/tests/init/root-folder/packages/core/package.json
+++ b/generator/tests/init/root-folder/packages/core/package.json
@@ -62,12 +62,12 @@
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/theia.git"
+    "url": "https://github.com/eclipse-theia/theia.git"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/theia/issues"
+    "url": "https://github.com/eclipse-theia/theia/issues"
   },
-  "homepage": "https://github.com/theia-ide/theia",
+  "homepage": "https://github.com/eclipse-theia/theia",
   "files": [
     "lib",
     "src"

--- a/plugins/factory-plugin/tests/projects.spec.ts
+++ b/plugins/factory-plugin/tests/projects.spec.ts
@@ -162,7 +162,7 @@ describe('Devfile: Projects:', () => {
                     'name': 'theia',
                     'source': {
                         'type': 'git',
-                        'location': 'https://github.com/theia-ide/theia.git'
+                        'location': 'https://github.com/eclipse-theia/theia.git'
                     }
                 },
                 {
@@ -175,7 +175,7 @@ describe('Devfile: Projects:', () => {
                     }
                 }
             ];
-            expect(projects[0].source.location).toBe('https://github.com/theia-ide/theia.git');
+            expect(projects[0].source.location).toBe('https://github.com/eclipse-theia/theia.git');
             expect(projects[1].source.location).toBe('https://github.com/eclipse/che-theia-factory-extension.git');
 
             projecthelper.updateOrCreateGitProjectInDevfile(projects,
@@ -201,7 +201,7 @@ describe('Devfile: Projects:', () => {
                     'name': 'theia',
                     'source': {
                         'type': 'git',
-                        'location': 'https://github.com/theia-ide/theia.git'
+                        'location': 'https://github.com/eclipse-theia/theia.git'
                     }
                 },
                 {
@@ -214,12 +214,12 @@ describe('Devfile: Projects:', () => {
                     }
                 }
             ];
-            expect(projects[0].source.location).toBe('https://github.com/theia-ide/theia.git');
+            expect(projects[0].source.location).toBe('https://github.com/eclipse-theia/theia.git');
             expect(projects[1].source.location).toBe('https://github.com/eclipse/che-theia-factory-extension.git');
 
             projecthelper.deleteProjectFromDevfile(projects, 'che-theia-factory-extension');
             expect(projects.length).toBe(1);
-            expect(projects[0].source.location).toBe('https://github.com/theia-ide/theia.git');
+            expect(projects[0].source.location).toBe('https://github.com/eclipse-theia/theia.git');
 
             projecthelper.deleteProjectFromDevfile(projects, 'theia');
             expect(projects.length).toBe(0);


### PR DESCRIPTION
Fixes https://github.com/eclipse/che/issues/14529

### What does this PR do?
As theia upstream moved from github.com/theia-ide/theia to github.com/eclipse-theia/theia, I'm opening this PR to target that.

Also this caused failures like https://github.com/eclipse/che/issues/14529, because the second call in the redirect was not using the github token, thus we were hitting API rate limits. This PR should fix that.

Only required places to fix #14529 are the dockerfiles, but I thought it would be nice to change it everywhere.

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/14529
