### PR TITLE
Disable building and publishing of 'eclipse/che-theia-endpoint-runtime' image

### DIFF
--- a/build.include
+++ b/build.include
@@ -56,7 +56,6 @@ is_publish_images() {
 PR_IMAGES=(
   dockerfiles/theia-dev
   dockerfiles/theia
-  dockerfiles/theia-endpoint-runtime
   dockerfiles/theia-endpoint-runtime-binary
 )
 
@@ -64,7 +63,6 @@ PR_IMAGES=(
 DOCKER_FILES_LOCATIONS=(
   dockerfiles/theia-dev
   dockerfiles/theia
-  dockerfiles/theia-endpoint-runtime
   dockerfiles/theia-endpoint-runtime-binary
   dockerfiles/remote-plugin-node
   dockerfiles/remote-plugin-java8
@@ -90,7 +88,6 @@ DOCKER_FILES_LOCATIONS=(
 PUBLISH_IMAGES_LIST=(
   eclipse/che-theia-dev
   eclipse/che-theia
-  eclipse/che-theia-endpoint-runtime
   eclipse/che-theia-endpoint-runtime-binary
   eclipse/che-remote-plugin-node
   eclipse/che-remote-plugin-runner-java8

--- a/dockerfiles/theia-endpoint-runtime/README.md
+++ b/dockerfiles/theia-endpoint-runtime/README.md
@@ -1,0 +1,4 @@
+
+# This Dockerfile is deprecated and subject for remove
+
+Now we are using [theia-endpoint-runtime-binary](../theia-endpoint-runtime-binary) image to provide remote plugin runtime.


### PR DESCRIPTION
### What does this PR do?
Disable building and publishing of `eclipse/che-theia-endpoint-runtime` image
After https://github.com/eclipse/che-theia/pull/485 PR we use `eclipse/che-theia-endpoint-runtime-binary` image to provide remote plugin runtime.