### PR TITLE
Resolve preview URL for notification

### DIFF
--- a/plugins/task-plugin/src/preview/task-events-handler.ts
+++ b/plugins/task-plugin/src/preview/task-events-handler.ts
@@ -75,7 +75,7 @@ export class CheTaskEventsHandler {
             default: {
                 const url = await this.previewUrlOpenService.resolve(previewUrl);
                 const message = `Task ${task.name} launched a service on ${url}`;
-                this.askUser(message, previewUrl);
+                this.askUser(message, url || previewUrl);
                 break;
             }
         }


### PR DESCRIPTION
### What does this PR do?
Resolve preview URL for notification.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14820

### How to test
Please use steps to reproduce from the issue description
or

1. start a workspace 
1. open `.theia/tasks.json` file and add the configuraion
 ```
           {
                "type": "che",
                "label": "test task",
                "command": "sleep 30 && echo task is completed",
                "target": {
                    "workingDir": "/projects",
                    "containerName": "che-dev"
                },
                "previewUrl": "${server.theia}",
                "problemMatcher": []
            }
```  

1. save `.theia/tasks.json` and run the task
1. right-bottom notification with previewUrl should appear. URL to theia component is correct there
1. try to use `Preview` and `Go To` buttons in the right-bottom notification: opened URL should be properly evaluated.


Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>