### PR TITLE
Use correct binary for packaging plugin into zip container

### DIFF
--- a/plugins/containers-plugin/package.json
+++ b/plugins/containers-plugin/package.json
@@ -45,7 +45,7 @@
     "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
     "lint:fix": "tslint -c ../../configs/tslint.json --fix --project .",
     "compile": "tsc",
-    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia:plugin pack",
+    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack",
     "watch": "tsc -w"
   },
   "engines": {

--- a/plugins/ports-plugin/package.json
+++ b/plugins/ports-plugin/package.json
@@ -29,7 +29,7 @@
     "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
     "lint:fix": "tslint -c ../../configs/tslint.json --fix --project .",
     "compile": "tsc",
-    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia:plugin pack",
+    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack",
     "watch": "tsc -w",
     "test": "jest",
     "test-watch": "jest --watchAll"

--- a/plugins/ssh-plugin/package.json
+++ b/plugins/ssh-plugin/package.json
@@ -45,7 +45,7 @@
         "compile": "tsc",
         "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
         "lint:fix": "tslint -c ../../configs/tslint.json --fix --project .",
-        "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia:plugin pack"
+        "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack"
       },
       "engines": {
         "theiaPlugin": "next"

--- a/plugins/task-plugin/package.json
+++ b/plugins/task-plugin/package.json
@@ -54,7 +54,7 @@
     "compile": "tsc",
     "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
     "lint:fix": "tslint -c ../../configs/tslint.json --fix --project .",
-    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia:plugin pack"
+    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack"
   },
   "engines": {
     "theiaPlugin": "next"

--- a/plugins/welcome-plugin/package.json
+++ b/plugins/welcome-plugin/package.json
@@ -42,7 +42,7 @@
     "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
     "lint:fix": "tslint -c ../../configs/tslint.json --fix --project .",
     "compile": "tsc",
-    "build": "yarn lint:fix && concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia:plugin pack",
+    "build": "yarn lint:fix && concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack",
     "watch": "tsc -w"
   },
   "engines": {

--- a/plugins/workspace-plugin/package.json
+++ b/plugins/workspace-plugin/package.json
@@ -27,7 +27,7 @@
         "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
         "lint:fix": "tslint -c ../../configs/tslint.json --fix --project .",
         "compile": "tsc",
-        "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia:plugin pack",
+        "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack",
         "watch": "tsc -w",
         "test": "jest",
         "test:watch": "jest --watchAll"


### PR DESCRIPTION
### What does this PR do?
This changes proposal fix build of che-theia after upgrade yarn to version 1.19.1

The problem was occurred when user upgrades yarn to version 1.19.1. Plugins are using `@theia/plugin-packager` as a dependency to pack themselves to zip container. On 1.19.0 there isn't any problem, because `@theia/plugin-packager` dependency provides `theia:plugin` and `theia-plugin` binaries. But on 1.19.1 there is only `theia-plugin` binary.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15552
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A
