### PR TITLE
Fix restarting a workspace from Che Theia in single-user mode

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
@@ -518,10 +518,11 @@ export class ChePluginManager {
             const cheWorkspaceID = await this.envVariablesServer.getValue('CHE_WORKSPACE_ID');
             // get machine token
             const cheMachineToken = await this.envVariablesServer.getValue('CHE_MACHINE_TOKEN');
-            if (cheWorkspaceID && cheWorkspaceID.value && cheMachineToken && cheMachineToken.value) {
+            if (cheWorkspaceID && cheWorkspaceID.value) {
                 this.messageService.info('Workspace is restarting...');
-                // ask Dashboard to restart the workspace giving him workpace ID & machine token
-                window.parent.postMessage(`restart-workspace:${cheWorkspaceID.value}:${cheMachineToken.value}`, '*');
+                const cheMachineTokenValue = cheMachineToken && cheMachineToken.value ? cheMachineToken.value : '';
+                // ask Dashboard to restart the workspace giving him workspace ID & machine token
+                window.parent.postMessage(`restart-workspace:${cheWorkspaceID.value}:${cheMachineTokenValue}`, '*');
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes bug in `@eclipse-che/theia-plugin-ext` extension which doesn't allow to send a message with `restart-workspace` action to parent window when Che runs in single-user mode.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/15367