### PR TITLE
Show notification when terminal fails to open.

### DIFF
--- a/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
@@ -95,12 +95,12 @@ export class RemoteTerminalWidget extends TerminalWidgetImpl {
 
                 let reason = '';
                 if (errEvent.stack.indexOf(badDefaultLoginErr) !== -1) {
-                    reason = ' Possible reason is bad default login.';
+                    reason = 'Possible reason is terminal cannot open default login shell. ';
                 } else if (errEvent.stack.indexOf(missedPrivilegesErr) !== -1) {
-                    reason = ' Possible reason is workspace service account lacks some privileges.';
+                    reason = 'Possible reason is workspace service account lacks some privileges. ';
                 }
-                reason += ' See more in "Output".';
-                this.messageService.error(`Terminal failed to open.${reason}`);
+                reason += 'See more in "Output".';
+                this.messageService.error(`Terminal failed to connect. ${reason}`);
             }
         }));
     }


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

If remote terminal fails to open, an error notification will be shown. A notification may contain possible fault reason. Also, an error's stack trace will be sent to Output channel.

#### Notifications

- `Terminal failed to open. Possible reason is bad default login. See more in "Output".`
- `Terminal failed to open. Possible reason is workspace service account lacks some privileges. See more in "Output".`
- `Terminal failed to open. See more in "Output".`

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/13980

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


