### PR TITLE
According to Dockerfile linter in vscode,...

### DIFF
--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -71,7 +71,7 @@ RUN npm config set prefix "${HOME}/.npm-global" && \
         chmod -R g+rwX ${f}; \
     done
 
-WORKDIR "/projects"
+WORKDIR /projects
 
 ADD src/entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
According to Dockerfile linter in vscode, 'WORKDIR paths should be absolute'

Change-Id: I04467062ee86168f39bd7cdc7943e2dcdd2ebff4
Signed-off-by: nickboldt <nboldt@redhat.com>