### PR TITLE
Use theia-plugin instead of theia:plugin.

### DIFF
--- a/plugins/containers-plugin/package.json
+++ b/plugins/containers-plugin/package.json
@@ -45,7 +45,7 @@
     "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
     "lint:fix": "tslint -c ../../configs/tslint.json --fix --project .",
     "compile": "tsc",
-    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia:plugin pack",
+    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack",
     "watch": "tsc -w"
   },
   "engines": {

--- a/plugins/ports-plugin/package.json
+++ b/plugins/ports-plugin/package.json
@@ -29,7 +29,7 @@
     "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
     "lint:fix": "tslint -c ../../configs/tslint.json --fix --project .",
     "compile": "tsc",
-    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia:plugin pack",
+    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack",
     "watch": "tsc -w",
     "test": "jest",
     "test-watch": "jest --watchAll"

--- a/plugins/ssh-plugin/package.json
+++ b/plugins/ssh-plugin/package.json
@@ -45,7 +45,7 @@
         "compile": "tsc",
         "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
         "lint:fix": "tslint -c ../../configs/tslint.json --fix --project .",
-        "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia:plugin pack"
+        "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack"
       },
       "engines": {
         "theiaPlugin": "next"

--- a/plugins/task-plugin/package.json
+++ b/plugins/task-plugin/package.json
@@ -54,7 +54,7 @@
     "compile": "tsc",
     "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
     "lint:fix": "tslint -c ../../configs/tslint.json --fix --project .",
-    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia:plugin pack"
+    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack"
   },
   "engines": {
     "theiaPlugin": "next"

--- a/plugins/telemetry-plugin/package.json
+++ b/plugins/telemetry-plugin/package.json
@@ -30,7 +30,7 @@
         "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
         "lint:fix": "tslint -c ../../configs/tslint.json --fix --project .",
         "compile": "tsc",
-        "build": "yarn lint:fix && concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia:plugin pack",
+        "build": "yarn lint:fix && concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack",
         "watch": "tsc -w"
       },
       "engines": {

--- a/plugins/welcome-plugin/package.json
+++ b/plugins/welcome-plugin/package.json
@@ -42,7 +42,7 @@
     "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
     "lint:fix": "tslint -c ../../configs/tslint.json --fix --project .",
     "compile": "tsc",
-    "build": "yarn lint:fix && concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia:plugin pack",
+    "build": "yarn lint:fix && concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack",
     "watch": "tsc -w"
   },
   "engines": {

--- a/plugins/workspace-plugin/package.json
+++ b/plugins/workspace-plugin/package.json
@@ -27,7 +27,7 @@
         "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
         "lint:fix": "tslint -c ../../configs/tslint.json --fix --project .",
         "compile": "tsc",
-        "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia:plugin pack",
+        "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack",
         "watch": "tsc -w",
         "test": "jest",
         "test:watch": "jest --watchAll"


### PR DESCRIPTION

### What does this PR do?

Uses `theia-plugin` instead of `theia:plugin` in each `compile` phase.

### What issues does this PR fix or reference?

Will fix eclipse/che#14145 eclipse/che#15552.
