### PR TITLE
Provide Docker image for Camel K plugin eclipse/che#14806

### DIFF
--- a/dockerfiles/remote-plugin-camelk-0.0.9/Dockerfile
+++ b/dockerfiles/remote-plugin-camelk-0.0.9/Dockerfile
@@ -1,0 +1,15 @@
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+FROM ${BUILD_ORGANIZATION}/che-remote-plugin-kubernetes-tooling-1.0.0:${BUILD_TAG}
+
+ENV KAMEL_VERSION 1.0.0-M1
+
+RUN curl -L https://github.com/apache/camel-k/releases/download/${KAMEL_VERSION}/camel-k-client-${KAMEL_VERSION}-linux-64bit.tar.gz | tar -C /usr/local/bin -xz \
+	&& chmod +x /usr/local/bin/kamel

--- a/dockerfiles/remote-plugin-camelk-0.0.9/build.sh
+++ b/dockerfiles/remote-plugin-camelk-0.0.9/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
+
+init --name:remote-plugin-camelk-0.0.9 "$@"
+build


### PR DESCRIPTION
- reuse Kubernetes image
- add kamel executable

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

### What does this PR do?

provides the Dockerfile that will be used for VS Code Camel K extension to pu tin Che registry

### What issues does this PR fix or reference?

eclipse/che#14806

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
