### PR TITLE
Throw error instead of using  hardcoded url for plugin registry

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -81,15 +81,8 @@ export class ChePluginServiceImpl implements ChePluginService {
 
             return Promise.reject('Plugin registry URI is not set.');
         } catch (error) {
-            // console.log('ERROR', error);
-            // return Promise.reject('Unable to get default plugin registry URI. ' + error.message);
-
-            // A temporary solution. Should throw an error instead.
-            this.defaultRegistry = {
-                name: 'Eclipse Che plugin registry',
-                uri: 'https://che-plugin-registry.openshift.io/v3/plugins/'
-            };
-            return this.defaultRegistry;
+            console.error(error);
+            return Promise.reject(`Unable to get default plugin registry URI. ${error.message}`);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Yevhen Vydolob <yvydolob@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Throws error instead of using hardcoded url for plugin registry

### What issues does this PR fix or reference?
eclipse/che#14553 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

