### PR TITLE
Add `jq` as a build dependency

### DIFF
--- a/cico_common.sh
+++ b/cico_common.sh
@@ -41,8 +41,9 @@ function install_deps() {
   curl -sL https://rpm.nodesource.com/setup_10.x | bash -
   yum-config-manager --add-repo https://dl.yarnpkg.com/rpm/yarn.repo
 
-  yum install -y docker-ce git nodejs yarn gcc-c++ make
-
+  yum install -y epel-release
+  yum install -y docker-ce git nodejs yarn gcc-c++ make jq
+  
   service docker start
   echo 'CICO: Dependencies installed'
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds `jq` as a build dependency
This is required to enable pushing static artifacts to the CDN

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/15791