### PR TITLE
Fixes failing unstable tests

### DIFF
--- a/generator/src/init-sources.ts
+++ b/generator/src/init-sources.ts
@@ -54,6 +54,11 @@ export class InitSources {
     private globalDevDependencies = new Map<string, string>();
 
     /**
+     * Will clone sources keeping or omiting the history
+     */
+    private keepHistory: boolean = true;
+
+    /**
      * Constructor
      */
     constructor(readonly rootFolder: string,
@@ -62,7 +67,13 @@ export class InitSources {
         readonly cheTheiaFolder: string,
         readonly assemblyFolder: string,
         readonly theiaVersion: string) {
+    }
 
+    /**
+     * Keep or omit git history when cloning sources
+     */
+    set keepGitHistory(value: boolean) {
+        this.keepHistory = value;
     }
 
     /**
@@ -272,7 +283,7 @@ export class InitSources {
         } else {
             Logger.info(`Cloning ${extension.source}...`);
             const repository = new Repository(extension.source);
-            extension.clonedDir = await repository.clone(this.cheTheiaFolder, repository.getRepositoryName(), extension.checkoutTo);
+            extension.clonedDir = await repository.clone(this.cheTheiaFolder, repository.getRepositoryName(), extension.checkoutTo, this.keepHistory);
         }
     }
 

--- a/generator/src/repository.ts
+++ b/generator/src/repository.ts
@@ -43,18 +43,21 @@ export class Repository {
      * @param checkoutFolder the CWD / directory where to launch the clone operation
      * @param dest the destination folder of the clone
      * @param checkoutTo the optional branch/tag to use when cloning
+     * @param keepHistory the optional flag to keep / omit git history
      */
-    public async clone(checkoutFolder: string, dest: string, checkoutTo?: string): Promise<string> {
+    public async clone(checkoutFolder: string, dest: string, checkoutTo?: string, keepHistory: boolean = true): Promise<string> {
         const commandTheiaFolder = new Command(checkoutFolder);
-        await commandTheiaFolder.exec(`git clone ${this.uri} ${dest}`);
+
+        // Use -b to clone the specific branch
+        let opts = checkoutTo ? `-b ${checkoutTo}` : '';
+
+        // Use --single-branch and --depth to omit git history
+        opts += keepHistory ? '' : ' --single-branch --depth 1';
+
+        await commandTheiaFolder.exec(`git clone ${opts} ${this.uri} ${dest}`);
 
         const clonedDir = path.resolve(checkoutFolder, dest);
-        if (checkoutTo) {
-            // need to change checkout
-            const commandClonedDir = new Command(clonedDir);
-            await commandClonedDir.exec(`git checkout -f ${checkoutTo}`);
-        }
-
         return clonedDir;
     }
+
 }

--- a/generator/tests/init-sources/init-sources.spec.ts
+++ b/generator/tests/init-sources/init-sources.spec.ts
@@ -21,6 +21,9 @@ import { YargsMockup } from "../cdn.spec";
 
 describe("Test Extensions", () => {
 
+    // Increase timeout to 30 seconds
+    jest.setTimeout(30000);
+
     const THEIA_DUMMY_VERSION = '1.2.3';
     const rootFolder = process.cwd();
     const assemblyExamplePath = path.resolve(rootFolder, "tests/init-sources/assembly-example");
@@ -46,7 +49,6 @@ describe("Test Extensions", () => {
         sourceExtension2Tmp = path.resolve(rootFolderTmp, 'source-code2');
         extensionYamlTmp = path.resolve(rootFolderTmp, 'extensions.yml');
 
-
         await fs.ensureDir(rootFolderTmp);
         await fs.ensureDir(packagesFolderTmp);
         await fs.ensureDir(pluginsFolderTmp);
@@ -69,7 +71,6 @@ describe("Test Extensions", () => {
         cp.execSync('git config --local user.email user@example.com', { cwd: path });
         cp.execSync(`git add ${path}`, { cwd: path });
         cp.execSync(`git commit -m "Init repo"`, { cwd: path });
-
     }
 
     afterEach(() => {
@@ -77,10 +78,14 @@ describe("Test Extensions", () => {
         fs.removeSync(rootFolderTmp);
     });
 
-
     test("test init sources generator", async () => {
-
-        const initSources = new InitSources(assemblyExamplePath, packagesFolderTmp, pluginsFolderTmp, cheTheiaFolderTmp, assemblyFolderTmp, THEIA_DUMMY_VERSION);
+        const initSources = new InitSources(
+            assemblyExamplePath,
+            packagesFolderTmp,
+            pluginsFolderTmp,
+            cheTheiaFolderTmp,
+            assemblyFolderTmp,
+            THEIA_DUMMY_VERSION);
 
         const yamlExtensionsContent = {
             sources: [
@@ -98,6 +103,7 @@ describe("Test Extensions", () => {
         const yml = json2yaml.stringify(yamlExtensionsContent);
         fs.writeFileSync(extensionYamlTmp, yml);
 
+        initSources.keepGitHistory = false;
         await initSources.generate(extensionYamlTmp);
 
         // need to perform checks
@@ -135,18 +141,29 @@ describe("Test Extensions", () => {
         expect(assemblyPackage.dependencies['@che-theia/sample1']).toBe('0.1.2');
         expect(assemblyPackage.dependencies['@che-theia/sample2']).toBe('6.7.8');
         expect(assemblyPackage.dependencies['@che-theia/extension-example2']).toBe('9.8.7');
-
-
     });
 
     test('extension with empty dependencies', async () => {
-        const initSources = new InitSources(assemblyExamplePath, packagesFolderTmp, pluginsFolderTmp, cheTheiaFolderTmp, assemblyFolderTmp, THEIA_DUMMY_VERSION);
+        const initSources = new InitSources(
+            assemblyExamplePath,
+            packagesFolderTmp,
+            pluginsFolderTmp,
+            cheTheiaFolderTmp,
+            assemblyFolderTmp,
+            THEIA_DUMMY_VERSION);
+
         await initSources.updateDependencies({ extSymbolicLinks: [path.resolve(rootFolder, "tests/init-sources/extension-empty")] } as ISource, false);
         expect(true).toBeTruthy();
     });
 
     test('extensions with dev mode', async () => {
-        const initSources = new InitSources(assemblyExamplePath, packagesFolderTmp, pluginsFolderTmp, cheTheiaFolderTmp, assemblyFolderTmp, THEIA_DUMMY_VERSION);
+        const initSources = new InitSources(
+            assemblyExamplePath,
+            packagesFolderTmp,
+            pluginsFolderTmp,
+            cheTheiaFolderTmp,
+            assemblyFolderTmp,
+            THEIA_DUMMY_VERSION);
 
         const yamlExtensionsContent = {
             sources: [
@@ -164,6 +181,7 @@ describe("Test Extensions", () => {
         const yml = json2yaml.stringify(yamlExtensionsContent);
         fs.writeFileSync(extensionYamlTmp, yml);
 
+        initSources.keepGitHistory = false;
         await initSources.generate(extensionYamlTmp, true);
 
         // check symlink are ok as well
@@ -174,7 +192,13 @@ describe("Test Extensions", () => {
     });
 
     test('use provided extensions', async () => {
-        const initSources = new InitSources(assemblyExamplePath, packagesFolderTmp, pluginsFolderTmp, cheTheiaFolderTmp, assemblyFolderTmp, THEIA_DUMMY_VERSION);
+        const initSources = new InitSources(
+            assemblyExamplePath,
+            packagesFolderTmp,
+            pluginsFolderTmp,
+            cheTheiaFolderTmp,
+            assemblyFolderTmp,
+            THEIA_DUMMY_VERSION);
 
         const yamlExtensionsContent = {
             sources: [
@@ -192,6 +216,7 @@ describe("Test Extensions", () => {
         const yml = json2yaml.stringify(yamlExtensionsContent);
         fs.writeFileSync(extensionYamlTmp, yml);
 
+        initSources.keepGitHistory = false;
         await initSources.readConfigurationAndGenerate(extensionYamlTmp, false);
 
         const ext1Folder1Link = await fs.readlink(path.join(packagesFolderTmp, `${InitSources.PREFIX_PACKAGES_EXTENSIONS}folder1`));
@@ -201,13 +226,28 @@ describe("Test Extensions", () => {
     });
 
     test('use default extensions', async () => {
-        const initSources = new InitSources(assemblyExamplePath, packagesFolderTmp, pluginsFolderTmp, cheTheiaFolderTmp, assemblyFolderTmp, THEIA_DUMMY_VERSION);
+        const initSources = new InitSources(
+            assemblyExamplePath,
+            packagesFolderTmp,
+            pluginsFolderTmp,
+            cheTheiaFolderTmp,
+            assemblyFolderTmp,
+            THEIA_DUMMY_VERSION);
+
+        initSources.keepGitHistory = false;
         await initSources.readConfigurationAndGenerate(undefined, false);
+
         expect(fs.readdirSync(packagesFolderTmp).length).toBeGreaterThan(0);
     });
 
     test('use provided extensions with dev mode', async () => {
-        const initSources = new InitSources(assemblyExamplePath, packagesFolderTmp, pluginsFolderTmp, cheTheiaFolderTmp, assemblyFolderTmp, THEIA_DUMMY_VERSION);
+        const initSources = new InitSources(
+            assemblyExamplePath,
+            packagesFolderTmp,
+            pluginsFolderTmp,
+            cheTheiaFolderTmp,
+            assemblyFolderTmp,
+            THEIA_DUMMY_VERSION);
 
         const yamlExtensionsContent = {
             sources: [
@@ -225,6 +265,7 @@ describe("Test Extensions", () => {
         const yml = json2yaml.stringify(yamlExtensionsContent);
         fs.writeFileSync(extensionYamlTmp, yml);
 
+        initSources.keepGitHistory = false;
         await initSources.readConfigurationAndGenerate(extensionYamlTmp, true);
 
         const ext1Folder1Link = await fs.readlink(path.join(packagesFolderTmp, `${InitSources.PREFIX_PACKAGES_EXTENSIONS}folder1`));
@@ -234,7 +275,14 @@ describe("Test Extensions", () => {
     });
 
     test('use default extensions with dev mode', async () => {
-        const initSources = new InitSources(assemblyExamplePath, packagesFolderTmp, pluginsFolderTmp, cheTheiaFolderTmp, assemblyFolderTmp, THEIA_DUMMY_VERSION);
+        const initSources = new InitSources(
+            assemblyExamplePath,
+            packagesFolderTmp,
+            pluginsFolderTmp,
+            cheTheiaFolderTmp,
+            assemblyFolderTmp,
+            THEIA_DUMMY_VERSION);
+
         let generateCalled = false;
         let configurationContent = undefined;
         initSources.generate = jest.fn(async (path: string) => {
@@ -242,6 +290,7 @@ describe("Test Extensions", () => {
             configurationContent = fs.readFileSync(path).toString();
         });
 
+        initSources.keepGitHistory = false;
         await initSources.readConfigurationAndGenerate(undefined, true);
 
         expect(generateCalled).toBe(true);
@@ -249,7 +298,14 @@ describe("Test Extensions", () => {
     });
 
     test('throw error if path to configuration does not exist', async () => {
-        const initSources = new InitSources(assemblyExamplePath, packagesFolderTmp, pluginsFolderTmp, cheTheiaFolderTmp, assemblyFolderTmp, THEIA_DUMMY_VERSION);
+        const initSources = new InitSources(
+            assemblyExamplePath,
+            packagesFolderTmp,
+            pluginsFolderTmp,
+            cheTheiaFolderTmp,
+            assemblyFolderTmp,
+            THEIA_DUMMY_VERSION);
+
         try {
             await initSources.readConfigurationAndGenerate('some/path/foo/bar.yaml', false);
         } catch (e) {
@@ -259,7 +315,14 @@ describe("Test Extensions", () => {
     });
 
     test('default extension uri is unreachable', async () => {
-        const initSources = new InitSources(assemblyExamplePath, packagesFolderTmp, pluginsFolderTmp, cheTheiaFolderTmp, assemblyFolderTmp, THEIA_DUMMY_VERSION);
+        const initSources = new InitSources(
+            assemblyExamplePath,
+            packagesFolderTmp,
+            pluginsFolderTmp,
+            cheTheiaFolderTmp,
+            assemblyFolderTmp,
+            THEIA_DUMMY_VERSION);
+
         let uri: string = InitSources.DEFAULT_EXTENSIONS_URI;
         try {
             (<any>InitSources)['DEFAULT_EXTENSIONS_URI'] = 'https://foobarfoo.com/foo/bar';
@@ -287,8 +350,15 @@ describe("Test Extensions", () => {
             default: false,
         });
     });
+
     test('use extensions and plugins', async () => {
-        const initSources = new InitSources(assemblyExamplePath, packagesFolderTmp, pluginsFolderTmp, cheTheiaFolderTmp, assemblyFolderTmp, THEIA_DUMMY_VERSION);
+        const initSources = new InitSources(
+            assemblyExamplePath,
+            packagesFolderTmp,
+            pluginsFolderTmp,
+            cheTheiaFolderTmp,
+            assemblyFolderTmp,
+            THEIA_DUMMY_VERSION);
 
         const yamlExtensionsContent = {
             sources: [
@@ -307,6 +377,7 @@ describe("Test Extensions", () => {
         const yml = json2yaml.stringify(yamlExtensionsContent);
         fs.writeFileSync(extensionYamlTmp, yml);
 
+        initSources.keepGitHistory = false;
         await initSources.readConfigurationAndGenerate(extensionYamlTmp, false);
 
         const ext1Folder1Link = await fs.readlink(path.join(packagesFolderTmp, `${InitSources.PREFIX_PACKAGES_EXTENSIONS}folder1`));
@@ -322,9 +393,18 @@ describe("Test Extensions", () => {
     });
 
     test('aliases replace with local source folder', async () => {
-        const initSources = new InitSources(assemblyExamplePath, packagesFolderTmp, pluginsFolderTmp, cheTheiaFolderTmp, assemblyFolderTmp, THEIA_DUMMY_VERSION);
+        const initSources = new InitSources(
+            assemblyExamplePath,
+            packagesFolderTmp,
+            pluginsFolderTmp,
+            cheTheiaFolderTmp,
+            assemblyFolderTmp,
+            THEIA_DUMMY_VERSION);
+
         const aliases = ['https://github.com/eclipse/che-theia=../che-theia', 'key1=value1', '../test=https://github.com/eclipse/che-theia'];
+
         initSources.initSourceLocationAliases(aliases);
+
         expect(initSources.sourceLocationAliases.get('https://github.com/eclipse/che-theia')).toBe('../che-theia');
         expect(initSources.sourceLocationAliases.get('../test')).toBe('https://github.com/eclipse/che-theia');
         expect(initSources.sourceLocationAliases.get('test')).toBeUndefined();
@@ -342,8 +422,18 @@ describe("Test Extensions", () => {
             extSymbolicLinks: [],
             pluginSymbolicLinks: []
         };
-        const initSources = new InitSources(assemblyExamplePath, packagesFolderTmp, pluginsFolderTmp, cheTheiaFolderTmp, assemblyFolderTmp, THEIA_DUMMY_VERSION);
+
+        const initSources = new InitSources(
+            assemblyExamplePath,
+            packagesFolderTmp,
+            pluginsFolderTmp,
+            cheTheiaFolderTmp,
+            assemblyFolderTmp,
+            THEIA_DUMMY_VERSION);
+
+        initSources.keepGitHistory = false;
         initSources.clone(source);
+
         expect(source.clonedDir).toBe(sourceExtension1Tmp);
     })
 });


### PR DESCRIPTION
Signed-off-by: Vitaliy Guliy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
The main reason while tests are failing is timeout when cloning che-theia sources.

To make tests stable, it was decided to:
- increase timeout to 30 seconds for failing tests
- add an option to omit git history when cloning che-theia sources

We can add a command line option for the generator for omitting git history. This improvement we could use when building docker images.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14276
