### PR TITLE
Fully fix the CDN support

### DIFF
--- a/dockerfiles/theia/build.sh
+++ b/dockerfiles/theia/build.sh
@@ -56,9 +56,11 @@ if [[ -z "$DOCKER_BUILD_TARGET" ]]; then
   "${base_dir}"/extract-for-cdn.sh "$IMAGE_NAME" "${base_dir}/theia_artifacts"
   LABEL_CONTENT=$(cat "${base_dir}"/theia_artifacts/cdn.json || true 2>/dev/null)
   if [ -n "${LABEL_CONTENT}" ]; then
-    BUILD_ARGS+="--label che-plugin.cdn.artifacts=$(echo ${LABEL_CONTENT} | sed 's/ //g') "
-    echo "Rebuilding with CDN label..."
-    build
+    echo "Adding the CDN label..."
+    docker build --label che-plugin.cdn.artifacts="$(echo ${LABEL_CONTENT} | sed 's/ //g')" -t "${IMAGE_NAME}-with-label" -<<EOF
+FROM ${IMAGE_NAME}
+EOF
+    docker tag "${IMAGE_NAME}-with-label" "${IMAGE_NAME}"
     "${base_dir}"/push-cdn-files-to-akamai.sh
   fi
 fi

--- a/generator/src/scripts/override-vs-loader.js
+++ b/generator/src/scripts/override-vs-loader.js
@@ -20,6 +20,9 @@ const fs = require('fs-extra');
             if (cdnJson.theia || cdnJson.monaco) {
                 await fs.rename('lib/vs/loader.js', 'lib/vs/original-loader.js');
                 await fs.copyFile('cdn/vs-loader.js', 'lib/vs/loader.js');
+                if (await fs.pathExists('lib/vs/loader.js.gz')) {
+                    await fs.rename('lib/vs/loader.js.gz', 'lib/vs/original-loader.js.gz');
+                }                
             }
         }
     } catch (e) {


### PR DESCRIPTION
# What does this PR do?

This PR finally fixes the remaining issues with the broken CDN support:
- During the build, the CDN process should rename the zip of the monaco vs loader. This is required to also fix the CDN support of static artifacts that are related to the Monaco editor 
- Fix an inconsistency between the docker image label and the content of the `cdn.json` file inside the image. This fix also avoids building the `che-theia` twice, which will reduce the build time. 

### What issues does this PR fix or reference?

eclipse/che#15791