### PR TITLE
Apply GitHub authentication plugin

### DIFF
--- a/che-theia-init-sources.yml
+++ b/che-theia-init-sources.yml
@@ -20,4 +20,5 @@ sources:
     - plugins/welcome-plugin
     - plugins/ssh-plugin
     - plugins/telemetry-plugin
+    - plugins/github-auth-plugin
   checkoutTo: master

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -46,10 +46,6 @@ export interface CheFactoryMain {
 export interface CheDevfile {
 }
 
-export interface CheGithub {
-    uploadPublicSshKey(publicKey: string): Promise<void>;
-}
-
 export interface CheDevfileMain {
     $createWorkspace(devfilePath: string): Promise<void>;
 }
@@ -65,8 +61,14 @@ export interface CheSshMain {
     $deleteKey(service: string, name: string): Promise<void>;
 }
 
+export interface CheGithub {
+    uploadPublicSshKey(publicKey: string): Promise<void>;
+    getToken(): Promise<string>;
+}
+
 export interface CheGithubMain {
     $uploadPublicSshKey(publicKey: string): Promise<void>;
+    $getToken(): Promise<string>;
 }
 
 /**
@@ -429,6 +431,7 @@ export interface CheApiService {
 
     getFactoryById(factoryId: string): Promise<cheApi.factory.Factory>;
 
+    getUserId(): Promise<string>;
     getUserPreferences(): Promise<Preferences>;
     getUserPreferences(filter: string | undefined): Promise<Preferences>;
     updateUserPreferences(update: Preferences): Promise<Preferences>;
@@ -444,6 +447,7 @@ export interface CheApiService {
     getAllSshKey(service: string): Promise<cheApi.ssh.SshPair[]>;
     submitTelemetryEvent(id: string, ownerId: string, ip: string, agent: string, resolution: string, properties: [string, string][]): Promise<void>;
     submitTelemetryActivity(): Promise<void>;
+    getOAuthToken(oAuthProvider: string): Promise<string | undefined>;
 }
 
 export const CHE_TASK_SERVICE_PATH = '/che-task-service';

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-api-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-api-service.ts
@@ -32,6 +32,12 @@ export class CheApiServiceImpl implements CheApiService {
         return process.env.CHE_API_INTERNAL;
     }
 
+    async getUserId(): Promise<string> {
+        const cheApiClient = await this.getCheApiClient();
+        const user = await cheApiClient.getCurrentUser();
+        return user.id;
+    }
+
     async getUserPreferences(filter?: string): Promise<Preferences> {
         const cheApiClient = await this.getCheApiClient();
         return cheApiClient.getUserPreferences(filter);
@@ -279,6 +285,15 @@ export class CheApiServiceImpl implements CheApiService {
         } catch (e) {
             console.error(e);
             throw new Error(e);
+        }
+    }
+
+    async getOAuthToken(oAuthProvider: string): Promise<string | undefined> {
+        const cheApiClient = await this.getCheApiClient();
+        try {
+            return await cheApiClient.getOAuthToken(oAuthProvider);
+        } catch (e) {
+            return undefined;
         }
     }
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
@@ -116,6 +116,9 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
         const github: typeof che.github = {
             uploadPublicSshKey(publicKey: string): Promise<void> {
                 return cheGithubImpl.uploadPublicSshKey(publicKey);
+            },
+            getToken(): Promise<string> {
+                return cheGithubImpl.getToken();
             }
         };
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-github.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-github.ts
@@ -22,4 +22,8 @@ export class CheGithubImpl implements CheGithub {
     uploadPublicSshKey(publicKey: string): Promise<void> {
         return this.githubMain.$uploadPublicSshKey(publicKey);
     }
+
+    getToken(): Promise<string> {
+        return this.githubMain.$getToken();
+    }
 }

--- a/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
+++ b/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
@@ -45,6 +45,7 @@ declare module '@eclipse-che/plugin' {
 
     export namespace github {
         export function uploadPublicSshKey(publicKey: string): Promise<void>;
+        export function getToken(): Promise<string>;
     }
 
     export namespace ssh {

--- a/plugins/github-auth-plugin/.gitignore
+++ b/plugins/github-auth-plugin/.gitignore
@@ -1,0 +1,3 @@
+lib/
+node_modules/
+*.theia

--- a/plugins/github-auth-plugin/README.md
+++ b/plugins/github-auth-plugin/README.md
@@ -1,0 +1,5 @@
+# Theia - Telemetry Plug-in
+
+## License
+
+[EPL-2.0](http://www.eclipse.org/legal/epl-2.0)

--- a/plugins/github-auth-plugin/README.md
+++ b/plugins/github-auth-plugin/README.md
@@ -1,4 +1,8 @@
-# Theia - Telemetry Plug-in
+# Theia - vscode Github pull-request plugin authenticator
+
+The plugin calls Che oAuth API service to get the GitHub token.
+Then it injects it to the user preferences. When the browser page is refreshed,
+the vscode GitHub PR plugin fetches the token and cleans the token from the preferences file.
 
 ## License
 

--- a/plugins/github-auth-plugin/package.json
+++ b/plugins/github-auth-plugin/package.json
@@ -5,7 +5,7 @@
       "keywords": [
         "theia-plugin"
       ],
-      "description": "Manage Eclipse Che Telemetry Plugin",
+      "description": "Authenticates the vscode Github pull-request plugin",
       "license": "EPL-2.0",
 
       "files": [

--- a/plugins/github-auth-plugin/package.json
+++ b/plugins/github-auth-plugin/package.json
@@ -1,0 +1,42 @@
+{
+      "name": "@eclipse-che/github-auth-plugin",
+      "version": "0.0.1",
+      "publisher": "Eclipse Che",
+      "keywords": [
+        "theia-plugin"
+      ],
+      "description": "Manage Eclipse Che Telemetry Plugin",
+      "license": "EPL-2.0",
+
+      "files": [
+        "src"
+      ],
+      "activationEvents": [
+        "*"
+      ],
+      "devDependencies": {
+        "@theia/plugin": "next",
+        "@theia/plugin-packager": "latest",
+        "@eclipse-che/plugin": "0.0.1",
+        "rimraf": "2.6.2",
+        "typescript-formatter": "7.2.2",
+        "typescript": "2.9.2",
+        "ts-loader": "^4.1.0"
+      },
+      "scripts": {
+        "prepare": "yarn run clean && yarn run build",
+        "clean": "rimraf lib",
+        "format": "tsfmt -r --useTsfmt ../../configs/tsfmt.json",
+        "lint": "tslint -c ../../configs/tslint.json --project tsconfig.json",
+        "lint:fix": "tslint -c ../../configs/tslint.json --fix --project .",
+        "compile": "tsc",
+        "build": "yarn lint:fix && concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack",
+        "watch": "tsc -w"
+      },
+      "engines": {
+        "theiaPlugin": "next"
+      },
+      "theiaPlugin": {
+          "backend": "lib/github-auth-plugin.js"
+      }
+}

--- a/plugins/github-auth-plugin/src/github-auth-plugin.ts
+++ b/plugins/github-auth-plugin/src/github-auth-plugin.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2019 Red Hat, Inc.
+ * Copyright (c) 2020 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/plugins/github-auth-plugin/src/github-auth-plugin.ts
+++ b/plugins/github-auth-plugin/src/github-auth-plugin.ts
@@ -24,8 +24,8 @@ export function start(context: theia.PluginContext) {
                 host: 'github.com',
                 token
             }], theia.ConfigurationTarget.Global);
-            theia.window.showWarningMessage('GitHub token has been set to preferences. Refresh the page to' +
-                'reinitialise the vscode GitHub pull-request plugin with the token');
+            theia.window.showWarningMessage('GitHub token has been set to preferences. ' +
+                'Refresh the page to reinitialise the vscode GitHub pull-request plugin with the token');
         }));
     }
 }

--- a/plugins/github-auth-plugin/src/github-auth-plugin.ts
+++ b/plugins/github-auth-plugin/src/github-auth-plugin.ts
@@ -1,0 +1,35 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import * as theia from '@theia/plugin';
+import * as che from '@eclipse-che/plugin';
+
+export function start(context: theia.PluginContext) {
+    if (theia.plugins.getPlugin('github.vscode-pull-request-github')) {
+        const informationMessageTestCommand = {
+            id: 'github-plugin-authenticate',
+            label: 'GitHub authenticate'
+        };
+        context.subscriptions.push(theia.commands.registerCommand(informationMessageTestCommand, async () => {
+            const token = await che.github.getToken();
+            const conf = await theia.workspace.getConfiguration();
+            await conf.update('githubPullRequests.hosts', [{
+                host: 'github.com',
+                token
+            }], theia.ConfigurationTarget.Global);
+            theia.window.showWarningMessage('GitHub token has been set to preferences. Refresh the page to' +
+                'reinitialise the vscode GitHub pull-request plugin with the token');
+        }));
+    }
+}
+
+export function stop() {
+
+}

--- a/plugins/github-auth-plugin/src/github-auth-plugin.ts
+++ b/plugins/github-auth-plugin/src/github-auth-plugin.ts
@@ -13,11 +13,11 @@ import * as che from '@eclipse-che/plugin';
 
 export function start(context: theia.PluginContext) {
     if (theia.plugins.getPlugin('github.vscode-pull-request-github')) {
-        const informationMessageTestCommand = {
+        const command = {
             id: 'github-plugin-authenticate',
             label: 'GitHub authenticate'
         };
-        context.subscriptions.push(theia.commands.registerCommand(informationMessageTestCommand, async () => {
+        context.subscriptions.push(theia.commands.registerCommand(command, async () => {
             const token = await che.github.getToken();
             const conf = await theia.workspace.getConfiguration();
             await conf.update('githubPullRequests.hosts', [{

--- a/plugins/github-auth-plugin/tsconfig.json
+++ b/plugins/github-auth-plugin/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "extends": "../../configs/base.tsconfig",
+    "compilerOptions": {
+        "skipLibCheck": true,
+        "lib": [
+            "es6",
+            "webworker"
+        ],
+        "rootDir": "src",
+        "outDir": "lib"
+    },
+    "include": [
+        "src"
+    ]
+}

--- a/plugins/github-auth-plugin/tsfmt.json
+++ b/plugins/github-auth-plugin/tsfmt.json
@@ -1,0 +1,18 @@
+{
+    "baseIndentSize": 0,
+    "newLineCharacter": "\n",
+    "indentSize": 4,
+    "tabSize": 4,
+    "indentStyle": 4,
+    "convertTabsToSpaces": true,
+    "insertSpaceAfterCommaDelimiter": true,
+    "insertSpaceAfterSemicolonInForStatements": true,
+    "insertSpaceBeforeAndAfterBinaryOperators": true,
+    "insertSpaceAfterKeywordsInControlFlowStatements": true,
+    "insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+    "insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
+    "insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": false,
+    "insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": false,
+    "placeOpenBraceOnNewLineForFunctions": false,
+    "placeOpenBraceOnNewLineForControlBlocks": false
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,9 +43,9 @@
     "@eclipse-che/api" latest
 
 "@eclipse-che/workspace-client@latest":
-  version "0.0.1-1574171760"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1574171760.tgz#e4066030fe4cb35f21a82e173e37633d37c76520"
-  integrity sha512-lCnrrb9jKkxbO9QSmFERHvDxrN+8j1X/3RypESu7n7nrG53ubEqnnquTbU+vEgrMHyg1x0ctLRiUBQarM8dslg==
+  version "0.0.1-1579077578"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1579077578.tgz#0fc322b536eb46bf271effc3f00a0435038b5966"
+  integrity sha512-j3hPUaMcld6cw0wuqQd/EjjUAkkq7J5iri8MCJYJf2eSylLnjYRabNfnfVS4REgj3b02VXLx3kuDGmNPLacSEw==
   dependencies:
     "@eclipse-che/api" "^7.0.0-beta-4.0"
     axios "0.19.0"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add a plugin that authenticates [vscode GitHub PR plugin](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) launched in Che-Theia
![ezgif-2-e8952916c88e](https://user-images.githubusercontent.com/7668752/72621490-060b7a00-394a-11ea-8a75-ba3b4008d7b9.gif)

The plugin calls Che oAuth API service to get the GitHub token. Then it injects it to the user preferences. When the browser page is refreshed the vscode GitHub PR plugin fetches the token and cleans the token from the preferences file.

This works only in single user Che. When https://github.com/eclipse/che/issues/15672 is applied the token could be fetched in the multi-user.

**What can be improved:**
The login actions that provided by the native vscode GitHub plugin are still redirect to the vscode authentication service. To override them we need:
1.  Apply `Urihandler` plugin API method: https://github.com/eclipse-theia/theia/issues/5119. It is used by the vscode GitHub PR plugin to handle the callback request from authentication server.
2. Authentication server url is hard-coded in the vscode GitHub PR plugin: https://github.com/microsoft/vscode-pull-request-github/blob/ddaa2bcd06ebc931e075cc9cab5a83f683e93e83/src/authentication/githubServer.ts#L16-L17
https://github.com/microsoft/vscode-pull-request-github/blob/ddaa2bcd06ebc931e075cc9cab5a83f683e93e83/src/authentication/githubServer.ts#L177-L179
so we need to propose a PR to the [vscode GitHub PR plugin](https://github.com/Microsoft/vscode-pull-request-github) repository that allows to override the authentication urls.

When the steps above are done we can setup the vscode GitHub PR plugin to use Che oAuth service for authentication and get rid of this authentication plugin.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14217

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
https://github.com/eclipse/che-docs/pull/1055