### PR TITLE
Post message to Dashboard in order to refresh keycloak token.

### DIFF
--- a/extensions/eclipse-che-theia-activity-tracker/src/browser/che-theia-activity-tracker-contribution.ts
+++ b/extensions/eclipse-che-theia-activity-tracker/src/browser/che-theia-activity-tracker-contribution.ts
@@ -59,6 +59,7 @@ export class CheTheiaActivityTrackerFrontendContribution implements FrontendAppl
 
     private sendRequestAndSetTimer(): void {
         this.activityService.resetTimeout();
+        this.messageUpdateKeycloakToken();
         this.isAnyActivity = false;
 
         setTimeout(() => this.checkActivityTimerCallback(), CheTheiaActivityTrackerFrontendContribution.REQUEST_PERIOD_MS);
@@ -70,6 +71,10 @@ export class CheTheiaActivityTrackerFrontendContribution implements FrontendAppl
         if (this.isAnyActivity) {
             this.sendRequestAndSetTimer();
         }
+    }
+
+    private messageUpdateKeycloakToken(): void {
+        window.parent.postMessage(`update-token:${CheTheiaActivityTrackerFrontendContribution.REQUEST_PERIOD_MS}`, '*');
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Activity tracker extension sends message to User Dashboard which makes UD to refresh keycloak token so as to avoid User Dashboard reloading. 

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/14933
