### PR TITLE
Add cdn link to welcome plugin webview meta tag to fix Firefox scp issue

### DIFF
--- a/plugins/welcome-plugin/src/welcome-plugin.ts
+++ b/plugins/welcome-plugin/src/welcome-plugin.ts
@@ -32,8 +32,6 @@ async function getHtmlForWebview(context: theia.PluginContext): Promise<string> 
     const welcomePage = new WelcomePage(context);
     const rendering = await welcomePage.render(context);
     // tslint:disable: max-line-length
-    //
-    // tslint:disable: max-line-length
     return `<!DOCTYPE html>
             <html lang="en">
             <head>

--- a/plugins/welcome-plugin/src/welcome-plugin.ts
+++ b/plugins/welcome-plugin/src/welcome-plugin.ts
@@ -32,11 +32,13 @@ async function getHtmlForWebview(context: theia.PluginContext): Promise<string> 
     const welcomePage = new WelcomePage(context);
     const rendering = await welcomePage.render(context);
     // tslint:disable: max-line-length
+    //
+    // tslint:disable: max-line-length
     return `<!DOCTYPE html>
             <html lang="en">
             <head>
                 <meta charset="UTF-8">
-                <meta http-equiv="Content-Security-Policy" content="font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'unsafe-inline' 'self';">
+                <meta http-equiv="Content-Security-Policy" content="font-src 'self' https://static.developers.redhat.com; style-src 'self' https://static.developers.redhat.com 'unsafe-inline'; script-src 'unsafe-inline' https://static.developers.redhat.com 'self';">
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
                 <link rel="stylesheet" type="text/css" href="${cssUri}">
                 </style>


### PR DESCRIPTION

### What does this PR do?
Welcome plugin uses styles from che-theia https://github.com/eclipse/che-theia/blob/master/plugins/welcome-plugin/resources/welcome-page.css#L290, and these styles collected in the cdn.
Fix error in the Firefox about font loading:
```
Content Security Policy: The page’s settings blocked the loading of a resource at https://static.developers.redhat.com/che/theia_artifacts/de59a97248b44599e6747a27a943f738.woff2 (“font-src”).) 
```
which cause issue with loading icons in the che-theia (especially in the file tree). P.S. Issue is unstable, because Firefox caches resources. Reproduced with latest enterprise long term Firefox esr 68.

### What issues does this PR fix or reference?
Part of the https://github.com/eclipse/che/issues/13442

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
