### PR TITLE
Add VS Code extension generator to theia-dev container

### DIFF
--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -44,7 +44,7 @@ EXPOSE 3000 3030
 RUN npm config set prefix "${HOME}/.npm-global" && \
     echo "--global-folder \"${HOME}/.yarn-global\"" > ${HOME}/.yarnrc && \
     # add eclipse che theia generator
-    yarn ${YARN_FLAGS} global add yo @theia/generator-plugin@0.0.1-1562578105 file:${HOME}/eclipse-che-theia-generator.tgz && \
+    yarn ${YARN_FLAGS} global add yo generator-code @theia/generator-plugin@0.0.1-1562578105 file:${HOME}/eclipse-che-theia-generator.tgz && \
     rm -rf ${HOME}/eclipse-che-theia-generator.tgz && \
     # Generate .passwd.template \
     cat /etc/passwd | \


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Installs `generator-code` package to theia-dev container. It allows to launch VS Code extension generator in theia-dev container using terminal.

### What issues does this PR fix or reference?
Part of the issue https://github.com/eclipse/che/issues/14228
