### PR TITLE
Add rsync tool to che-theia-dev container

### DIFF
--- a/dockerfiles/theia-dev/docker/alpine/install-dependencies.dockerfile
+++ b/dockerfiles/theia-dev/docker/alpine/install-dependencies.dockerfile
@@ -12,5 +12,6 @@ RUN apk add --update --no-cache \
     # bash shell
     bash \
     # some lib to compile 'native-keymap' npm mpdule
-    libx11-dev libxkbfile-dev
-    
+    libx11-dev libxkbfile-dev \
+    # synchronization tool
+    rsync

--- a/dockerfiles/theia-dev/docker/ubi8/install-dependencies.dockerfile
+++ b/dockerfiles/theia-dev/docker/ubi8/install-dependencies.dockerfile
@@ -1,3 +1,3 @@
 USER root
-RUN yum install -y curl make cmake gcc gcc-c++ python2 git git-core-doc openssh less bash tar gzip \
+RUN yum install -y curl make cmake gcc gcc-c++ python2 git git-core-doc openssh less bash tar gzip rsync \
     && yum -y clean all && rm -rf /var/cache/yum


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Rsync tool is needed to synchronize sources between /projects and /tmp directories to be able to build them in /tmp directory on che.openshift.io

