### PR TITLE
Revert "feat(core): add Camel K docker file to the list of image to build"

### DIFF
--- a/docker_image_build.include
+++ b/docker_image_build.include
@@ -44,7 +44,6 @@ dockerfiles/remote-plugin-kubernetes-tooling-1.0.0
 dockerfiles/remote-plugin-openshift-connector-0.0.17
 dockerfiles/remote-plugin-openshift-connector-0.0.21
 dockerfiles/remote-plugin-openshift-connector-0.1.0
-dockerfiles/remote-plugin-camelk-0.0.9
 dockerfiles/remote-plugin-dependency-analytics-0.0.12
 dockerfiles/remote-plugin-dependency-analytics-0.0.13
 )
@@ -68,7 +67,6 @@ eclipse/che-remote-plugin-kubernetes-tooling-1.0.0
 eclipse/che-remote-plugin-openshift-connector-0.0.17
 eclipse/che-remote-plugin-openshift-connector-0.0.21
 eclipse/che-remote-plugin-openshift-connector-0.1.0
-eclipse/che-remote-plugin-camelk-0.0.9
 eclipse/che-remote-plugin-dependency-analytics-0.0.12
 eclipse/che-remote-plugin-dependency-analytics-0.0.13
 )


### PR DESCRIPTION
Reverts eclipse/che-theia#478
as it is making the master to fail and I have no idea how to fix it:

```
The push refers to repository [docker.io/eclipse/che-remote-plugin-camelk-0.0.9]
cb8720a72b9a: Preparing
0e75c05e8731: Preparing
e5bee3b287c3: Preparing
cbaff6e374e6: Preparing
ac8a5ead271d: Preparing
b022716fa5ce: Preparing
99d0d4f68ae9: Preparing
53ac1bdeddc2: Preparing
b58325fd75e7: Preparing
99f41ef21e62: Preparing
3a5ccd3762b9: Preparing
f3eaf5209bfb: Preparing
9f15ecbdf2f3: Preparing
53ac1bdeddc2: Waiting
b58325fd75e7: Waiting
99f41ef21e62: Waiting
3a5ccd3762b9: Waiting
f3eaf5209bfb: Waiting
9f15ecbdf2f3: Waiting
b022716fa5ce: Waiting
99d0d4f68ae9: Waiting
denied: requested access to the resource is denied
```

Which resource access is denied? Why?