### PR TITLE
Restore use of Akamai auth as a variable

### DIFF
--- a/dockerfiles/theia/push-cdn-files-to-akamai.sh
+++ b/dockerfiles/theia/push-cdn-files-to-akamai.sh
@@ -17,7 +17,9 @@ fi
 echo "Pushing CDN files to the Akamai directory..."
 cd "${base_dir}"
 
-cat ${AKAMAI_CHE_AUTH} > akamai.conf
+cat > akamai.conf << EOF
+${AKAMAI_CHE_AUTH}
+EOF
 
 for file in $(find theia_artifacts -type f -print | grep -v 'cdn.json'); do
   echo "   Pushing $file" 


### PR DESCRIPTION
### What does this PR do?

This PR restores the use of the AKAMAI_CHE_AUTH as being a multi-line env variable, instead of being a file that contains the information

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/15791