### PR TITLE
Deprecate current.project.path variable

### DIFF
--- a/plugins/task-plugin/src/variable/project-path-variable-resolver.ts
+++ b/plugins/task-plugin/src/variable/project-path-variable-resolver.ts
@@ -9,17 +9,17 @@
  **********************************************************************/
 
 import { injectable } from 'inversify';
-import Uri from 'vscode-uri';
 import * as che from '@eclipse-che/plugin';
 import * as theia from '@theia/plugin';
 import * as startPoint from '../task-plugin-backend';
 
 const VARIABLE_NAME = 'current.project.path';
-const SELECTED_CONTEXT_COMMAND = 'theia.plugin.workspace.selectedContext';
 const PROJECTS_ROOT_VARIABLE = 'CHE_PROJECTS_ROOT';
 const ERROR_MESSAGE_TEMPLATE = 'Can not resolve \'current.project.path\' variable.';
 /**
  * Contributes the variable for getting path for current project as a relative path to the first directory under the root workspace.
+ * 
+ * @deprecated will be removed soon. Use ${workspaceFolder} macro instead.
  */
 @injectable()
 export class ProjectPathVariableResolver {
@@ -38,33 +38,7 @@ export class ProjectPathVariableResolver {
             return this.onError('Projects root is not set');
         }
 
-        const selections = await theia.commands.executeCommand<Uri[]>(SELECTED_CONTEXT_COMMAND);
-        if (!selections || selections.length < 1) {
-            return this.onError('Please select a project.');
-        }
-
-        const selection = selections[0];
-        const selectionPath = selection.path;
-        const workspaceFolder = theia.workspace.getWorkspaceFolder(theia.Uri.file(selectionPath));
-        if (!workspaceFolder) {
-            return this.onError('Selection doesn\'t match any workspace folder.');
-        }
-
-        const workspaceFolderPath = workspaceFolder.uri.path;
-        if (workspaceFolderPath === this.projectsRoot) {
-            const splittedSelectionUri = selectionPath.substring(workspaceFolderPath.length).split('/');
-            const project = splittedSelectionUri.shift() || splittedSelectionUri.shift();
-
-            this.isResolved = true;
-            return `${this.projectsRoot}/${project}`;
-        }
-
-        if (workspaceFolderPath.startsWith(this.projectsRoot)) {
-            this.isResolved = true;
-            return workspaceFolderPath;
-        }
-
-        return this.onError('The selection isn\'t under the current workspace root folder.');
+        return this.projectsRoot;
     }
 
     private createVariable(): che.Variable {
@@ -76,10 +50,10 @@ export class ProjectPathVariableResolver {
         };
     }
 
-    private onError(error?: string) {
+    private onError(error: string) {
         this.isResolved = false;
 
-        const errorMessage = error ? `${ERROR_MESSAGE_TEMPLATE} ${error}` : ERROR_MESSAGE_TEMPLATE;
+        const errorMessage = `${ERROR_MESSAGE_TEMPLATE} ${error}`;
         theia.window.showErrorMessage(errorMessage);
         return Promise.reject(errorMessage);
     }


### PR DESCRIPTION
### What does this PR do?
For the current state `${current.project.path}` is redundant and with this changes proposal marks as deprecated. User may use `${workspaceFolder}` instead.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13636
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
Deprecate `${current.project.path}` macro
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
