### PR TITLE
Downgrade Kubernetes plugin parent image to Buildah v1.11.2

### DIFF
--- a/dockerfiles/remote-plugin-kubernetes-tooling-1.0.4/Dockerfile
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-1.0.4/Dockerfile
@@ -9,7 +9,7 @@
 #   Red Hat, Inc. - initial API and implementation
 
 FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-endpoint-runtime:${BUILD_TAG} as endpoint
-FROM quay.io/buildah/stable:v1.11.3
+FROM quay.io/buildah/stable:v1.11.2
 
 ENV KUBECTL_VERSION v1.16.1
 ENV HELM_VERSION v2.14.3


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Downgrades Kubernetes plugin parent image to `buildah/stable:v1.11.2` as `buildah/stable:v1.11.3` has been removed on quay.io.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14965

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
