### PR TITLE
Correct resolving of current project path

### DIFF
--- a/plugins/task-plugin/src/variable/project-path-variable-resolver.ts
+++ b/plugins/task-plugin/src/variable/project-path-variable-resolver.ts
@@ -14,57 +14,58 @@ import * as che from '@eclipse-che/plugin';
 import * as theia from '@theia/plugin';
 import * as startPoint from '../task-plugin-backend';
 
+const fs = require('fs');
+
 const VARIABLE_NAME = 'current.project.path';
 const SELECTED_CONTEXT_COMMAND = 'theia.plugin.workspace.selectedContext';
 const PROJECTS_ROOT_VARIABLE = 'CHE_PROJECTS_ROOT';
-const ERROR_MESSAGE_TEMPLATE = 'Can not resolve \'current.project.path\' variable.';
+const SELECT_PROJECT_MESSAGE = 'Please select a project before executing a command to make it possible to resolve the current project path.';
 /**
  * Contributes the variable for getting path for current project as a relative path to the first directory under the root workspace.
  */
 @injectable()
 export class ProjectPathVariableResolver {
-    private projectsRoot: string | undefined;
-    private isResolved: boolean = false;
+    private projectsRoot: string;
 
     async registerVariables(): Promise<void> {
-        this.projectsRoot = await theia.env.getEnvVariable(PROJECTS_ROOT_VARIABLE);
+        const projectsRoot = await theia.env.getEnvVariable(PROJECTS_ROOT_VARIABLE);
+        if (projectsRoot === undefined) {
+            return Promise.reject('Projects root is not provided');
+        }
+
+        this.projectsRoot = projectsRoot;
 
         const variableSubscription = await che.variables.registerVariable(this.createVariable());
         startPoint.getSubscriptions().push(variableSubscription);
     }
 
     async resolve(): Promise<string> {
-        if (!this.projectsRoot) {
-            return this.onError('Projects root is not set');
-        }
+        let value = '';
 
         const selections = await theia.commands.executeCommand<Uri[]>(SELECTED_CONTEXT_COMMAND);
-        if (!selections || selections.length < 1) {
-            return this.onError('Please select a project.');
+
+        if (selections !== undefined && selections.length === 1) {
+            // retrieve project path from selection
+            const relPath = selections[0].path.substring(this.projectsRoot.length).split('/');
+            const project = relPath.shift() || relPath.shift();
+
+            if (project !== undefined) {
+                value = `${this.projectsRoot}/${project}`;
+            }
+        } else {
+            // get project folder from workspace folders, first folder in workspaceFolders is .theia
+            const folders = fs.readdirSync(this.projectsRoot, {withFileTypes: false});
+
+            if (folders !== undefined && folders.length === 2) {
+                value = `${this.projectsRoot}/${folders[1]}`;
+            }
         }
 
-        const selection = selections[0];
-        const selectionPath = selection.path;
-        const workspaceFolder = theia.workspace.getWorkspaceFolder(theia.Uri.file(selectionPath));
-        if (!workspaceFolder) {
-            return this.onError('Selection doesn\'t match any workspace folder.');
+        if (value.length === 0) {
+            theia.window.showWarningMessage(SELECT_PROJECT_MESSAGE);
         }
 
-        const workspaceFolderPath = workspaceFolder.uri.path;
-        if (workspaceFolderPath === this.projectsRoot) {
-            const splittedSelectionUri = selectionPath.substring(workspaceFolderPath.length).split('/');
-            const project = splittedSelectionUri.shift() || splittedSelectionUri.shift();
-
-            this.isResolved = true;
-            return `${this.projectsRoot}/${project}`;
-        }
-
-        if (workspaceFolderPath.startsWith(this.projectsRoot)) {
-            this.isResolved = true;
-            return workspaceFolderPath;
-        }
-
-        return this.onError('The selection isn\'t under the current workspace root folder.');
+        return value;
     }
 
     private createVariable(): che.Variable {
@@ -72,15 +73,7 @@ export class ProjectPathVariableResolver {
             name: VARIABLE_NAME,
             description: 'The path of the project root folder',
             resolve: async () => this.resolve(),
-            isResolved: this.isResolved
+            isResolved: false
         };
-    }
-
-    private onError(error?: string) {
-        this.isResolved = false;
-
-        const errorMessage = error ? `${ERROR_MESSAGE_TEMPLATE} ${error}` : ERROR_MESSAGE_TEMPLATE;
-        theia.window.showErrorMessage(errorMessage);
-        return Promise.reject(errorMessage);
     }
 }


### PR DESCRIPTION
### What does this PR do?
This changes proposal modifies behavior of resolving `${current.project.path}` by respecting current selection and presence of projects in project root. Besides if user didn't select any project, the warning message will be shown.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13636
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
