### PR TITLE
Make theia hostname configurable

### DIFF
--- a/dockerfiles/theia/src/entrypoint.sh
+++ b/dockerfiles/theia/src/entrypoint.sh
@@ -51,6 +51,10 @@ else
     fi
 fi
 
+if [ -z "$THEIA_HOST" ]; then
+  THEIA_HOST="0.0.0.0"
+fi
+
 # SITTERM / SIGINT
 responsible_shutdown() {
   echo ""
@@ -77,7 +81,7 @@ fi
 shopt -u nocasematch
 
 # run Che Theia
-node src-gen/backend/main.js /projects --hostname=127.0.0.1 --port=${THEIA_PORT} &
+node src-gen/backend/main.js /projects --hostname=${THEIA_HOST} --port=${THEIA_PORT} &
 
 PID=$!
 

--- a/dockerfiles/theia/src/entrypoint.sh
+++ b/dockerfiles/theia/src/entrypoint.sh
@@ -77,7 +77,7 @@ fi
 shopt -u nocasematch
 
 # run Che Theia
-node src-gen/backend/main.js /projects --hostname=0.0.0.0 --port=${THEIA_PORT} &
+node src-gen/backend/main.js /projects --hostname=127.0.0.1 --port=${THEIA_PORT} &
 
 PID=$!
 


### PR DESCRIPTION
### What does this PR do?

This makes Theia listen on configurable hostname. This is taken advantage of in https://github.com/eclipse/che-plugin-registry/pull/378 which makes the Theia endpoint listen on localhost only to enable truly secure deployment.

### What issues does this PR fix or reference?
eclipse/che#15651, eclipse/che#15890, https://github.com/eclipse/che-plugin-registry/pull/378
