### PR TITLE
Add the required env vars to restore CDN Support

### DIFF
--- a/build.include
+++ b/build.include
@@ -66,8 +66,6 @@ buildImages() {
     GITHUB_TOKEN_ARG="GITHUB_TOKEN=${GITHUB_TOKEN:-}"
     echo "Building image in ${image_dir}"
      if [ "$image_dir" == "dockerfiles/theia" ]; then
-       export CDN_PREFIX=https://static.developers.redhat.com/che/theia_artifacts/
-       export MONACO_CDN_PREFIX=https://cdn.jsdelivr.net/npm/
        bash $(pwd)/$image_dir/build.sh --build-args:${GITHUB_TOKEN_ARG},THEIA_VERSION=${THEIA_VERSION} --tag:${IMAGE_TAG} --branch:${THEIA_BRANCH} --git-ref:${THEIA_GIT_REFS} ${FILTERED_ARGS}
        elif [ "$image_dir" == "dockerfiles/theia-dev" ]; then
        bash $(pwd)/$image_dir/build.sh --build-arg:${GITHUB_TOKEN_ARG} --tag:${IMAGE_TAG} ${FILTERED_ARGS}

--- a/build.include
+++ b/build.include
@@ -66,6 +66,8 @@ buildImages() {
     GITHUB_TOKEN_ARG="GITHUB_TOKEN=${GITHUB_TOKEN:-}"
     echo "Building image in ${image_dir}"
      if [ "$image_dir" == "dockerfiles/theia" ]; then
+       export CDN_PREFIX=https://static.developers.redhat.com/che/theia_artifacts/
+       export MONACO_CDN_PREFIX=https://cdn.jsdelivr.net/npm/
        bash $(pwd)/$image_dir/build.sh --build-args:${GITHUB_TOKEN_ARG},THEIA_VERSION=${THEIA_VERSION} --tag:${IMAGE_TAG} --branch:${THEIA_BRANCH} --git-ref:${THEIA_GIT_REFS} ${FILTERED_ARGS}
        elif [ "$image_dir" == "dockerfiles/theia-dev" ]; then
        bash $(pwd)/$image_dir/build.sh --build-arg:${GITHUB_TOKEN_ARG} --tag:${IMAGE_TAG} ${FILTERED_ARGS}

--- a/cico_build_master.sh
+++ b/cico_build_master.sh
@@ -22,6 +22,9 @@ set -e
 
 parse "$@"
 
+export CDN_PREFIX=https://static.developers.redhat.com/che/theia_artifacts/
+export MONACO_CDN_PREFIX=https://cdn.jsdelivr.net/npm/
+
 install_deps
 load_jenkins_vars
 buildImages

--- a/cico_build_release.sh
+++ b/cico_build_release.sh
@@ -9,4 +9,7 @@
 #
 # See: https://sipb.mit.edu/doc/safe-shell/
 
+export CDN_PREFIX=https://static.developers.redhat.com/che/theia_artifacts/
+export MONACO_CDN_PREFIX=https://cdn.jsdelivr.net/npm/
+
 /bin/bash ./cico_build_master.sh


### PR DESCRIPTION
### What does this PR do?

This PR adds 2 required environment variables to the CI builds in order to restore the CDN support in `che-theia` image.
This support had been broken when migrating the CI to centos-ci. 

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/15791
