### PR TITLE
Remove che-machine-exec:next plugin from remote plugin devfile.

### DIFF
--- a/extensions/eclipse-che-theia-plugin-remote/devfile.yaml
+++ b/extensions/eclipse-che-theia-plugin-remote/devfile.yaml
@@ -11,8 +11,6 @@ components:
     id: eclipse/che-theia/next
     alias: theia-editor
   - type: chePlugin
-    id: eclipse/che-machine-exec-plugin/next
-  - type: chePlugin
     id: che-incubator/typescript/latest
     memoryLimit: 2Gi
   - type: dockerimage


### PR DESCRIPTION
### What does this PR do?
Remove che-machine-exec:next plugin from remote plugin devfile.
che-machine-exec is predefined plugin and next tag is depracated and removed.

### What issues does this PR fix or reference?
none. Devfile support.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>

