### PR TITLE
Also fetch the CDN Auth variable from Jenkins env

### DIFF
--- a/cico_common.sh
+++ b/cico_common.sh
@@ -14,6 +14,7 @@
 function load_jenkins_vars() {
   if [ -e "jenkins-env.json" ]; then
     eval "$(./env-toolkit load -f jenkins-env.json \
+            AKAMAI_CHE_AUTH \
             CHE_BOT_GITHUB_TOKEN \
             QUAY_ECLIPSE_CHE_USERNAME \
             QUAY_ECLIPSE_CHE_PASSWORD \


### PR DESCRIPTION
### What does this PR do?

This PR allows fetching a new environment variable, in `cico` CI build, to retrieve the Akamai auth environment variable required to push che-theia artifacts to the CDN.

### What issues does this PR fix or reference?

This is a followup of PR https://github.com/eclipse/che-theia/pull/607
