### PR TITLE
Add script for PR build job, update links for new CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 
 <div id="badges" align="center">
 
-  [![Build Status](https://ci.codenvycorp.com/buildStatus/icon?job=che-theia-next)](https://ci.codenvycorp.com/job/che-theia-next)
+  [![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-che-theia-che-build-master)](https://ci.centos.org/view/Devtools/job/devtools-che-theia-che-build-master/)
+  [![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-che-theia-che-nightly)](https://ci.centos.org/view/Devtools/job/devtools-che-theia-che-nightly/)
   [![mattermost](https://img.shields.io/badge/chat-on%20mattermost-blue.svg)](https://mattermost.eclipse.org/eclipse/channels/eclipse-che-ide2-team)
   [![Open questions](https://img.shields.io/badge/Open-questions-blue.svg?style=flat-curved)](https://github.com/eclipse/che/issues?utf8=%E2%9C%93&q=label%3Aarea%2Ftheia+label%3Akind%2Fquestion+)
   [![Open bugs](https://img.shields.io/badge/Open-bugs-red.svg?style=flat-curved)](https://github.com/eclipse/che/issues?utf8=%E2%9C%93&q=label%3Aarea%2Ftheia+label%3Akind%2Fbug+)

--- a/cico_build_pr.sh
+++ b/cico_build_pr.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# See: https://sipb.mit.edu/doc/safe-shell/
+
+# Output command before executing
+set -x
+
+# Exit on error
+set -e
+
+#include common scripts
+. ./cico_common.sh
+
+install_deps
+load_jenkins_vars
+
+#Set images tag to current commit id. 
+sed -i -e 's/IMAGE_TAG="..*"/IMAGE_TAG="'${GIT_COMMIT}'"/' build.include
+
+
+. ./build.include
+
+parse "$@"
+
+buildImages

--- a/devfiles/che-theia-all.devfile.yaml
+++ b/devfiles/che-theia-all.devfile.yaml
@@ -27,7 +27,7 @@ components:
 
   - alias: che-dev
     type: dockerimage
-    image: eclipse/che-theia-dev:next
+    image: "quay.io/eclipse/che-theia-dev:next"
     mountSources: true
     endpoints:
       - name: "theia-dev-flow"

--- a/dockerfiles/theia/README.md
+++ b/dockerfiles/theia/README.md
@@ -65,22 +65,15 @@ It specifies tag or branch for base Theia. Build script clones Theia sources, sw
 Parameter `${THEIA_BRANCH}` is optional. If it's not specified, the default value `'master'` will be used.
 
 
-CI generates several tags of [docker images](https://hub.docker.com/r/eclipse/che-theia/tags). Below is the list of images:
+CI generates several tags of [docker images](https://quay.io/repository/eclipse/che-theia?tab=tags). Below is the list of images:
 
 - `eclipse/che-theia:next`
   - theia branch: [master](https://github.com/theia-ide/theia/)
   - che-theia branch: [master](https://github.com/eclipse/che-theia)
-  - CI [build job](https://ci.codenvycorp.com/job/che-theia-next/)
+  - CI [build job](https://ci.centos.org/view/Devtools/job/devtools-che-theia-che-build-master/)
+  - CI [nightly build job](https://ci.centos.org/view/Devtools/job/devtools-che-theia-che-nightly/)
 
-- `eclipse/che-theia:7.0.0-next` Che-Theia 7.0.0 with the latest changes
-  - theia branch: [che-7.0.0](https://github.com/theia-ide/theia/tree/che-7.0.0)
-  - che-theia branch: [7.0.0](https://github.com/eclipse/che-theia/tree/7.0.0)
-  - CI [build job](https://ci.codenvycorp.com/job/che-theia-7.0.0-next/)
-
-- `eclipse/che:theia:latest` the latest stable Che-Theia 7.0.0 release
-  - theia branch: [che-7.0.0](https://github.com/theia-ide/theia/tree/che-7.0.0)
-  - che-theia tag: [v7.0.0-rc-4.0](https://github.com/eclipse/che-theia/tree/v7.0.0-rc-4.0)
-
+- `eclipse/che:theia:latest` the latest stable Che-Theia 7.x release, updates on each release by CI [release job](https://ci.centos.org/view/Devtools/job/devtools-che-theia-che-release/)
 
 ## Theia version
 


### PR DESCRIPTION
### What does this PR do?
Add script for PR build job, update links for new CI
>Note: there are no PR build job yet on centos CI

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14849
