### PR TITLE
Register preview URL links as variables

### DIFF
--- a/plugins/task-plugin/src/che-task-backend-module.ts
+++ b/plugins/task-plugin/src/che-task-backend-module.ts
@@ -30,6 +30,7 @@ import { ConfigFileLaunchConfigsExtractor } from './extract/config-file-launch-c
 import { ConfigFileTasksExtractor } from './extract/config-file-task-configs-extractor';
 import { VsCodeLaunchConfigsExtractor } from './extract/vscode-launch-configs-extractor';
 import { VsCodeTaskConfigsExtractor } from './extract/vscode-task-configs-extractor';
+import { PreviewUrlVariableResolver } from './variable/preview-url-variable-resolver';
 
 const container = new Container();
 container.bind(CheTaskProvider).toSelf().inSingletonScope();
@@ -40,6 +41,7 @@ container.bind(MachinesPicker).toSelf().inSingletonScope();
 container.bind(MachineExecClient).toSelf().inSingletonScope();
 container.bind(MachineExecWatcher).toSelf().inSingletonScope();
 container.bind(ServerVariableResolver).toSelf().inSingletonScope();
+container.bind(PreviewUrlVariableResolver).toSelf().inSingletonScope();
 container.bind(ProjectPathVariableResolver).toSelf().inSingletonScope();
 container.bind(CheWorkspaceClient).toSelf().inSingletonScope();
 container.bind(CheTaskPreviewMode).toSelf().inSingletonScope();

--- a/plugins/task-plugin/src/che-workspace-client.ts
+++ b/plugins/task-plugin/src/che-workspace-client.ts
@@ -17,6 +17,12 @@ const TERMINAL_SERVER_TYPE = 'terminal';
 @injectable()
 export class CheWorkspaceClient {
 
+    /** Returns 'key -> url' map of links for the current workspace. */
+    async getLinks(): Promise<{ [key: string]: string } | undefined> {
+        const workspace = await this.getCurrentWorkspace();
+        return workspace.links;
+    }
+
     async getMachines(): Promise<{ [attrName: string]: cheApi.workspace.Machine }> {
         const workspace = await this.getCurrentWorkspace();
         const runtime = workspace.runtime;

--- a/plugins/task-plugin/src/preview/previews-widget.ts
+++ b/plugins/task-plugin/src/preview/previews-widget.ts
@@ -76,21 +76,19 @@ export class PreviewUrlsWidget {
     }
 
     private async renderPreviews(): Promise<Array<string>> {
-        return await Promise.all(
-            this.options.tasks.map(
-                async (cheTask: theia.Task) => {
-                    const previewUrl = cheTask.definition.previewUrl;
-                    const url = await this.previewUrlOpenService.resolve(previewUrl);
+        const previews = [];
+        for (const cheTask of this.options.tasks) {
+            const previewUrl = cheTask.definition.previewUrl;
+            const url = await this.previewUrlOpenService.resolve(previewUrl);
 
-                    const server = `<a class="task-link" href="${url}" target="_blank">${url}</a>`;
-                    const taskLabel = `<label>${cheTask.name}</label>`;
-                    const previewButton = `<button class='button' type="button" onclick="preview('${INTERNALLY_CHOICE}', '${url}')">${PREVIEW_BUTTON_NAME}</button>`;
-                    const goToButton = `<button class='button' type="button" onclick="preview('${EXTERNALLY_CHOICE}', '${url}')">${GO_TO_BUTTON_NAME}</button>`;
+            const server = `<a class="task-link" href="${url}" target="_blank">${url}</a>`;
+            const taskLabel = `<label>${cheTask.name}</label>`;
+            const previewButton = `<button class='button' type="button" onclick="preview('${INTERNALLY_CHOICE}', '${url}')">${PREVIEW_BUTTON_NAME}</button>`;
+            const goToButton = `<button class='button' type="button" onclick="preview('${EXTERNALLY_CHOICE}', '${url}')">${GO_TO_BUTTON_NAME}</button>`;
 
-                    return this.renderTemplate(server, taskLabel, previewButton, goToButton);
-                }
-            )
-        );
+            previews.push(this.renderTemplate(server, taskLabel, previewButton, goToButton));
+        }
+        return previews;
     }
 
     private renderTemplate(server: string, taskLabel: string, previewButton: string, goToButton: string) {

--- a/plugins/task-plugin/src/preview/task-events-handler.ts
+++ b/plugins/task-plugin/src/preview/task-events-handler.ts
@@ -59,23 +59,25 @@ export class CheTaskEventsHandler {
 
         await this.tasksPreviewManager.onTaskStarted(task);
 
+        const url = await this.previewUrlOpenService.resolve(previewUrl) || previewUrl;
+
         const mode = this.taskPreviewMode.get();
         switch (mode) {
             case PreviewMode.AlwaysGoTo: {
-                this.previewUrlOpenService.previewExternally(previewUrl);
+                this.previewUrlOpenService.previewExternally(url);
                 break;
             }
             case PreviewMode.AlwaysPreview: {
-                this.previewUrlOpenService.previewInternally(previewUrl);
+                this.previewUrlOpenService.previewInternally(url);
                 break;
             }
             case PreviewMode.Off: {
                 break;
             }
             default: {
-                const url = await this.previewUrlOpenService.resolve(previewUrl);
+
                 const message = `Task ${task.name} launched a service on ${url}`;
-                this.askUser(message, url || previewUrl);
+                this.askUser(message, url);
                 break;
             }
         }

--- a/plugins/task-plugin/src/task-plugin-backend.ts
+++ b/plugins/task-plugin/src/task-plugin-backend.ts
@@ -20,6 +20,7 @@ import { ProjectPathVariableResolver } from './variable/project-path-variable-re
 import { CheTaskEventsHandler } from './preview/task-events-handler';
 import { TasksPreviewManager } from './preview/tasks-preview-manager';
 import { ExportConfigurationsManager } from './export/export-configs-manager';
+import { PreviewUrlVariableResolver } from './variable/preview-url-variable-resolver';
 
 let pluginContext: theia.PluginContext;
 let outputChannel: theia.OutputChannel | undefined;
@@ -35,6 +36,9 @@ export async function start(context: theia.PluginContext) {
 
     const serverVariableResolver = container.get<ServerVariableResolver>(ServerVariableResolver);
     serverVariableResolver.registerVariables();
+
+    const previewUrlVariableResolver = container.get<PreviewUrlVariableResolver>(PreviewUrlVariableResolver);
+    previewUrlVariableResolver.registerVariables();
 
     const projectPathVariableResolver = container.get<ProjectPathVariableResolver>(ProjectPathVariableResolver);
     projectPathVariableResolver.registerVariables();

--- a/plugins/task-plugin/src/variable/preview-url-variable-resolver.ts
+++ b/plugins/task-plugin/src/variable/preview-url-variable-resolver.ts
@@ -1,0 +1,57 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { inject, injectable } from 'inversify';
+import * as che from '@eclipse-che/plugin';
+import * as startPoint from '../task-plugin-backend';
+import { CheWorkspaceClient } from '../che-workspace-client';
+
+/** Prefix which allows to recognize preview URL links among workspace links */
+const PREVIEW_URL_PREFIX = 'previewurl';
+
+/**
+ * Contributes the substitution variables, in form of `previewurl.<unique_string>`,
+ * which are resolved to the URL using workspace links.
+ */
+@injectable()
+export class PreviewUrlVariableResolver {
+
+    @inject(CheWorkspaceClient)
+    protected readonly cheWorkspaceClient!: CheWorkspaceClient;
+
+    /** Extracts preview URL links for current workspace and register them as variables. */
+    async registerVariables(): Promise<void> {
+        const links = await this.cheWorkspaceClient.getLinks();
+        if (!links) {
+            return;
+        }
+
+        for (const link in links) {
+            if (!links.hasOwnProperty(link) || !link.startsWith(PREVIEW_URL_PREFIX)) {
+                continue;
+            }
+
+            const url = links[link];
+            if (url) {
+                const variableSubscription = await che.variables.registerVariable(this.createVariable(link, url));
+                startPoint.getSubscriptions().push(variableSubscription);
+            }
+        }
+    }
+
+    private createVariable(variable: string, url: string): che.Variable {
+        return {
+            name: `${variable}`,
+            description: url,
+            resolve: async () => url,
+            isResolved: true
+        };
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Register preview URL links as variables

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14892

### How to test
1. Server side changes are [under review](https://github.com/eclipse/che/pull/14713), so please start server using image:
`chectl server:start -i quay.io/mvala/che-server:previewurl`
 2. I modified a little devfiles from [the PR description](https://github.com/eclipse/che/pull/14713)(@sparkoo thanks! ) and add the reference for `docker image: maxura/che-theia:503` related to the current PR, so you can use the following devfile:

<details>
<summary>Devfile</summary>

```
apiVersion: 1.0.1-beta
metadata:
 name: preview-url-support
projects:
  - name: dummy-http-server
    source:
      type: git
      location: "https://github.com/sparkoo/dummy-http-server.git"
components:
  - 
    alias: che-dev
    type: dockerimage
    image: eclipse/che-theia-dev:next
    mountSources: true
    endpoints:
      - name: "theia-dev"
        port: 3130
        attributes:
          protocol: tcp
          public: 'true'
    memoryLimit: 4Gi
  - 
    alias: theia-editor
    reference: >-
      https://raw.githubusercontent.com/RomanNikitenko/che-plugin-registry/master/v3/plugins/eclipse/che-theia/custom/meta.yaml
    type: cheEditor
  
  -
    type: kubernetes
    alias: go-k8s
    mountSources: true
    referenceContent: |
          kind: List
          items:
          - kind: Pod
            apiVersion: v1
            metadata:
              name: go-runner
            spec:
              containers:
                - name: go-110-server
                  image: quay.io/eclipse/che-golang-1.10:nightly
                - name: go-112-server
                  image: quay.io/eclipse/che-golang-1.12:nightly
  -
    type: dockerimage
    image: quay.io/eclipse/che-golang-1.10:nightly
    alias: go-cli
    mountSources: true
    memoryLimit: 256Mi

commands:
- name: test k8s component
  previewUrl:
    port: 8080
    path: /hello
  actions:
      -
        type: exec
        component: go-k8s
        command: "go run main.go 8080 /hello"
        workdir: ${CHE_PROJECTS_ROOT}/dummy-http-server

- name: test dockerimage component
  previewUrl:
    port: 8081
    path: "/hello"
  actions:
      -
        type: exec
        component: go-cli
        command: "go run main.go 8081 /hello"
        workdir: ${CHE_PROJECTS_ROOT}/dummy-http-server

```
</details>

2. Run `test dockerimage component` task from `Terminal => Run Task` menu for testing preview URL functionality for task with defined `docker image` component.
3. Run `test k8s component` task from `Terminal => Run Task` menu for testing preview URL functionality for task with defined `kubernetes` component. 
For this case please select `go-runner/go-110-server` or `go-runner/go-112-server` when IDE prompts list of containers for running.

For both cases URL should be resolved, you can check it using `Preview` and `Go to` buttons, please see the screenshot.

4. Please try to restart the workspace and rerun both tasks, check again that preview URL is resolved. 

![preview_url_support](https://user-images.githubusercontent.com/5676062/67332395-9e4eba00-f527-11e9-9575-e5745f4f1810.png)

 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
