### PR TITLE
Add build commands into Che Theia remote devfile

### DIFF
--- a/extensions/eclipse-che-theia-plugin-remote/devfile.yaml
+++ b/extensions/eclipse-che-theia-plugin-remote/devfile.yaml
@@ -58,6 +58,24 @@ commands:
         component: theia-dev
         command: 'yarn'
         workdir: /projects/theia
+  - name: Build plugin-ext
+    actions:
+      - type: exec
+        component: theia-dev
+        command: 'npx run build @theia/plugin-ext'
+        workdir: /projects/theia
+  - name: Build theia-remote
+    actions:
+      - type: exec
+        component: theia-dev
+        command: 'npx run build @eclipse-che/theia-remote'
+        workdir: /projects/theia
+  - name: Build assembly
+    actions:
+      - type: exec
+        component: theia-dev
+        command: 'yarn'
+        workdir: /projects/theia/examples/assembly
   - name: Watch changes in Theia Remote Extension
     actions:
       - type: exec


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Adds commands to build `plugin-ext` (Theia plugin API impl) , `theia-remote` (remote plugin side mechanism) and Che-Theia assembly. The commands are useful when watchers cannot be used for some reason and a developer doesn't want to compile whole Theia to apply changes.

