### PR TITLE
Remove @theia/tslint extension in favor of plugin

### DIFF
--- a/generator/src/templates/assembly-package.mst
+++ b/generator/src/templates/assembly-package.mst
@@ -41,7 +41,6 @@
     "@theia/search-in-workspace": "^{{ version }}",
     "@theia/task": "^{{ version }}",
     "@theia/textmate-grammars": "^{{ version }}",
-    "@theia/tslint": "^{{ version }}",
     "@theia/userstorage": "^{{ version }}",
     "@theia/variable-resolver": "^{{ version }}",
     "@theia/workspace": "^{{ version }}"

--- a/generator/tests/init-sources/assembly-example/assembly-package.json
+++ b/generator/tests/init-sources/assembly-example/assembly-package.json
@@ -32,7 +32,6 @@
     "@theia/search-in-workspace": "^0.3.16",
     "@theia/task": "^0.3.16",
     "@theia/textmate-grammars": "^0.3.16",
-    "@theia/tslint": "^0.3.16",
     "@theia/userstorage": "^0.3.16",
     "@theia/variable-resolver": "^0.3.16",
     "@theia/workspace": "^0.3.16",

--- a/generator/tests/production/assembly/package.json
+++ b/generator/tests/production/assembly/package.json
@@ -32,7 +32,6 @@
     "@theia/search-in-workspace": "^0.3.16",
     "@theia/task": "^0.3.16",
     "@theia/textmate-grammars": "^0.3.16",
-    "@theia/tslint": "^0.3.16",
     "@theia/userstorage": "^0.3.16",
     "@theia/variable-resolver": "^0.3.16",
     "@theia/workspace": "^0.3.16",


### PR DESCRIPTION
Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
The PR removes @theia/tslint extension in favor of plugin

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/14070

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
@theia/tslint extension is removed in favor of plugin

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
