### PR TITLE
Fix message of sparse checkout to fit template

### DIFF
--- a/plugins/factory-plugin/src/theia-commands.ts
+++ b/plugins/factory-plugin/src/theia-commands.ts
@@ -171,7 +171,7 @@ export class TheiaGitCloneCommand implements TheiaImportCommand {
 
         await git.sparseCheckout(this.projectPath, this.locationURI, this.sparseCheckoutDir, commitReference);
 
-        theia.window.showInformationMessage(`Directory ${this.sparseCheckoutDir} of ${this.locationURI} was cloned to ${this.projectPath}.`);
+        theia.window.showInformationMessage(`Sources by template ${this.sparseCheckoutDir} of ${this.locationURI} was cloned to ${this.projectPath}.`);
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Changes message when a project is sparsely cloned to fit a sparse checkout template case. For example `/dir/*.java`.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13671