### PR TITLE
Fix buildah login command in Kubernetes plugin sidecar

### DIFF
--- a/dockerfiles/remote-plugin-kubernetes-tooling-1.0.4/Dockerfile
+++ b/dockerfiles/remote-plugin-kubernetes-tooling-1.0.4/Dockerfile
@@ -21,8 +21,10 @@ RUN mkdir /projects && \
     for f in "${HOME}" "/etc/passwd" "/projects"; do \
       echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
       chmod -R g+rwX ${f}; \
-    done \
-    && curl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
+    done && \
+    # buildah login requires writing to /run
+    chgrp -R 0 /run && chmod -R g+rwX /run && \
+    curl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl && \
     curl -o- -L https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar xvz -C /usr/local/bin --strip 1 && \
     # set up local Helm configuration skipping Tiller installation


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes `buildah login` command in a Kubernetes plugin sidecar. It's part of `Kubernetes: Run` command flow.

![image](https://user-images.githubusercontent.com/1636395/67865328-c5ad1480-fb2f-11e9-828f-6efb9089456e.png)


### What issues does this PR fix or reference?
closes https://github.com/eclipse/che/issues/15005

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
