### PR TITLE
[Port plugin] Do not suggest to open link of exposed by workspace config port

### DIFF
--- a/plugins/ports-plugin/src/ports-plugin.ts
+++ b/plugins/ports-plugin/src/ports-plugin.ts
@@ -122,6 +122,12 @@ async function onOpenPort(port: Port) {
         if (matchingWorkspacePort.serverName.startsWith(SERVER_REDIRECT_PATTERN)) {
             return;
         }
+
+        // check if endpoint has preview url, and if so do not show dialog to avoid duplication with task plugin
+        if (matchingWorkspacePort.previewUrl) {
+            return;
+        }
+
         const interactions: MessageItem[] = [{ title: 'Open Link' }];
         const msg = `A process is now listening on port ${matchingWorkspacePort.portNumber}. External URL is ${matchingWorkspacePort.url}`;
         const result = await theia.window.showInformationMessage(msg, { modal: true }, ...interactions);

--- a/plugins/ports-plugin/src/workspace-handler.ts
+++ b/plugins/ports-plugin/src/workspace-handler.ts
@@ -9,7 +9,7 @@
  **********************************************************************/
 
 import * as che from '@eclipse-che/plugin';
-import { WorkspacePort } from './workspace-port';
+import { WorkspacePort, PreviewUrl } from './workspace-port';
 
 /**
  * Grab ports exposed in the workspace.
@@ -23,13 +23,25 @@ export class WorkspaceHandler {
         if (!workspace) {
             return ports;
         }
+
+        const previewUrls: PreviewUrl[] = [];
+        if (workspace.devfile && workspace.devfile.commands) {
+            const commands = workspace.devfile.commands;
+            for (const command of commands) {
+                if (command.previewUrl && command.previewUrl.port) {
+                    previewUrls.push({ port: command.previewUrl.port.toString(), path: command.previewUrl.path });
+                }
+            }
+        }
+
         const runtimeMachines = workspace!.runtime!.machines || {};
         Object.keys(runtimeMachines).forEach((machineName: string) => {
             const machineServers = runtimeMachines[machineName].servers || {};
             Object.keys(machineServers).forEach((serverName: string) => {
                 const url = machineServers[serverName].url!;
                 const portNumber = machineServers[serverName].attributes!.port!;
-                ports.push({ portNumber, serverName, url });
+                const previewUrl = previewUrls.find(previewUrlData => previewUrlData.port === portNumber);
+                ports.push({ portNumber, serverName, url, previewUrl });
             });
 
         });

--- a/plugins/ports-plugin/src/workspace-port.ts
+++ b/plugins/ports-plugin/src/workspace-port.ts
@@ -13,6 +13,15 @@
  */
 export interface WorkspacePort {
     url: string;
-    portNumber: string
-    serverName: string
+    portNumber: string;
+    serverName: string;
+    previewUrl?: PreviewUrl;
+}
+
+/**
+ * Exposed server preview url configuration.
+ */
+export interface PreviewUrl {
+    port: string;
+    path?: string;
 }


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Removes functionality from port plugin which suggest to open link of already opened in workspace configuration port.
This is mainly done because of preview url suggestion when a task is started. In such case two popups are raised.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14802
