### PR TITLE
Do not catch error while executing Git commands, factory plugin

### DIFF
--- a/plugins/factory-plugin/src/exec.ts
+++ b/plugins/factory-plugin/src/exec.ts
@@ -18,12 +18,14 @@ export async function execute(commandLine: string, args?: string[], options?: Sp
     return new Promise<string>((resolve, reject) => {
         const command = spawn(commandLine, args, options);
         let result = '';
+        let error = '';
         // tslint:disable-next-line:no-any
         command.stdout.on('data', (data: any) => {
             result += data.toString();
         });
         // tslint:disable-next-line:no-any
         command.stderr.on('data', (data: any) => {
+            error += data.toString();
             console.error(`Child process ${commandLine} stderr: ${data}`);
         });
         command.on('close', (code: number | null) => {
@@ -33,7 +35,7 @@ export async function execute(commandLine: string, args?: string[], options?: Sp
                 resolve(result.trim());
                 console.log(message);
             } else {
-                reject(new Error(message));
+                reject(new Error(error.length > 0 ? error : message));
                 console.error(message);
             }
         });

--- a/plugins/factory-plugin/src/git.ts
+++ b/plugins/factory-plugin/src/git.ts
@@ -16,7 +16,12 @@ export interface GitUpstreamBranch {
 }
 
 export async function getUpstreamBranch(projectPath: string): Promise<GitUpstreamBranch | undefined> {
-    const remoteBranchRef = await execGit(projectPath, 'rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}');
+    let remoteBranchRef;
+    try {
+        remoteBranchRef = await execGit(projectPath, 'rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}');
+    } catch (e) {
+        console.log(e);
+    }
     if (!remoteBranchRef) {
         return;
     }
@@ -27,8 +32,12 @@ export async function getUpstreamBranch(projectPath: string): Promise<GitUpstrea
     return gitUpstreamBranch;
 }
 
-export function getRemoteURL(remote: string, projectPath: string): Promise<string | undefined> {
-    return execGit(projectPath, 'config', '--get', `remote.${remote}.url`);
+export async function getRemoteURL(remote: string, projectPath: string): Promise<string | undefined> {
+    try {
+        return execGit(projectPath, 'config', '--get', `remote.${remote}.url`);
+    } catch (e) {
+        console.log(e);
+    }
 }
 
 export function parseGitUpstreamBranch(gitBranchvvOutput: string): GitUpstreamBranch | undefined {
@@ -55,5 +64,5 @@ export function getGitRootFolder(uri: string): string {
 }
 
 export async function execGit(directory: string, ...args: string[]): Promise<string | undefined> {
-    return execute('git', args, { cwd: directory }).catch(() => undefined);
+    return execute('git', args, { cwd: directory });
 }


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add ability to handle error from `execGit()` method.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/14775

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
