### PR TITLE
Display default Plugin icon when error

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-view-list.tsx
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-view-list.tsx
@@ -59,6 +59,7 @@ interface ListItemProps {
 
 interface ListItemState {
     pluginStatus: PluginStatus;
+    iconFailed: boolean;
 }
 
 export class ChePluginListItem extends React.Component<ListItemProps, ListItemState> {
@@ -69,7 +70,8 @@ export class ChePluginListItem extends React.Component<ListItemProps, ListItemSt
         const status = props.pluginItem.installed ? 'installed' : 'not_installed';
 
         this.state = {
-            pluginStatus: status
+            pluginStatus: status,
+            iconFailed: false
         };
     }
 
@@ -239,11 +241,22 @@ export class ChePluginListItem extends React.Component<ListItemProps, ListItemSt
         </select>;
     }
 
+    protected onIconFailed = async () => {
+        const plugin = this.props.pluginItem;
+        const metadata = plugin.versionList[plugin.version];
+        if (metadata) {
+            this.setState({
+                pluginStatus: this.state.pluginStatus,
+                iconFailed: true
+            });
+        }
+    }
+
     protected renderIcon(metadata: ChePluginMetadata): React.ReactNode {
-        if (metadata.icon) {
+        if (!this.state.iconFailed && metadata.icon) {
             // return the icon
             return <div className='che-plugin-icon'>
-                <img src={metadata.icon}></img>
+                <img src={metadata.icon} onError={this.onIconFailed}></img>
             </div>;
         }
 
@@ -277,7 +290,8 @@ export class ChePluginListItem extends React.Component<ListItemProps, ListItemSt
 
     protected setStatus(status: PluginStatus): void {
         this.setState({
-            pluginStatus: status
+            pluginStatus: status,
+            iconFailed: this.state.iconFailed
         });
     }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Handles loading of plugin icon. Displays default icon when the plugin icon cannot be loaded.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15193
