### PR TITLE
Do not use webview service for product logo in about dialog

### DIFF
--- a/extensions/eclipse-che-theia-about/package.json
+++ b/extensions/eclipse-che-theia-about/package.json
@@ -7,6 +7,7 @@
   "description": "Eclipse Che - Theia About menu",
   "dependencies": {
     "@theia/core": "next",
+    "@theia/mini-browser": "next",
     "@eclipse-che/theia-plugin-ext": "0.0.1"
   },
   "publishConfig": {

--- a/extensions/eclipse-che-theia-about/src/browser/about-che-theia-dialog.ts
+++ b/extensions/eclipse-che-theia-about/src/browser/about-che-theia-dialog.ts
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
+import * as path from 'path';
 import { AboutDialog, AboutDialogProps, ABOUT_EXTENSIONS_CLASS, ABOUT_CONTENT_CLASS } from '@theia/core/lib/browser/about-dialog';
 import { injectable, inject, postConstruct } from 'inversify';
 import { CheProductService, Product } from '@eclipse-che/theia-plugin-ext/lib/common/che-protocol';
@@ -50,11 +51,8 @@ export class AboutCheTheiaDialog extends AboutDialog {
             logo = logo.substring(7);
         }
 
-        if (logo.startsWith('/')) {
-            return `/webview${logo}`;
-        } else {
-            return `/webview/${logo}`;
-        }
+        // Use relative endpoint path
+        return path.join('mini-browser', logo);
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
In About dialog we used webview API implementation endpoint to retrieve product logo. Such approach is not good and current PR retrieves the logo via upstream mini-browser service.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14883