### PR TITLE
Add SHELL environment variable into theia-ide dockerfile

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -109,6 +109,7 @@ RUN find production -exec sh -c "chgrp 0 {}; chmod g+rwX {}" \; 2>log.txt
 
 ENV USE_LOCAL_GIT=true \
     HOME=/home/theia \
+    SHELL=/bin/bash \
     THEIA_DEFAULT_PLUGINS=local-dir:///default-theia-plugins \
     # Specify the directory of git (avoid to search at init of Theia)
     LOCAL_GIT_DIRECTORY=/usr \


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds **SHELL** environment variable into theia-ide dockerfile. This env points to default shell.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15116

