### PR TITLE
Add the `epel-release` repo for `jq`

### DIFF
--- a/cico_common.sh
+++ b/cico_common.sh
@@ -41,6 +41,7 @@ function install_deps() {
   curl -sL https://rpm.nodesource.com/setup_10.x | bash -
   yum-config-manager --add-repo https://dl.yarnpkg.com/rpm/yarn.repo
 
+  yum install -y epel-release
   yum install -y docker-ce git nodejs yarn gcc-c++ make jq
 
   service docker start


### PR DESCRIPTION
### What does this PR do?

This PR adds the `epel-release` repo in order to be able to install `jq` as a build dependency

### What issues does this PR fix or reference?

This PR is a followup of PR https://github.com/eclipse/che-theia/pull/614