### PR TITLE
add --image-name: flag so that full image...

### DIFF
--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -92,6 +92,9 @@ init() {
       --git-ref:*)
         GIT_REF="${1#*:}"
         shift ;;
+      --image-name:*)
+        IMAGE_NAME="${1#*:}"
+        shift ;;
       --*)
         printf "${RED}Unknown parameter: $1${NC}\n"; exit 2 ;;
       *)
@@ -99,7 +102,7 @@ init() {
     esac
   done
 
-  IMAGE_NAME="$ORGANIZATION/$PREFIX-$NAME:$TAG"
+  IMAGE_NAME="${IMAGE_NAME:-$ORGANIZATION/$PREFIX-$NAME:$TAG}"
 }
 
 build() {


### PR DESCRIPTION
add --image-name: flag so that full image name can be overridden, not just fragments (eg., when we don't want PREFIX-NAME as the container name, but just NAME)

Related to https://github.com/eclipse/che/issues/13765

Change-Id: I91333d8404c7c36fec1d58d4bfe488da7eb3cde9
Signed-off-by: nickboldt <nboldt@redhat.com>