### PR TITLE
Use CHE_API_INTERNAL instead of CHE_API_EXTERNAL.

### DIFF
--- a/extensions/eclipse-che-theia-terminal/src/node/workspace-service-impl.ts
+++ b/extensions/eclipse-che-theia-terminal/src/node/workspace-service-impl.ts
@@ -104,7 +104,7 @@ export class CHEWorkspaceServiceImpl implements CHEWorkspaceService {
     }
 
     private getWsMasterApiEndPoint(): string | undefined {
-        return process.env['CHE_API_EXTERNAL'];
+        return process.env['CHE_API_INTERNAL'];
     }
 
     private getMachineToken(): string | undefined {


### PR DESCRIPTION
### What does this PR do?

Uses CHE_API_INTERNAL instead of CHE_API_EXTERNAL.
As che-theia backend is behind of Ingress, it can be connected to the Che API server with the K8s DNS name.

### What issues does this PR fix or reference?

None.
