### PR TITLE
Add 'github' project type to factory-plugin

### DIFF
--- a/plugins/factory-plugin/src/theia-commands.ts
+++ b/plugins/factory-plugin/src/theia-commands.ts
@@ -46,6 +46,7 @@ export function buildProjectImportCommand(
 
     switch (project.source.type) {
         case 'git':
+        case 'github':
             return new TheiaGitCloneCommand(project, projectsRoot);
         case 'zip':
             return new TheiaImportZipCommand(project, projectsRoot);


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Adds missed project type to factory plugin.

### What issues does this PR fix or reference?

fix https://github.com/eclipse/che/issues/14668
