### PR TITLE
Serialize webview in welcome plugin to be able to restore it after page reload

### DIFF
--- a/extensions/eclipse-che-theia-user-preferences/package.json
+++ b/extensions/eclipse-che-theia-user-preferences/package.json
@@ -13,6 +13,7 @@
   ],
   "dependencies": {
     "@theia/core": "next",
+    "@theia/workspace": "next",
     "nsfw": "^1.2.2",
     "@theia/preferences": "next",
     "@eclipse-che/theia-plugin-ext": "^0.0.1"

--- a/extensions/eclipse-che-theia-user-preferences/src/browser/che-storage-service.ts
+++ b/extensions/eclipse-che-theia-user-preferences/src/browser/che-storage-service.ts
@@ -7,10 +7,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { injectable, inject } from 'inversify';
+import { injectable, inject, postConstruct } from 'inversify';
 import { StorageService } from '@theia/core/lib/browser';
 import { StorageServer } from '../common/storage-server';
 import { ILogger } from '@theia/core/lib/common/logger';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 
 @injectable()
 export class CheStorageService implements StorageService {
@@ -18,14 +19,26 @@ export class CheStorageService implements StorageService {
     @inject(StorageServer)
     private storageServer: StorageServer;
 
+    @inject(WorkspaceService)
+    protected workspaceService: WorkspaceService;
+
     @inject(ILogger)
     protected logger: ILogger;
 
-    setData<T>(key: string, data?: T): Promise<void> {
+    private initialized: Promise<void>;
+
+    @postConstruct()
+    protected init(): void {
+        this.initialized = this.workspaceService.roots.then(() => {});
+    }
+
+    async setData<T>(key: string, data?: T): Promise<void> {
+        await this.initialized;
         return this.storageServer.setData(key, JSON.stringify(data));
     }
 
     async getData<T>(key: string, defaultValue?: T): Promise<T | undefined> {
+        await this.initialized;
         try {
             const data = await this.storageServer.getData(key);
             if (data === undefined) {

--- a/plugins/welcome-plugin/src/welcome-page.ts
+++ b/plugins/welcome-plugin/src/welcome-page.ts
@@ -16,9 +16,6 @@ import * as che from '@eclipse-che/plugin';
  */
 export class WelcomePage {
 
-    constructor(readonly pluginContext: theia.PluginContext) {
-    }
-
     /**
      * Returns the Logo URI for usinf as an image in webview frame.
      */
@@ -37,7 +34,7 @@ export class WelcomePage {
         return theia.Uri.file(logo).with({ scheme: 'theia-resource' });
     }
 
-    protected renderHeader(context: theia.PluginContext): string {
+    protected renderHeader(): string {
         const logoDark = typeof che.product.logo === 'object' ? this.getLogoUri(che.product.logo.dark) : this.getLogoUri(che.product.logo);
         const logoLight = typeof che.product.logo === 'object' ? this.getLogoUri(che.product.logo.light) : this.getLogoUri(che.product.logo);
 
@@ -173,9 +170,9 @@ export class WelcomePage {
         </div>`;
     }
 
-    public async render(context: theia.PluginContext) {
+    public async render() {
         return `<div class='che-welcome-container'>
-            ${this.renderHeader(context)}
+            ${this.renderHeader()}
             <div class='flex-grid'>
                 <div class='col'>
                     ${await this.renderStart()}


### PR DESCRIPTION
### What does this PR do?
This changes proposal add several fixes to the welcome page plugin. The main problem was related to the restoring opened editors after page reloading. Welcome page represents as a _WebView_ panel, that should be restored after plugin starting phase. But at workspace opening phase the plugin tried to open _WebView_ that is not consistent with the main bootstrap flow. Here is some fixes that performed in this PR:

- Add ability to serialize welcome page _WebView_ to be able to restore it.

- Reduced delay **from 1 to 0.1 second** when welcome page should be opened after workspace is started.

- Changed mechanism of restoring welcome page. **Now it opens in case when there isn't any opened other editors and there is enabled option in Theia Preferences.** 

**_Note that application state is storing after 10 second when any operation with any widget was performed._**

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15317
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
