### PR TITLE
chore(docker): Fix theia build: che theia archive was not a .gz archive

### DIFF
--- a/dockerfiles/theia/build.sh
+++ b/dockerfiles/theia/build.sh
@@ -16,7 +16,7 @@ DIR=$(cd "$(dirname "$0")"; pwd)
 
 # create che-theia archive
 echo "Compresing 'che-theia' --> ${DIR}/asset-che-theia.tar.gz"
-cd "${DIR}"/../.. && git ls-files -z -c -o --exclude-standard | xargs -0 tar rf ${DIR}/asset-che-theia.tar.gz
+cd "${DIR}"/../.. && git ls-files -c -o --exclude-standard | tar czvf ${DIR}/asset-che-theia.tar.gz  -T -
 
 # Download plugins
 THEIA_YEOMAN_PLUGIN="${DIR}/asset-untagged-c11870b25a17d20bb7a7-theia_yeoman_plugin.theia"


### PR DESCRIPTION
### What does this PR do?

Fix command for building che-theia archive
Also it's was appending to the archive so you might had duplicates

### What issues does this PR fix or reference?
brew system / @nickboldt reported that when using the archive, it was a tar archive, not gzipped archive as filename extension was reported.

Change-Id: I25a7a45b2af6ab20c961c1f34303722e4e9de13c
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
