### PR TITLE
Restore publishing npm modules on each master build

### DIFF
--- a/cico_build_master.sh
+++ b/cico_build_master.sh
@@ -31,3 +31,8 @@ load_jenkins_vars
 set -x
 buildImages
 publishImagesOnQuay
+
+set +x
+#Release npm packages
+printf "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}\n" >> ~/.npmrc
+yarn run publish:next

--- a/cico_common.sh
+++ b/cico_common.sh
@@ -18,6 +18,7 @@ function load_jenkins_vars() {
             CHE_BOT_GITHUB_TOKEN \
             QUAY_ECLIPSE_CHE_USERNAME \
             QUAY_ECLIPSE_CHE_PASSWORD \
+            CHE_NPM_AUTH_TOKEN \
             JENKINS_URL \
             GIT_BRANCH \
             GIT_COMMIT \
@@ -28,6 +29,7 @@ function load_jenkins_vars() {
             ghprbPullId)"
     #export provided GH token
     export GITHUB_TOKEN=${CHE_BOT_GITHUB_TOKEN}
+    export NPM_AUTH_TOKEN=${CHE_NPM_AUTH_TOKEN}
   fi
 }
 


### PR DESCRIPTION
### What does this PR do?
During transition to ci.centos.org publishing of npm modules was lost.
This PR restore publishing.
