### PR TITLE
Use dashboard to restart the workspace 7.3.2

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
@@ -509,7 +509,8 @@ export class ChePluginManager {
     }
 
     /**
-     * Checks whether it's possible to restart the workspace.
+     * Checks whether IDE is opened inside frame in dashboard.
+     * If yes, IDE can send request to the dashboard to restart the workspace. 
      */
     restartEnabled(): boolean {
         return window.parent !== window;

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
@@ -516,6 +516,12 @@ export class ChePluginManager {
     }
 
     async restartWorkspace(): Promise<void> {
+        // Uncomment this for production
+        // if (!this.restartEnabled()) {
+        //     this.messageService.info('Use dashboard to restart your workspace.');
+        //     return;
+        // }
+
         const confirm = new ConfirmDialog({
             title: 'Restart Workspace',
             msg: 'Are you sure you want to restart your workspace?',

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
@@ -516,12 +516,6 @@ export class ChePluginManager {
     }
 
     async restartWorkspace(): Promise<void> {
-        // Uncomment this for production
-        // if (!this.restartEnabled()) {
-        //     this.messageService.info('Use dashboard to restart your workspace.');
-        //     return;
-        // }
-
         const confirm = new ConfirmDialog({
             title: 'Restart Workspace',
             msg: 'Are you sure you want to restart your workspace?',

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
@@ -510,7 +510,7 @@ export class ChePluginManager {
 
     /**
      * Checks whether IDE is opened inside frame in dashboard.
-     * If yes, IDE can send request to the dashboard to restart the workspace. 
+     * If yes, IDE can send request to the dashboard to restart the workspace.
      */
     restartEnabled(): boolean {
         return window.parent !== window;

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-widget.tsx
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-widget.tsx
@@ -41,6 +41,8 @@ export class ChePluginWidget extends ReactWidget {
 
     protected currentFilter: string;
 
+    protected restartEnabled: boolean;
+
     constructor(
         @inject(ChePluginManager) protected chePluginManager: ChePluginManager,
         @inject(ChePluginMenu) protected chePluginMenu: ChePluginMenu
@@ -73,6 +75,8 @@ export class ChePluginWidget extends ReactWidget {
         this.node.ondragover = event => {
             event.preventDefault();
         };
+
+        this.restartEnabled = this.chePluginManager.restartEnabled();
     }
 
     protected onAfterShow(msg: Message) {
@@ -196,16 +200,29 @@ export class ChePluginWidget extends ReactWidget {
     // Restart your workspace to apply changes
     protected renderUpdateWorkspaceNotification(): React.ReactNode {
         if (this.needToRestartWorkspace) {
-            const notificationStyle = this.hidingRestartWorkspaceNotification ? 'notification hiding' : 'notification';
+
+            let notificationStyle = this.hidingRestartWorkspaceNotification ? 'notification hiding' : 'notification';
+            if (this.restartEnabled) {
+                notificationStyle += ' notification-button-panel';
+            }
+
+            const notification = this.restartEnabled ?
+                <div className='notification-button' onClick={this.restartWorkspace}
+                    title='Click to restart your workspace with applying changes'>
+                    <div className='notification-message-icon'><i className='fa fa-check-circle'></i></div>
+                    <div className='notification-message-text'>Click here to apply changes and restart your workspace</div>
+                </div>
+                :
+                <div className='notification-message'>
+                    <div className='notification-message-icon'><i className='fa fa-exclamation-triangle'></i></div>
+                    <div className='notification-message-text'>Use dashboard to apply changes and restart your workspace</div>
+                </div>;
+
             return <div className='che-plugins-notification' >
                 <div className={notificationStyle}>
-                    <div className='notification-message' onClick={this.restartWorkspace}>
-                        <i className='fa fa-check-circle'></i>&nbsp;
-                        Click here to apply changes and restart your workspace
-                    </div>
-
+                    {notification}
                     <div className='notification-control'>
-                        <div className='notification-hide' onClick={this.hideNotification}>
+                        <div className='notification-hide' onClick={this.hideNotification} title='Hide'>
                             <i className='fa fa-close alert-close' ></i>
                         </div>
                     </div>

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/style/che-plugins.css
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/style/che-plugins.css
@@ -40,31 +40,52 @@
     color: #FFFFFF;
 }
 
+.che-plugins-notification .notification-button-panel:hover {
+    background-color: var(--theia-success-color1);
+}
+
+.che-plugins-notification .notification-button-panel:active {
+    box-shadow: 0px 0px 2px 0px var(--theia-success-color2);
+    outline: none;
+}
+
 .che-plugins-notification .notification.hiding {
     opacity: 0;
 }
 
-.che-plugins-notification .notification-message {
+.che-plugins-notification .notification-message,
+.che-plugins-notification .notification-button {
     position: absolute;
     left: 0px;
     top: 9px;
     right: 28px;
     height: 28px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     line-height: 28px;
-    padding-left: 9px;
+    overflow: hidden;
+}
+
+.che-plugins-notification .notification-button {
     cursor: pointer;
 }
 
-.che-plugins-notification .notification:hover {
-    background-color: var(--theia-success-color1);
+.notification-message-icon {
+    position: absolute;
+    left: 0px;
+    top: 0px;
+    width: 28px;
+    height: 28px;
+    text-align: center;
 }
 
-.che-plugins-notification .notification:active {
-    box-shadow: 0px 0px 2px 0px var(--theia-success-color2);
-    outline: none;
+.notification-message-text {
+    position: absolute;
+    left: 28px;
+    right: 0px;
+    top: 0px;
+    bottom: 0px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 .che-plugins-notification .notification-control {


### PR DESCRIPTION
Signed-off-by: Vitaliy Guliy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Asks the Dashboard to restart the workspace after plugin installation. 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15006

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
