### PR TITLE
Use theia-plugin-ext from node_modules.

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-api-provider.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-api-provider.ts
@@ -22,7 +22,7 @@ export class ChePluginApiProvider implements ExtPluginApiProvider {
                 initFunction: 'initializeApi',
                 initVariable: 'che_api_provider'
             },
-            backendInitPath: path.join(__dirname, '../plugin/node/che-api-node-provider.js')
+            backendInitPath: path.join('@eclipse-che/theia-plugin-ext/lib/plugin/node/che-api-node-provider.js')
         };
     }
 

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-backend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-backend-module.ts
@@ -27,6 +27,12 @@ const localModule = ConnectionContainerModule.create(({ bind }) => {
 });
 
 export default new ContainerModule(bind => {
+    try {
+        // Force to include theia-plugin-ext inside node_modules
+        require('@eclipse-che/theia-plugin-ext/lib/node/che-plugin-api-provider.js');
+    } catch (err) {
+        console.log('Unable to set up che theia plugin api: ', err);
+    }
     bind(HostedPluginMapping).toSelf().inSingletonScope();
     bind(MetadataProcessor).to(RemoteMetadataProcessor).inSingletonScope();
     bind(PluginReaderExtension).toSelf().inSingletonScope();


### PR DESCRIPTION
### What does this PR do?
Use theia-plugin-ext from node_modules. We need this because nexe tool doesn't resolve path with `__dirname`.

### What issues does this PR fix or reference?
Needed for https://github.com/eclipse/che/issues/13387

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
