### PR TITLE
Do not expose Jenkins env vars in console output

### DIFF
--- a/cico_build_master.sh
+++ b/cico_build_master.sh
@@ -26,6 +26,8 @@ export CDN_PREFIX=https://static.developers.redhat.com/che/theia_artifacts/
 export MONACO_CDN_PREFIX=https://cdn.jsdelivr.net/npm/
 
 install_deps
+set +x
 load_jenkins_vars
+set -x
 buildImages
 publishImagesOnQuay


### PR DESCRIPTION
### What does this PR do?

Avoid outputing (through the use of `set -x`) the environment variables that are injected by Jenkins.
This is important if they contain secrets or tokens.

### What issues does this PR fix or reference?

This is a followup of PR https://github.com/eclipse/che-theia/pull/607

