### PR TITLE
CHE-14616: Do not show git user config message if they set to global config

### DIFF
--- a/extensions/eclipse-che-theia-git-provisioner/src/browser/git-config-changes-tracker.ts
+++ b/extensions/eclipse-che-theia-git-provisioner/src/browser/git-config-changes-tracker.ts
@@ -10,17 +10,17 @@
 
 import { injectable } from 'inversify';
 import { Emitter, Event } from '@theia/core';
-import { CheGitNoticationClient, GitConfigChanged } from '../common/git-notification-proxy';
+import { CheGitClient, GitConfigChanged } from '../common/git-protocol';
 
 @injectable()
-export class CheGitNoticationClientImpl implements CheGitNoticationClient {
+export class CheGitClientImpl implements CheGitClient {
 
     private onChangedEmitter = new Emitter<GitConfigChanged>();
 
     get changeEvent(): Event<GitConfigChanged> {
         return this.onChangedEmitter.event;
     }
-    notify() {
+    firePreferencesChanged() {
         const event: GitConfigChanged = {};
         this.onChangedEmitter.fire(event);
     }

--- a/extensions/eclipse-che-theia-git-provisioner/src/browser/git-frontend-module.ts
+++ b/extensions/eclipse-che-theia-git-provisioner/src/browser/git-frontend-module.ts
@@ -18,17 +18,17 @@ import { ContainerModule } from 'inversify';
 import { FrontendApplicationContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
 import { bindGitPreferences } from './git-preferences';
 import { CheTheiaStatusBarFrontendContribution } from './status-bar-contribution';
-import { CheGitNoticationServer, CheGitNoticationPath, CheGitNoticationClient } from '../common/git-notification-proxy';
-import { CheGitNoticationClientImpl } from './git-config-changes-tracker';
+import { CheGitService, CheGitServicePath, CheGitClient } from '../common/git-protocol';
+import { CheGitClientImpl } from './git-config-changes-tracker';
 
 export default new ContainerModule(bind => {
     bindGitPreferences(bind);
     bind(FrontendApplicationContribution).to(CheTheiaStatusBarFrontendContribution).inSingletonScope();
-    bind(CheGitNoticationClientImpl).toSelf().inSingletonScope();
-    bind(CheGitNoticationClient).toService(CheGitNoticationClientImpl);
-    bind(CheGitNoticationServer).toDynamicValue(ctx => {
+    bind(CheGitClientImpl).toSelf().inSingletonScope();
+    bind(CheGitClient).toService(CheGitClientImpl);
+    bind(CheGitService).toDynamicValue(ctx => {
         const provider = ctx.container.get(WebSocketConnectionProvider);
-        const client = ctx.container.get<CheGitNoticationClient>(CheGitNoticationClient);
-        return provider.createProxy<CheGitNoticationServer>(CheGitNoticationPath, client);
+        const client = ctx.container.get<CheGitClient>(CheGitClient);
+        return provider.createProxy<CheGitService>(CheGitServicePath, client);
     }).inSingletonScope();
 });

--- a/extensions/eclipse-che-theia-git-provisioner/src/common/git-protocol.ts
+++ b/extensions/eclipse-che-theia-git-provisioner/src/common/git-protocol.ts
@@ -9,20 +9,23 @@
  **********************************************************************/
 
 import { JsonRpcServer } from '@theia/core';
+import { UserConfiguration } from '../node/git-configuration-controller';
 
 export const GIT_USER_NAME = 'git.user.name';
 export const GIT_USER_EMAIL = 'git.user.email';
 
-export const CheGitNoticationPath = '/services/che-git-notification';
+export const CheGitServicePath = '/services/che-git-service';
 
-export const CheGitNoticationClient = Symbol('CheGitNoticationClient');
+export const CheGitClient = Symbol('CheGitClient');
 
-export interface CheGitNoticationClient {
-    notify(): void;
+export interface CheGitClient {
+    firePreferencesChanged(): void;
 }
 
-export const CheGitNoticationServer = Symbol('CheGitNoticationServer');
+export const CheGitService = Symbol('CheGitService');
 
-export interface CheGitNoticationServer extends JsonRpcServer<CheGitNoticationClient> { }
+export interface CheGitService extends JsonRpcServer<CheGitClient> {
+    getUserConfigurationFromGitConfig(): Promise<UserConfiguration>
+}
 
 export interface GitConfigChanged { }

--- a/extensions/eclipse-che-theia-git-provisioner/src/node/git-backend-module.ts
+++ b/extensions/eclipse-che-theia-git-provisioner/src/node/git-backend-module.ts
@@ -18,17 +18,17 @@ import { ContainerModule } from 'inversify';
 import { GitConfigurationListenerContribution } from './git-configuration-contribution';
 import { GitConfigurationController } from './git-configuration-controller';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
-import { CheGitNoticationServer, CheGitNoticationPath, CheGitNoticationClient } from '../common/git-notification-proxy';
+import { CheGitService, CheGitServicePath, CheGitClient } from '../common/git-protocol';
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
 
 export default new ContainerModule(bind => {
     bind(GitConfigurationController).toSelf().inSingletonScope();
-    bind(CheGitNoticationServer).toService(GitConfigurationController);
+    bind(CheGitService).toService(GitConfigurationController);
     bind(GitConfigurationListenerContribution).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toService(GitConfigurationListenerContribution);
     bind(ConnectionHandler).toDynamicValue(ctx =>
-        new JsonRpcConnectionHandler<CheGitNoticationClient>(CheGitNoticationPath, client => {
-            const server = ctx.container.get<CheGitNoticationServer>(CheGitNoticationServer);
+        new JsonRpcConnectionHandler<CheGitClient>(CheGitServicePath, client => {
+            const server = ctx.container.get<CheGitService>(CheGitService);
             server.setClient(client);
             client.onDidCloseConnection(() => server.dispose());
             return server;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Check user name and email in the global Git config. If present do not show git user config message:
![screenshot-che-che 192 168 39 24 nip io-2019 11 14-15_50_31](https://user-images.githubusercontent.com/7668752/68862660-87e6e900-06f6-11ea-89ba-70a40bce2f43.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14616

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A