### PR TITLE
Intercept uri arguments and set container name into file scheme

### DIFF
--- a/extensions/eclipse-che-theia-plugin-remote/src/node/execute-command-container-aware.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/execute-command-container-aware.ts
@@ -1,0 +1,25 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import { CommandRegistryImpl } from '@theia/plugin-ext/lib/plugin/command-registry';
+import { overrideUri } from './che-content-aware-utils';
+
+export class ExecuteCommandContainerAware {
+    static makeExecuteCommandContainerAware(commandRegistryExt: CommandRegistryImpl) {
+        const executeCommandContainerAware = new ExecuteCommandContainerAware();
+        executeCommandContainerAware.overrideExecuteCommand(commandRegistryExt);
+    }
+
+    overrideExecuteCommand(commandRegistryExt: CommandRegistryImpl) {
+        const originalExecuteCommand = commandRegistryExt.executeCommand.bind(commandRegistryExt);
+        // tslint:disable-next-line:no-any
+        const executeCommand = (id: string, ...args: any[]) => originalExecuteCommand(id, ...args.map(arg => arg.scheme ? overrideUri(arg) : arg));
+        commandRegistryExt.executeCommand = executeCommand;
+    }
+}

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-init.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-init.ts
@@ -36,6 +36,7 @@ import { Deferred } from '@theia/core/lib/common/promise-util';
 import { DocumentContainerAware } from './document-container-aware';
 import { LanguagesContainerAware } from './languages-container-aware';
 import { PluginManagerExtImpl } from '@theia/plugin-ext/lib/plugin/plugin-manager';
+import { ExecuteCommandContainerAware } from './execute-command-container-aware';
 
 interface CheckAliveWS extends ws {
     alive: boolean;
@@ -214,6 +215,8 @@ to pick-up automatically a free port`));
         DocumentContainerAware.makeDocumentContainerAware((webSocketClient.rpc as any).locals.get(MAIN_RPC_CONTEXT.DOCUMENTS_EXT.id));
         // tslint:disable-next-line:no-any
         LanguagesContainerAware.makeLanguagesContainerAware((webSocketClient.rpc as any).locals.get(MAIN_RPC_CONTEXT.LANGUAGES_EXT.id));
+        // tslint:disable-next-line:no-any
+        ExecuteCommandContainerAware.makeExecuteCommandContainerAware((webSocketClient.rpc as any).locals.get(MAIN_RPC_CONTEXT.COMMAND_REGISTRY_EXT.id));
 
         let channelName = '';
         if (process.env.CHE_MACHINE_NAME) {


### PR DESCRIPTION
### What does this PR do?
Register ArgumentProcessor that is responsible to process only URI argument types. Argument processor checks for the path and if path is not starts with project root, then file scheme modifies with the container name to be looks like this: `file-sidecar-${machineName}`. This will allow che-theia to pass into executed commands correct file resources, taken from different containers.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13044
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Intercept uri arguments and set container name into file scheme

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - internal modification.
