### PR TITLE
fix(build): Python dependencies are requiring gcc at build time

### DIFF
--- a/dockerfiles/remote-plugin-python-3.7.3/Dockerfile
+++ b/dockerfiles/remote-plugin-python-3.7.3/Dockerfile
@@ -14,9 +14,10 @@ RUN apt-get update && \
     apt-get install wget -y && \
 	wget -O - https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get update && \
-	apt-get install nodejs -y && \
-	apt-get clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/* && \
-    pip install pylint python-language-server[all] ptvsd 'jedi<0.15,>=0.14.1'
+	apt-get install nodejs gcc build-essential -y && \
+    pip install pylint python-language-server[all] ptvsd 'jedi<0.15,>=0.14.1' && \
+    apt-get purge -y --auto-remove gcc build-essential && \
+	apt-get clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/*
 
 ENV HOME=/home/theia
 

--- a/dockerfiles/remote-plugin-python-3.7.4/Dockerfile
+++ b/dockerfiles/remote-plugin-python-3.7.4/Dockerfile
@@ -23,9 +23,10 @@ RUN apt-get update && \
     apt-get install wget -y && \
 	wget -O - https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get update && \
-	apt-get install nodejs -y && \
-	apt-get clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/* && \
-    pip install pylint python-language-server[all] ptvsd 'jedi<0.15,>=0.14.1'
+	apt-get install nodejs gcc build-essential -y && \
+    pip install pylint python-language-server[all] ptvsd 'jedi<0.15,>=0.14.1' && \
+    apt-get purge -y --auto-remove gcc build-essential && \
+	apt-get clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/*
 
 ADD etc/entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
### What does this PR do?
add missing dependencies
```
00:50:02     creating build/temp.linux-x86_64-3.7/lib
00:50:02     gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I./python -I./lib -I/usr/local/include/python3.7m -c ./python/ujson.c -o build/temp.linux-x86_64-3.7/./python/ujson.o -D_GNU_SOURCE
00:50:02     unable to execute 'gcc': No such file or directory
00:50:02     error: command 'gcc' failed with exit status 1
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15230

Change-Id: Ie10d532813968140d4cfe5a6e8724f73837ab16a
Signed-off-by: Florent Benoit <fbenoit@redhat.com>



