### PR TITLE
[Remote plugins] Call OnDidDeploy only if client is set

### DIFF
--- a/extensions/eclipse-che-theia-plugin-remote/src/node/hosted-plugin-remote.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/hosted-plugin-remote.ts
@@ -25,7 +25,7 @@ type PromiseResolver = (value?: Buffer) => void;
 @injectable()
 export class HostedPluginRemote {
 
-    private client: HostedPluginClient;
+    private client: HostedPluginClient | undefined;
 
     @inject(ILogger)
     protected readonly logger: ILogger;
@@ -160,7 +160,9 @@ export class HostedPluginRemote {
                 const entryName = getPluginId(deployedPlugin.metadata.model);
                 if (!this.hostedPluginMapping.getPluginsEndPoints().has(entryName)) {
                     this.hostedPluginMapping.getPluginsEndPoints().set(entryName, jsonMessage.endpointName);
-                    this.client.onDidDeploy();
+                    if (this.client) {
+                        this.client.onDidDeploy();
+                    }
                 }
             });
             return;


### PR DESCRIPTION
### What does this PR do?
In remote plugins mechanism we send some meta information between main Theia and remote plugin host. This PR provides the fix for the case when client has not connected yet, but we've got a message to send. It is safe to not to send the info, because when client is ready it queries the info itself.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14942
