### PR TITLE
Add `jq` as a build dependency

### DIFF
--- a/cico_common.sh
+++ b/cico_common.sh
@@ -41,7 +41,7 @@ function install_deps() {
   curl -sL https://rpm.nodesource.com/setup_10.x | bash -
   yum-config-manager --add-repo https://dl.yarnpkg.com/rpm/yarn.repo
 
-  yum install -y docker-ce git nodejs yarn gcc-c++ make
+  yum install -y docker-ce git nodejs yarn gcc-c++ make jq
 
   service docker start
   echo 'CICO: Dependencies installed'


### PR DESCRIPTION
### What does this PR do?

This is required to allow pushing CDN files to the CDN store.

### What issues does this PR fix or reference?

This PR is a follow up of PR #607