### PR TITLE
Add WORKDIR into dotnet image

### DIFF
--- a/dockerfiles/remote-plugin-dotnet-2.2.105/Dockerfile
+++ b/dockerfiles/remote-plugin-dotnet-2.2.105/Dockerfile
@@ -88,6 +88,8 @@ ENV ASPNETCORE_URLS=http://+:80 \
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help
 
+WORKDIR /projects
+
 ADD etc/entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds WORKDIR into dotnet plugin image to fix the problem with running netcoredbg.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15025

