### PR TITLE
Fix getting processId at using terminal API

### DIFF
--- a/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
@@ -99,7 +99,18 @@ export class RemoteTerminalWidget extends TerminalWidgetImpl {
         } catch (err) {
             throw new Error('Failed to create terminal server proxy. Cause: ' + err);
         }
-        this.terminalId = typeof id !== 'number' ? await this.createTerminal() : await this.attachTerminal(id);
+
+        try {
+            this.terminalId = typeof id !== 'number' ? await this.createTerminal() : await this.attachTerminal(id);
+        } catch (error) {
+            if (IBaseTerminalServer.validateId(id)) {
+                this.terminalId = id;
+                this.onDidOpenEmitter.fire(undefined);
+                return this.terminalId;
+            }
+            throw new Error('Failed to start terminal. Cause: ' + error);
+        }
+
         this.connectTerminalProcess();
 
         await this.waitForRemoteConnection;


### PR DESCRIPTION
### What does this PR do?
Fix the bug related to hanging of request for getting [processId](https://github.com/eclipse-theia/theia/blob/2a978748c6e51a1f31adb34ed4661528e4e98438/packages/plugin/src/theia.d.ts#L2550) for terminal.

The cause of the bug is: [deferredProcessId](https://github.com/eclipse-theia/theia/blob/02c5c1d4539efa8b19f9d0991be9827c88e184f6/packages/plugin-ext/src/plugin/terminal-ext.ts#L94) is never resolved/rejected for case when starting of a terminal is failed. The good example to reproduce it:
- run a task
- wait till the task is completed
- refresh page and try to get `processId` using terminal API

So for this case attempt to attach to corresponding terminal is failed (the task is completed), as result we have opened terminal widget, but info about `processId` for related terminal is absent.

The PR allows to resolve deferred `processId` for described case if we have valid `id`.
 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14659

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>