### PR TITLE
Add scripts for Centos CI

### DIFF
--- a/cico_build_master.sh
+++ b/cico_build_master.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# See: https://sipb.mit.edu/doc/safe-shell/
+
+# Output command before executing
+set -x
+
+# Exit on error
+set -e
+
+#include common scripts
+. ./cico_common.sh
+. ./build.include
+
+
+parse "$@"
+
+install_deps
+load_jenkins_vars
+buildImages
+publishImagesOnQuay

--- a/cico_build_nightly.sh
+++ b/cico_build_nightly.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# See: https://sipb.mit.edu/doc/safe-shell/
+
+/bin/bash ./cico_build_master.sh

--- a/cico_build_release.sh
+++ b/cico_build_release.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# See: https://sipb.mit.edu/doc/safe-shell/
+
+/bin/bash ./cico_build_master.sh

--- a/cico_common.sh
+++ b/cico_common.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# See: https://sipb.mit.edu/doc/safe-shell/
+
+# Source environment variables of the jenkins slave
+# that might interest this worker.
+function load_jenkins_vars() {
+  if [ -e "jenkins-env.json" ]; then
+    eval "$(./env-toolkit load -f jenkins-env.json \
+            CHE_BOT_GITHUB_TOKEN \
+            QUAY_ECLIPSE_CHE_USERNAME \
+            QUAY_ECLIPSE_CHE_PASSWORD \
+            JENKINS_URL \
+            GIT_BRANCH \
+            GIT_COMMIT \
+            BUILD_NUMBER \
+            ghprbSourceBranch \
+            ghprbActualCommit \
+            BUILD_URL \
+            ghprbPullId)"
+    #export provided GH token
+    export GITHUB_TOKEN=${CHE_BOT_GITHUB_TOKEN}
+  fi
+}
+
+function install_deps() {
+  # We need to disable selinux for now, XXX
+  /usr/sbin/setenforce 0  || true
+
+  # Get all the deps in
+  yum install -y yum-utils device-mapper-persistent-data lvm2
+  yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+  curl -sL https://rpm.nodesource.com/setup_10.x | bash -
+  yum-config-manager --add-repo https://dl.yarnpkg.com/rpm/yarn.repo
+
+  yum install -y docker-ce git nodejs yarn gcc-c++ make
+
+  service docker start
+  echo 'CICO: Dependencies installed'
+}
+
+publishImagesOnQuay() {
+    REGISTRY="quay.io"
+    # For pushing to quay.io 'eclipse' organization we need to use different credentials
+    QUAY_USERNAME=${QUAY_ECLIPSE_CHE_USERNAME}
+    QUAY_PASSWORD=${QUAY_ECLIPSE_CHE_PASSWORD}
+    if [ -n "${QUAY_USERNAME}" ] && [ -n "${QUAY_PASSWORD}" ]; then
+        docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" "${REGISTRY}"
+    else
+      echo "Could not login, missing credentials for pushing to the '${ORGANIZATION}' organization"
+      return
+    fi
+
+  for image in "${PUBLISH_IMAGES_LIST[@]}"
+  do
+    echo "Publishing image ${image}..."
+    if [[ -n "${THEIA_DOCKER_IMAGE_VERSION}" ]]; then
+      docker tag "${image}:${IMAGE_TAG}" "${REGISTRY}/${image}:${THEIA_DOCKER_IMAGE_VERSION}"
+      docker tag "${image}:${IMAGE_TAG}" "${REGISTRY}/${image}:${IMAGE_TAG}"
+      echo y | docker push "${REGISTRY}/${image}:${IMAGE_TAG}"
+      echo y | docker push "${REGISTRY}/${image}:${THEIA_DOCKER_IMAGE_VERSION}"
+    else
+      docker tag "${image}:${IMAGE_TAG}" "${REGISTRY}/${image}:${IMAGE_TAG}"
+      echo y | docker push "${REGISTRY}/${image}:${IMAGE_TAG}"
+    fi
+  done
+}

--- a/dockerfiles/theia-dev/build.sh
+++ b/dockerfiles/theia-dev/build.sh
@@ -27,7 +27,7 @@ then
     # Delete previous archive if any
     rm -f $CHE_THEIA_GENERATOR_PACKAGE
     echo "Building Che Theia generator"
-    cd "${base_dir}"/../../generator/ && yarn prepare && yarn pack --filename $CHE_THEIA_GENERATOR_PACKAGE_NAME
+    cd "${base_dir}"/../../generator/ && yarn && yarn pack --filename $CHE_THEIA_GENERATOR_PACKAGE_NAME
 fi
 echo "Copying Che Theia generator"
 cp "${CHE_THEIA_GENERATOR_PACKAGE}" "${base_dir}/asset-${CHE_THEIA_GENERATOR_PACKAGE_NAME}"


### PR DESCRIPTION
### What does this PR do?
Add scripts for Centos CI, for now it is only `master`, `nightly` and `release` scripts.
Note that [https://ci.centos.org/view/Devtools/](https://ci.centos.org/view/Devtools/) will publish docker images on [quay.io](https://quay.io):

- che-theia-dev - https://quay.io/repository/eclipse/che-theia-dev?tag=latest&tab=tags
- che-theia - https://quay.io/repository/eclipse/che-theia?tag=latest&tab=tags
- eclipse/che-theia-endpoint-runtime-binary - https://quay.io/repository/eclipse/che-theia-endpoint-runtime-binary?tab=tags

### What issues does this PR fix or reference?
eclipse/che#14849
