### PR TITLE
Add python 3.7.4 runtime to dependency analytics

### DIFF
--- a/docker_image_build.include
+++ b/docker_image_build.include
@@ -42,6 +42,7 @@ dockerfiles/remote-plugin-kubernetes-tooling-1.0.0
 dockerfiles/remote-plugin-openshift-connector-0.0.17
 dockerfiles/remote-plugin-openshift-connector-0.0.21
 dockerfiles/remote-plugin-dependency-analytics-0.0.12
+dockerfiles/remote-plugin-dependency-analytics-0.0.13
 )
 
 IMAGES_LIST=(
@@ -62,6 +63,7 @@ eclipse/che-remote-plugin-kubernetes-tooling-1.0.0
 eclipse/che-remote-plugin-openshift-connector-0.0.17
 eclipse/che-remote-plugin-openshift-connector-0.0.21
 eclipse/che-remote-plugin-dependency-analytics-0.0.12
+eclipse/che-remote-plugin-dependency-analytics-0.0.13
 )
 
 buildImages() {

--- a/dockerfiles/remote-plugin-dependency-analytics-0.0.13/Dockerfile
+++ b/dockerfiles/remote-plugin-dependency-analytics-0.0.13/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:${BUILD_TAG}
+# npm comes from the base image, install maven and python3.
+RUN apk --update --no-cache add openjdk8 procps nss maven python3 && [[ ! -e /usr/bin/python ]] && \
+    ln -sf /usr/bin/python3 /usr/bin/python
+ENV JAVA_HOME /usr/lib/jvm/default-jvm/
+
+ENV MAVEN_VERSION 3.5.4
+ENV MAVEN_HOME /usr/lib/mvn
+ENV PATH $MAVEN_HOME/bin:$PATH
+
+RUN wget http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz && \
+  tar -zxvf apache-maven-$MAVEN_VERSION-bin.tar.gz && \
+  rm apache-maven-$MAVEN_VERSION-bin.tar.gz && \
+  mv apache-maven-$MAVEN_VERSION /usr/lib/mvn
+
+WORKDIR /projects

--- a/dockerfiles/remote-plugin-dependency-analytics-0.0.13/build.sh
+++ b/dockerfiles/remote-plugin-dependency-analytics-0.0.13/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
+
+init --name:remote-plugin-dependency-analytics-0.0.13 "$@"
+build


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
It adds python runtime to dependency analytics image which is needed for Dependency Analytics Plugin from [0.0.13](https://marketplace.visualstudio.com/items?itemName=redhat.fabric8-analytics) onwards. 

Related but reverted PR: https://github.com/eclipse/che-theia/pull/445