### PR TITLE
Use component for task configuration instead of container name

### DIFF
--- a/plugins/task-plugin/README.md
+++ b/plugins/task-plugin/README.md
@@ -21,7 +21,7 @@ The format of a Che task is the following:
     "command": "",
     "target": {
         "workspaceId": "",
-        "containerName": "",
+        "component": "",
         "workingDir": ""
     },
     "previewUrl": ""

--- a/plugins/task-plugin/src/che-task-backend-module.ts
+++ b/plugins/task-plugin/src/che-task-backend-module.ts
@@ -31,6 +31,7 @@ import { ConfigFileTasksExtractor } from './extract/config-file-task-configs-ext
 import { VsCodeLaunchConfigsExtractor } from './extract/vscode-launch-configs-extractor';
 import { VsCodeTaskConfigsExtractor } from './extract/vscode-task-configs-extractor';
 import { PreviewUrlVariableResolver } from './variable/preview-url-variable-resolver';
+import { BackwardCompatibilityResolver } from './task/backward-compatibility';
 
 const container = new Container();
 container.bind(CheTaskProvider).toSelf().inSingletonScope();
@@ -54,6 +55,7 @@ container.bind(ConfigFileTasksExtractor).toSelf().inSingletonScope();
 container.bind(ConfigFileLaunchConfigsExtractor).toSelf().inSingletonScope();
 container.bind(VsCodeLaunchConfigsExtractor).toSelf().inSingletonScope();
 container.bind(VsCodeTaskConfigsExtractor).toSelf().inSingletonScope();
+container.bind(BackwardCompatibilityResolver).toSelf().inSingletonScope();
 
 container.bind(PreviewUrlsWidget).toSelf().inTransientScope();
 container.bind(PreviewUrlsWidgetFactory).toDynamicValue(ctx => ({

--- a/plugins/task-plugin/src/che-workspace-client.ts
+++ b/plugins/task-plugin/src/che-workspace-client.ts
@@ -23,6 +23,23 @@ export class CheWorkspaceClient {
         return workspace.links;
     }
 
+    /** Returns array of containers' names for the current workspace. */
+    async getContainersNames(): Promise<string[]> {
+        const containerNames: string[] = [];
+
+        try {
+            const containers = await this.getMachines();
+            for (const containerName in containers) {
+                if (containers.hasOwnProperty(containerName)) {
+                    containerNames.push(containerName);
+                }
+            }
+        } catch (error) {
+        } finally {
+            return containerNames;
+        }
+    }
+
     async getMachines(): Promise<{ [attrName: string]: cheApi.workspace.Machine }> {
         const workspace = await this.getCurrentWorkspace();
         const runtime = workspace.runtime;

--- a/plugins/task-plugin/src/export/export-configs-manager.ts
+++ b/plugins/task-plugin/src/export/export-configs-manager.ts
@@ -23,7 +23,7 @@ export interface ConfigurationsExporter {
      * @param workspaceFolder workspace folder for exporting configs in the config file
      * @param commands commands with configurations for export
      */
-    export(workspaceFolder: theia.WorkspaceFolder, commands: cheApi.workspace.Command[]): void;
+    export(workspaceFolder: theia.WorkspaceFolder, commands: cheApi.workspace.Command[]): Promise<void>;
 }
 /** Contains configurations as array of object and as raw content and is used at getting configurations from config file for example */
 export interface Configurations<T> {

--- a/plugins/task-plugin/src/export/launch-configs-exporter.ts
+++ b/plugins/task-plugin/src/export/launch-configs-exporter.ts
@@ -31,7 +31,7 @@ export class LaunchConfigurationsExporter implements ConfigurationsExporter {
     @inject(VsCodeLaunchConfigsExtractor)
     protected readonly vsCodeLaunchConfigsExtractor: VsCodeLaunchConfigsExtractor;
 
-    export(workspaceFolder: theia.WorkspaceFolder, commands: cheApi.workspace.Command[]): void {
+    async export(workspaceFolder: theia.WorkspaceFolder, commands: cheApi.workspace.Command[]): Promise<void> {
         const launchConfigFileUri = this.getConfigFileUri(workspaceFolder.uri.path);
         const configFileConfigs = this.configFileLaunchConfigsExtractor.extract(launchConfigFileUri);
         const vsCodeConfigs = this.vsCodeLaunchConfigsExtractor.extract(commands);

--- a/plugins/task-plugin/src/task/backward-compatibility.ts
+++ b/plugins/task-plugin/src/task/backward-compatibility.ts
@@ -1,0 +1,90 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { injectable, inject } from 'inversify';
+import * as che from '@eclipse-che/plugin';
+import { CHE_TASK_TYPE } from './task-protocol';
+import { CheWorkspaceClient } from '../che-workspace-client';
+import { getAttribute } from '../utils';
+import { COMPONENT_ATTRIBUTE } from '../machine/machines-picker';
+
+/** Contains logic to provide backward compatibility. */
+@injectable()
+export class BackwardCompatibilityResolver {
+
+    @inject(CheWorkspaceClient)
+    protected readonly cheWorkspaceClient!: CheWorkspaceClient;
+
+    /**
+     * Provides backward compatibility for `containerName` field of task configuration.
+     * `containerName` was used to indicate which container should be used for running task configuration
+     * `component` is used instead of `containerName` for this goal.
+     *
+     * So, the following configuration:
+     * {
+     *     "type": "che",
+     *     "label": "theia:build",
+     *     "command": "yarn",
+     *     "target": {
+     *        "workingDir": "/projects/theia",
+     *        "containerName": "che-dev"
+     *      }
+     *  }
+     *
+     * should be replaced by:
+     *
+     * {
+     *     "type": "che",
+     *     "label": "theia:build",
+     *     "command": "yarn",
+     *     "target": {
+     *        "workingDir": "/projects/theia",
+     *        "component": "che-dev"
+     *      }
+     *  }
+     *
+     * Note: `containerName` is replaced by empty `component` field if the corresponding component is not found.
+     *       List of containers is displayed at running task for this case and user has opportunity to select a container for running.
+     *
+     * @param configs task configurations for resolving
+     */
+    async resolveComponent(configs: che.TaskConfiguration[]): Promise<che.TaskConfiguration[]> {
+        if (configs.length === 0) {
+            return configs;
+        }
+
+        const containers = await this.cheWorkspaceClient.getMachines();
+        for (const config of configs) {
+            if (config.type !== CHE_TASK_TYPE) {
+                continue;
+            }
+
+            const target = config.target;
+            if (!target || !target.containerName) {
+                continue;
+            }
+
+            const containerName = target.containerName;
+            target.containerName = undefined;
+            target.component = '';
+
+            if (!containers.hasOwnProperty(containerName)) {
+                continue;
+            }
+
+            const container = containers[containerName];
+            const component = getAttribute(COMPONENT_ATTRIBUTE, container.attributes);
+            if (component) {
+                target.component = component;
+            }
+        }
+        return configs;
+    }
+}

--- a/plugins/task-plugin/src/task/converter.ts
+++ b/plugins/task-plugin/src/task/converter.ts
@@ -11,7 +11,8 @@
 import { che as cheApi } from '@eclipse-che/api';
 import { Task } from '@theia/plugin';
 import { TaskConfiguration } from '@eclipse-che/plugin';
-import { CHE_TASK_TYPE, MACHINE_NAME_ATTRIBUTE, PREVIEW_URL_ATTRIBUTE, WORKING_DIR_ATTRIBUTE } from './task-protocol';
+import { CHE_TASK_TYPE, PREVIEW_URL_ATTRIBUTE, WORKING_DIR_ATTRIBUTE, COMPONENT_ALIAS_ATTRIBUTE } from './task-protocol';
+import { getAttribute } from '../utils';
 
 /** Converts the Che command to Theia Task Configuration */
 export function toTaskConfiguration(command: cheApi.workspace.Command): TaskConfiguration {
@@ -21,10 +22,10 @@ export function toTaskConfiguration(command: cheApi.workspace.Command): TaskConf
         command: command.commandLine,
         _scope: undefined, // not to put into tasks.json
         target: {
-            workingDir: getCommandAttribute(command, WORKING_DIR_ATTRIBUTE),
-            containerName: getCommandAttribute(command, MACHINE_NAME_ATTRIBUTE)
+            workingDir: getAttribute(WORKING_DIR_ATTRIBUTE, command.attributes),
+            component: getAttribute(COMPONENT_ALIAS_ATTRIBUTE, command.attributes)
         },
-        previewUrl: getCommandAttribute(command, PREVIEW_URL_ATTRIBUTE)
+        previewUrl: getAttribute(PREVIEW_URL_ATTRIBUTE, command.attributes)
     };
 
     return taskConfig;
@@ -37,10 +38,10 @@ export function toTask(command: cheApi.workspace.Command): Task {
             type: CHE_TASK_TYPE,
             command: command.commandLine,
             target: {
-                workingDir: getCommandAttribute(command, WORKING_DIR_ATTRIBUTE),
-                containerName: getCommandAttribute(command, MACHINE_NAME_ATTRIBUTE)
+                workingDir: getAttribute(WORKING_DIR_ATTRIBUTE, command.attributes),
+                component: getAttribute(COMPONENT_ALIAS_ATTRIBUTE, command.attributes)
             },
-            previewUrl: getCommandAttribute(command, PREVIEW_URL_ATTRIBUTE)
+            previewUrl: getAttribute(PREVIEW_URL_ATTRIBUTE, command.attributes)
         },
         name: `${command.name}`,
         source: CHE_TASK_TYPE,

--- a/plugins/task-plugin/src/task/task-protocol.ts
+++ b/plugins/task-plugin/src/task/task-protocol.ts
@@ -14,6 +14,7 @@ export const CHE_TASK_TYPE: string = 'che';
 export const MACHINE_NAME_ATTRIBUTE: string = 'machineName';
 export const PREVIEW_URL_ATTRIBUTE: string = 'previewUrl';
 export const WORKING_DIR_ATTRIBUTE: string = 'workingDir';
+export const COMPONENT_ALIAS_ATTRIBUTE: string = 'componentAlias';
 
 export interface CheTaskDefinition extends TaskDefinition {
     readonly target?: Target,
@@ -24,4 +25,5 @@ export interface Target {
     workspaceId?: string,
     containerName?: string,
     workingDir?: string
+    component?: string,
 }

--- a/plugins/task-plugin/src/utils.ts
+++ b/plugins/task-plugin/src/utils.ts
@@ -16,6 +16,20 @@ import { FormattingOptions, ParseError, JSONPath } from 'jsonc-parser';
 
 const fs = require('fs');
 
+/** Allows to get attribute by given name, returns `undefined` if attribute is not found */
+export function getAttribute(attributeName: string, attributes?: { [key: string]: string; }): string | undefined {
+    if (!attributes) {
+        return undefined;
+    }
+
+    for (const attribute in attributes) {
+        if (attribute === attributeName) {
+            return attributes[attribute];
+        }
+    }
+    return undefined;
+}
+
 /**
  * Apply segments to the url endpoint, where are:
  * @param endPointUrl - url endpoint, for example 'http://ws:/some-server/api'


### PR DESCRIPTION
### What does this PR do?
Use `component` field for task configuration instead of `containerName` one.

`containerName` is used to indicate which container should be used for running task configuration.
The problem is: some container names are dynamic and are changed at restarting workspace.

The PR changes  suggest to use `component` instead of `containerName` for this goal. So, the new behavior is:
- `devfile` and `tasks.json` files keep `component` field
- `component` is used to identify the target container at running a configuration 
- dropdown menu is displayed to provide ability to select target container if component contains few containers
  
Backward compatibility for `containerName` field of task configuration is provided for existing workspaces.
    
So, the following configuration:
```
          {
                "type": "che",
                "label": "theia:build",
                "command": "yarn",
                "target": {
                    "workingDir": "/projects/theia",
                    "containerName": "che-dev"
                }
          }
```
at starting workspace is replaced by:

```
          {
                "type": "che",
                "label": "theia:build",
                "command": "yarn",
                "target": {
                    "workingDir": "/projects/theia",
                    "component": "che-dev"
                }
          }
```
Note: `containerName` is replaced by empty `component` field if the corresponding component is not found (dynamic container name case). List of containers is displayed at running task for this case and user has opportunity to select a container for running.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13993

### How to test
 1. Use the following devfile, which contains the reference for `docker image: maxura/che-theia:512` related to the current PR.

<details>
<summary>Devfile</summary>

```
apiVersion: 1.0.0
metadata:
 name: component-test
projects:
  - name: dummy-http-server
    source:
      type: git
      location: "https://github.com/sparkoo/dummy-http-server.git"
  - name: che-theia
    source:
      type: git
      location: 'https://github.com/eclipse/che-theia.git'
components:

  - 
    alias: che-dev
    type: dockerimage
    image: eclipse/che-theia-dev:next
    mountSources: true
    endpoints:
      - name: "theia-dev"
        port: 3130
        attributes:
          protocol: tcp
          public: 'true'
    memoryLimit: 2048M

  - 
    alias: theia-editor
    reference: >-
      https://raw.githubusercontent.com/RomanNikitenko/che-plugin-registry/master/v3/plugins/eclipse/che-theia/custom/meta.yaml
    type: cheEditor

  - 
    id: che-incubator/typescript/1.30.2
    alias: tsc
    type: chePlugin
    memoryLimit: 2048M
  
  -
    type: kubernetes
    alias: go-k8s
    mountSources: true
    referenceContent: |
          kind: List
          items:
          - kind: Pod
            apiVersion: v1
            metadata:
              name: go-runner
            spec:
              containers:
                - name: go-110-server
                  image: quay.io/eclipse/che-golang-1.10:nightly
                - name: go-112-server
                  image: quay.io/eclipse/che-golang-1.12:nightly

commands:

- name: test theia component
  actions:
  - type: exec
    component: theia-editor
    command: >
              yarn
    workdir: /projects/che-theia

- name: test tsc component
  actions:
  - type: exec
    component: tsc
    command: >
              sleep 2 && echo hello! 
    workdir: /projects/che-theia

- name: test che-dev component
  actions:
  - type: exec
    component: che-dev
    command: >
              yarn
    workdir: /projects/che-theia

- name: test k8s component
  actions:
      -
        type: exec
        component: go-k8s
        command: "go run main.go 8080 /hello"
        workdir: ${CHE_PROJECTS_ROOT}/dummy-http-server

- name: run
  actions:
  - type: vscode-task
    referenceContent: |
            {
                    "version": "2.0.0",
                    "tasks": 
                    [
                     {
                      "label": "shell:build",
                       "type": "shell",
                       "options": {"cwd": "/projects/che-theia"},
                       "command": "yarn",
                       "args": []
                     }
                    ]
            }

- name: debug
  actions:
  - type: vscode-launch
    referenceContent: |
            {
             "version": "0.2.0",
             "configurations": [
              {
               "type": "node",
               "request": "attach",
               "name": "Attach by Process ID",
               "processId": "${command:PickProcess}"
              }
             ]
            }

```
</details>

2. Check that `tasks.json` file contains `che` task configurations with `component` field instead of  `containerName` filed.

3. Try to run tasks, try to stop workspace, start workspace and run tasks again: components `theia-editor` and `tsc` have dynamic names for containers, so pay attention on running `test theia component` and `test tsc component` tasks after restarting workspace.

4. Component `go-k8s` has `go-110-server` and `go-112-server` containers, so at running of `test k8s component` task dropdown list should display only these containers instead of all containers.

5. You can check backward compatibility for `containerName` field of task configuration: 
- for task `test che-dev component` replace `component` field by `containerName` in `tasks.json` file and refresh the page. Expected behavior - `containerName` is replaced by `component` field and task can be run.
- for case when the corresponding component can not be found expected behavior: `containerName` is replaced by `component` field with empty value, at running the task dopdown list is displayed and user has opportunity to select a container for running. 


Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
