### PR TITLE
in order to be able to use...

### DIFF
--- a/dockerfiles/theia-dev/docker/ubi8/builder-image-from.dockerfile
+++ b/dockerfiles/theia-dev/docker/ubi8/builder-image-from.dockerfile
@@ -1,1 +1,2 @@
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10
 FROM registry.access.redhat.com/ubi8/nodejs-10:1-51

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/runtime-from.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/runtime-from.dockerfile
@@ -1,1 +1,2 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal as runtime
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0-213 as runtime

--- a/dockerfiles/theia-endpoint-runtime/docker/ubi8/runtime-from.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime/docker/ubi8/runtime-from.dockerfile
@@ -1,2 +1,3 @@
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10
 FROM registry.access.redhat.com/ubi8/nodejs-10:1-51 as runtime
 USER root

--- a/dockerfiles/theia/docker/ubi8/runtime-from.dockerfile
+++ b/dockerfiles/theia/docker/ubi8/runtime-from.dockerfile
@@ -1,1 +1,2 @@
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10
 FROM registry.access.redhat.com/ubi8/nodejs-10:1-51 as runtime


### PR DESCRIPTION
in order to be able to use updateBaseImages.sh integration in Jenkins jobs to automatically update to newer image tags, we need the URL from which to get the image tag info; also set a tag for ubi-minimal -- can't just use latest or else builds are not reproduceable

Change-Id: I6680871b856c756a04d60f66c83f2ae445315b67
Signed-off-by: nickboldt <nboldt@redhat.com>