### PR TITLE
Add Dockerfile for Kubernetes Che Plugin based on VS Code Kubernetes extension 1.0.4

### DIFF
--- a/build.include
+++ b/build.include
@@ -77,6 +77,7 @@ DOCKER_FILES_LOCATIONS=(
   dockerfiles/remote-plugin-dotnet-2.2.105
   dockerfiles/remote-plugin-kubernetes-tooling-0.1.17
   dockerfiles/remote-plugin-kubernetes-tooling-1.0.0
+  dockerfiles/remote-plugin-kubernetes-tooling-1.0.4
   dockerfiles/remote-plugin-openshift-connector-0.0.17
   dockerfiles/remote-plugin-openshift-connector-0.0.21
   dockerfiles/remote-plugin-openshift-connector-0.1.0
@@ -101,6 +102,7 @@ PUBLISH_IMAGES_LIST=(
   eclipse/che-remote-plugin-dotnet-2.2.105
   eclipse/che-remote-plugin-kubernetes-tooling-0.1.17
   eclipse/che-remote-plugin-kubernetes-tooling-1.0.0
+  eclipse/che-remote-plugin-kubernetes-tooling-1.0.4
   eclipse/che-remote-plugin-openshift-connector-0.0.17
   eclipse/che-remote-plugin-openshift-connector-0.0.21
   eclipse/che-remote-plugin-openshift-connector-0.1.0

--- a/dockerfiles/remote-plugin-kubernetes-tooling-1.0.4/Dockerfile
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-1.0.4/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:${BUILD_TAG} as endpoint
+FROM quay.io/buildah/stable:v1.11.3
+
+ENV KUBECTL_VERSION v1.16.1
+ENV HELM_VERSION v2.14.3
+ENV HOME=/home/theia
+
+RUN curl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    curl -o- -L https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar xvz -C /usr/local/bin --strip 1 && \
+    # set up local Helm configuration skipping Tiller installation
+    helm init --client-only && \
+    # 'which' utility is used by VS Code Kubernetes extension to find the binaries, e.g. 'kubectl'
+    dnf install -y which nodejs
+
+COPY --from=endpoint /home/theia /home/theia
+COPY --from=endpoint /projects /projects
+COPY --from=endpoint /etc/passwd /etc/passwd
+COPY --from=endpoint /etc/group /etc/group
+COPY --from=endpoint /entrypoint.sh /entrypoint.sh
+
+RUN chmod g+w /home/theia
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dockerfiles/remote-plugin-kubernetes-tooling-1.0.4/build.sh
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-1.0.4/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
+
+init --name:remote-plugin-kubernetes-tooling-1.0.4 "$@"
+build


### PR DESCRIPTION

Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds Dockerfile for building an image for Kubernetes Tooling Che Plugin 1.0.4 introduced by https://github.com/eclipse/che-plugin-registry/pull/256

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13316

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
