### PR TITLE
Update preview:build script section after call che:theia init

### DIFF
--- a/generator/src/init.ts
+++ b/generator/src/init.ts
@@ -72,4 +72,17 @@ export class Init {
         return mustache.render(template, tags).replace(/&#x2F;/g, '/');
     }
 
+    async updadeBuildConfiguration(): Promise<void> {
+        const theiaPackagePath = path.join(this.rootFolder, 'package.json');
+        const theiaPackage = await readPkg(theiaPackagePath);
+        const scriptsConfiguration = theiaPackage.scripts;
+
+        if (scriptsConfiguration && scriptsConfiguration['prepare:build']) {
+            scriptsConfiguration['prepare:build'] = 'yarn build && run lint && lerna run build';
+        }
+
+        const json = JSON.stringify(theiaPackage, undefined, 2);
+        await fs.writeFile(theiaPackagePath, json);
+    }
+
 }

--- a/generator/src/yargs.ts
+++ b/generator/src/yargs.ts
@@ -39,6 +39,7 @@ const commandArgs = yargs
                 const init = new Init(process.cwd(), assemblyFolder, cheFolder, pluginsFolder);
                 const version = await init.getCurrentVersion();
                 await init.generate();
+                await init.updadeBuildConfiguration();
                 const extensions = new InitSources(process.cwd(), packagesFolder, pluginsFolder, cheFolder, assemblyFolder, version);
                 await extensions.initSourceLocationAliases(args.alias);
                 await extensions.readConfigurationAndGenerate(args.config, args.dev);


### PR DESCRIPTION
### What does this PR do?
This changes proposal updates `prepare:build` section in `theia/package.json` after `che:theia init` command call from:
```
"prepare:build": "yarn build && run lint && run build \"@theia/example-*\" --stream --parallel",
```

to:
```
"prepare:build": "yarn build && run lint && lerna run build",
```

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15932
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
