### PR TITLE
Adapt che tasks to updated validation system

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-task-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-task-main.ts
@@ -40,6 +40,6 @@ export class CheTaskMainImpl implements CheTaskMain {
     }
 
     async $addTaskSubschema(schema: TaskJSONSchema): Promise<void> {
-        this.taskSchemaUpdater.addSubschema(schema);
+        return this.taskSchemaUpdater.addSubschema(schema);
     }
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-task-impl.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-task-impl.ts
@@ -49,6 +49,6 @@ export class CheTaskImpl implements CheTask {
     }
 
     async addTaskSubschema(schema: TaskJSONSchema): Promise<void> {
-        this.cheTaskMain.$addTaskSubschema(schema);
+        return this.cheTaskMain.$addTaskSubschema(schema);
     }
 }

--- a/plugins/task-plugin/src/export/export-configs-manager.ts
+++ b/plugins/task-plugin/src/export/export-configs-manager.ts
@@ -45,21 +45,26 @@ export class ExportConfigurationsManager {
     @multiInject(ConfigurationsExporter)
     protected readonly exporters: ConfigurationsExporter[];
 
-    async export() {
+    async export(): Promise<void> {
         const workspaceFolders = theia.workspace.workspaceFolders;
         if (!workspaceFolders || workspaceFolders.length < 1) {
             return;
         }
 
+        const exportPromises = [];
         const cheCommands = await this.cheWorkspaceClient.getCommands();
         for (const exporter of this.exporters) {
-            this.doExport(workspaceFolders, cheCommands, exporter);
+            exportPromises.push(this.doExport(workspaceFolders, cheCommands, exporter));
         }
+
+        await Promise.all(exportPromises);
     }
 
-    private doExport(workspaceFolders: theia.WorkspaceFolder[], cheCommands: cheApi.workspace.Command[], exporter: ConfigurationsExporter) {
+    private async doExport(workspaceFolders: theia.WorkspaceFolder[], cheCommands: cheApi.workspace.Command[], exporter: ConfigurationsExporter): Promise<void> {
+        const exportConfigsPromises = [];
         for (const workspaceFolder of workspaceFolders) {
-            exporter.export(workspaceFolder, cheCommands);
+            exportConfigsPromises.push(exporter.export(workspaceFolder, cheCommands));
         }
+        await Promise.all(exportConfigsPromises);
     }
 }

--- a/plugins/task-plugin/src/task-plugin-backend.ts
+++ b/plugins/task-plugin/src/task-plugin-backend.ts
@@ -52,10 +52,10 @@ export async function start(context: theia.PluginContext) {
     const taskRunnerSubscription = await che.task.registerTaskRunner(CHE_TASK_TYPE, cheTaskRunner);
     getSubscriptions().push(taskRunnerSubscription);
 
+    await che.task.addTaskSubschema(CHE_TASK_SCHEMA);
+
     const exportConfigurationsManager = container.get<ExportConfigurationsManager>(ExportConfigurationsManager);
     exportConfigurationsManager.export();
-
-    che.task.addTaskSubschema(CHE_TASK_SCHEMA);
 }
 
 export function stop() { }


### PR DESCRIPTION
### What does this PR do?
The validation system for task configurations in `theia` project [was updated](https://github.com/eclipse-theia/theia/pull/6616/files#r350946933):
- **the previous behavior**: the logic is task valid or not was executed every time we took the configurations for running.
- **the current behavior**:  the validation is executed on events (for example, config file was changed).

I [added](https://github.com/eclipse-theia/theia/commit/f85acd6e78b29df856b6f3df268116e2cbf6601f) `onDidChangeTaskSchema` event in `theia` project to validate tasks configurations when task schema is changed. It allows to reorganize tasks at adding schema for tasks in general and for `che` tasks in particular.

The current PR changes regulates the order of this process for `che` tasks: 
- at first: adding schema for `che` tasks
- next: export configurations of `che` commands as `theia` tasks to `tasks.json` file 

So it allows to have registered schema for `che` tasks when configurations are exported and satisfy updated validation system in `theia` project. 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15332

### How to test
1. Use the following devfile, which contains the reference for image with changes related to the current PR (you can check it using `Help=> About` dialog).
 
<details>
<summary>Devfile</summary>
 
```
apiVersion: 1.0.1-beta
metadata:
 name: wksp-test-che-tasks
projects:
  - name: che-theia
    source:
      type: git
      location: 'https://github.com/eclipse/che-theia.git'
  - name: theia
    source:
      type: git
      location: 'https://github.com/theia-ide/theia.git'
components:
  - 
    alias: che-dev
    type: dockerimage
    image: eclipse/che-theia-dev:next
    mountSources: true
    endpoints:
      - name: "theia-dev"
        port: 3130
        attributes:
          protocol: tcp
          public: 'true'
    memoryLimit: 2Gi

  - 
    alias: theia-editor
    reference: >-
      https://raw.githubusercontent.com/RomanNikitenko/che-plugin-registry/master/v3/plugins/eclipse/che-theia/next/meta.yaml
    type: cheEditor
   
commands:
- name: test CHE task
  actions:
  - type: exec
    component: theia-editor
    command: >
              sleep 2 && echo CHE task is completed
    workdir: /projects/theia

- name: theia:build
  actions:
  - type: exec
    component: che-dev
    command: >
              yarn
    workdir: /projects/theia

- name: che-theia:build
  actions:
  - type: exec
    component: che-dev
    command: >
              yarn
    workdir: /projects/che-theia

```
</details>
 
2. Go to `Terminal => Run Task` 
 `che` tasks should be available for running, try to run a task
3. Try to run a task from `My Workspace` panel
4. Try to refresh the page and run a task using `Terminal => Run Task` menu
5. Try to refresh the page and run a task using `My Workspace` panel
    

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
