### PR TITLE
Run Che command in selected container

### DIFF
--- a/plugins/containers-plugin/src/containers-plugin.ts
+++ b/plugins/containers-plugin/src/containers-plugin.ts
@@ -8,9 +8,13 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import { ContainersTreeDataProvider } from './containers-tree-data-provider';
-import { ContainersService } from './containers-service';
 import * as theia from '@theia/plugin';
+import { ContainersService } from './containers-service';
+import {
+    ContainersTreeDataProvider,
+    CONTAINERS_PLUGIN_RUN_TASK_COMMAND_ID,
+    containersTreeTaskLauncherCommandHandler
+} from './containers-tree-data-provider';
 
 export function start(context: theia.PluginContext) {
     const treeDataProvider = new ContainersTreeDataProvider();
@@ -28,6 +32,11 @@ export function start(context: theia.PluginContext) {
         console.error(error);
         theia.window.showErrorMessage(error);
     });
+
+    const containersTreeTaskLauncherCommand = { id: CONTAINERS_PLUGIN_RUN_TASK_COMMAND_ID };
+    context.subscriptions.push(
+        theia.commands.registerCommand(containersTreeTaskLauncherCommand, containersTreeTaskLauncherCommandHandler)
+    );
 }
 
 export function stop() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8270,9 +8270,9 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
-"moxios@git://github.com/stoplightio/moxios.git#v1.3.0":
+"moxios@git://github.com/stoplightio/moxios#v1.3.0":
   version "1.3.0"
-  resolved "git://github.com/stoplightio/moxios.git#9d702c8eafee4b02917d6bc400ae15f1e835cf51"
+  resolved "git://github.com/stoplightio/moxios#9d702c8eafee4b02917d6bc400ae15f1e835cf51"
   dependencies:
     class-autobind "^0.1.4"
 


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
In some cases it is impossible to figure out container for a command defined in Che workspace devfile. Then such a command is displayed in each container of the workspace in Workspace panel. But when a user clicks on it, Che asks the user to select container in which this command should be run. But in case of clicking on specific node of specific container it is obvious in which container this command should be run this time.
This PR addresses such case and runs the clicked command in the right container.

Example of workspace which has ambiguous commands:
<details>
<summary>devfile</summary>

```yaml
metadata:
  name: test-tasks
projects:
  - name: NodeJS-Sample-App.git
    source:
      location: 'https://github.com/sleshchenko/NodeJS-Sample-App.git'
      type: git
      branch: master
components:
  - id: eclipse/che-theia/next
    type: cheEditor
    alias: theia-editor
  - referenceContent: |
      ---
      apiVersion: v1
      kind: List
      items:
      -
        apiVersion: apps/v1
        kind: Deployment
        metadata:
          name: mongo
          labels:
            app.kubernetes.io/name: employee-manager
            app.kubernetes.io/component: database
        spec:
          selector:
            matchLabels:
              app.kubernetes.io/name: employee-manager
              app.kubernetes.io/component: database
          template:
            metadata:
              labels:
                app.kubernetes.io/name: employee-manager
                app.kubernetes.io/component: database
              name: mongo
            spec:
              containers:
              - name: mongo
                image: mongo
                ports:
                - name: mongo
                  containerPort: 27017
                volumeMounts:
                    - name: mongo-persistent-storage
                      mountPath: /data/db
              volumes:
                - name: mongo-persistent-storage
                  persistentVolumeClaim:
                    claimName: mongo-persistent-storage
      -
        apiVersion: v1
        kind: Service
        metadata:
          name: mongo
          labels:
            app.kubernetes.io/name: employee-manager
            app.kubernetes.io/component: database
        spec:
          ports:
            - port: 27017
              targetPort: 27017
          selector:
            app.kubernetes.io/name: employee-manager
            app.kubernetes.io/component: database
      -
        apiVersion: v1
        kind: PersistentVolumeClaim
        metadata:
          name: mongo-persistent-storage
          labels:
            app.kubernetes.io/name: employee-manager
            app.kubernetes.io/component: database
        spec:
          accessModes:
          - ReadWriteOnce
          resources:
            requests:
              storage: 1Gi
      -
        apiVersion: apps/v1
        kind: Deployment
        metadata:
          name: nodejs-app
          labels:
            app.kubernetes.io/name: employee-manager
            app.kubernetes.io/component: nodejs-app
        spec:
          selector:
            matchLabels:
              app.kubernetes.io/name: employee-manager
              app.kubernetes.io/component: nodejs-app
          template:
            metadata:
              labels:
                app.kubernetes.io/name: employee-manager
                app.kubernetes.io/component: nodejs-app
              name: nodejs-app
            spec:
              containers:
              - name: web-app
                command: ["tail"]
                args: ["-f", "/dev/null"]
                image: "sleshchenko/nodejs-mongo-sample:latest"
                ports:
                - containerPort: 3000
                  name: http-server
                env:
                  - name: MONGO_HOST
                    value: "mongo"
                  - name: MONGO_PORT
                    value: "27017"
                volumeMounts:
                  - name: projects
                    mountPath: /projects
              volumes:
                - name: projects
                  persistentVolumeClaim:
                    claimName: projects
      -
        apiVersion: v1
        kind: Service
        metadata:
          name: web
          labels:
            app.kubernetes.io/name: employee-manager
            app.kubernetes.io/component: nodejs-app
        spec:
          type: LoadBalancer
          ports:
            - name: web
              port: 80
              targetPort: 3000
              protocol: TCP
          selector:
            app.kubernetes.io/name: employee-manager
            app.kubernetes.io/component: nodejs-app
      -
        apiVersion: extensions/v1beta1
        kind: Ingress
        metadata:
          name: nodejs-ingress
          labels:
            app.kubernetes.io/name: employee-manager
            app.kubernetes.io/component: nodejs-app
          annotations:
            kubernetes.io/ingress.class: "nginx"
        spec:
          rules:
          - host: nodejs.192.168.99.100.nip.io
            http:
              paths:
              - path: /
                backend:
                  serviceName: web
                  servicePort: 80
      -
        apiVersion: v1
        kind: PersistentVolumeClaim
        metadata:
          name: projects
          labels:
            app.kubernetes.io/name: employee-manager
            app.kubernetes.io/component: nodejs-app
        spec:
          accessModes:
          - ReadWriteOnce
          resources:
            requests:
              storage: 1Gi
    type: kubernetes
    alias: employee-manager
    reference: deploy_k8s.yaml
apiVersion: 1.0.0
commands:
  - name: Test ls and echo
    actions:
      - workdir: /home
        type: exec
        command: ls -l && echo "hello world"
        component: employee-manager
  - name: Echo test works
    actions:
      - workdir: /projects
        type: exec
        command: ls -la && echo "hello world"
        component: theia-dev
  - name: Test echo
    actions:
      - type: exec
        command: echo "hello world"
        component: employee-manager
  - name: Test echo
    actions:
      - type: exec
        command: echo "hello world"
        component: employee-manager
  - name: build (test)
    actions:
      - workdir: /projects/theia
        type: exec
        command: yarn
        component: employee-manager

```

</details>


Provides fix for: https://github.com/eclipse/che/issues/13764