### PR TITLE
Add Dockerfile for OpenShift Connector plugin v0.1.1

### DIFF
--- a/build.include
+++ b/build.include
@@ -79,6 +79,7 @@ DOCKER_FILES_LOCATIONS=(
   dockerfiles/remote-plugin-openshift-connector-0.0.17
   dockerfiles/remote-plugin-openshift-connector-0.0.21
   dockerfiles/remote-plugin-openshift-connector-0.1.0
+  dockerfiles/remote-plugin-openshift-connector-0.1.1
   dockerfiles/remote-plugin-camelk-0.0.9
   dockerfiles/remote-plugin-dependency-analytics-0.0.12
   dockerfiles/remote-plugin-dependency-analytics-0.0.13
@@ -104,6 +105,7 @@ PUBLISH_IMAGES_LIST=(
   eclipse/che-remote-plugin-openshift-connector-0.0.17
   eclipse/che-remote-plugin-openshift-connector-0.0.21
   eclipse/che-remote-plugin-openshift-connector-0.1.0
+  eclipse/che-remote-plugin-openshift-connector-0.1.1
   eclipse/che-remote-plugin-camelk-0.0.9
   eclipse/che-remote-plugin-dependency-analytics-0.0.12
   eclipse/che-remote-plugin-dependency-analytics-0.0.13

--- a/dockerfiles/remote-plugin-openshift-connector-0.1.1/Dockerfile
+++ b/dockerfiles/remote-plugin-openshift-connector-0.1.1/Dockerfile
@@ -25,7 +25,7 @@ ENV GLIBC_VERSION=2.30-r0 \
     OC_TAG=0cbc58b \
     KUBECTL_VERSION=v1.16.2
 
-# the plugin executes the commands relying on Bash
+# plugin executes the commands relying on Bash
 RUN apk add --update --no-cache bash && \
     # install glibc compatibility layer package for Alpine Linux
     # see https://github.com/openshift/origin/issues/18942 for the details

--- a/dockerfiles/remote-plugin-openshift-connector-0.1.1/Dockerfile
+++ b/dockerfiles/remote-plugin-openshift-connector-0.1.1/Dockerfile
@@ -1,0 +1,47 @@
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+FROM alpine:3.10.2
+
+ENV HOME=/home/theia
+
+RUN mkdir /projects ${HOME} && \
+    # Change permissions to let any arbitrary user
+    for f in "${HOME}" "/etc/passwd" "/projects"; do \
+      echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
+      chmod -R g+rwX ${f}; \
+    done
+
+ENV GLIBC_VERSION=2.30-r0 \
+    ODO_VERSION=v1.0.0 \
+    OC_VERSION=v3.11.0 \
+    OC_TAG=0cbc58b \
+    KUBECTL_VERSION=v1.16.2
+
+# the plugin executes the commands relying on Bash
+RUN apk add --update --no-cache bash && \
+    # install glibc compatibility layer package for Alpine Linux
+    # see https://github.com/openshift/origin/issues/18942 for the details
+    wget -O glibc-${GLIBC_VERSION}.apk https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk && \
+    apk --update --allow-untrusted add glibc-${GLIBC_VERSION}.apk && \
+    rm -f glibc-${GLIBC_VERSION}.apk && \
+    # install oc
+    wget -O- https://github.com/openshift/origin/releases/download/${OC_VERSION}/openshift-origin-client-tools-${OC_VERSION}-${OC_TAG}-linux-64bit.tar.gz | tar xvz -C /usr/local/bin --strip 1 && \
+    # install odo
+    wget -O /usr/local/bin/odo https://mirror.openshift.com/pub/openshift-v4/clients/odo/${ODO_VERSION}/odo-linux-amd64 && \
+    chmod +x /usr/local/bin/odo && \
+    # install kubectl
+    wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+    chmod +x /usr/local/bin/kubectl
+
+ADD etc/entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}

--- a/dockerfiles/remote-plugin-openshift-connector-0.1.1/build.sh
+++ b/dockerfiles/remote-plugin-openshift-connector-0.1.1/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
+
+init --name:remote-plugin-openshift-connector-0.1.1 "$@"
+build

--- a/dockerfiles/remote-plugin-openshift-connector-0.1.1/etc/entrypoint.sh
+++ b/dockerfiles/remote-plugin-openshift-connector-0.1.1/etc/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# Copyright (c) 2018-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+set -e
+
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
+
+if ! whoami >/dev/null 2>&1; then
+    echo "${USER_NAME:-user}:x:${USER_ID}:0:${USER_NAME:-user} user:${HOME}:/bin/sh" >> /etc/passwd
+fi
+
+# Grant access to projects volume in case of non root user with sudo rights
+if [ "${USER_ID}" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /dev/null 2>&1; then
+    sudo chown "${USER_ID}:${GROUP_ID}" /projects
+fi
+
+exec "$@"


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds Dockerfile to build an image for running OpenShift Connector Che Plugin based on the VS Code extension v0.1.1. The latest version contains an important [fix](https://github.com/redhat-developer/vscode-openshift-tools/pull/1254) for `Open URL` command.
Also, the Dockerfile updates odo from v1.0.0-beta5 to v1.0.0 as it's required by the VS Code extension.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13406
https://github.com/eclipse/che/issues/13410

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
