### PR TITLE
Add missing dependency for async-limiter to fix ci-build

### DIFF
--- a/generator/src/templates/assembly-package.mst
+++ b/generator/src/templates/assembly-package.mst
@@ -69,6 +69,7 @@
   },
   "devDependencies": {
     "@theia/cli": "^{{ version }}",
-    "html-webpack-plugin": "^3.2.0"
+    "html-webpack-plugin": "^3.2.0",
+    "async-limiter": "^2.0.0"
   }
 }


### PR DESCRIPTION
### What does this PR do?
This changes proposal adds missing library `async-limiter` to fix ci-build PR task. This is a temporary solution to have successful ci-build in each PR.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15695


<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
