### PR TITLE
feat(core) Use newer Kamel executable 1.0.0-M4 eclipse/che#15086

### DIFF
--- a/dockerfiles/remote-plugin-camelk-0.0.10/Dockerfile
+++ b/dockerfiles/remote-plugin-camelk-0.0.10/Dockerfile
@@ -9,7 +9,7 @@
 #   Red Hat, Inc. - initial API and implementation
 FROM ${BUILD_ORGANIZATION}/che-remote-plugin-kubernetes-tooling-1.0.0:${BUILD_TAG}
 
-ENV KAMEL_VERSION 1.0.0-M3
+ENV KAMEL_VERSION 1.0.0-M4
 
 RUN curl -L https://github.com/apache/camel-k/releases/download/${KAMEL_VERSION}/camel-k-client-${KAMEL_VERSION}-linux-64bit.tar.gz | tar -C /usr/local/bin -xz \
 	&& chmod +x /usr/local/bin/kamel


### PR DESCRIPTION
It is notably fixing an issue with using the container service account
instead of the kubeconfig when provided

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?


### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
