### PR TITLE
Devfile for che-theia dogfooding on che.openshift.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Table of contents
  - [Devfiles](#devfiles)
  - [Contribute to Theia or Che-Theia extensions or built-in Che-Theia plugins](#contribute-to-theia-or-che-theia-extensions-or-built-in-che-theia-plugins)
    - [Just want to build the plugin and run with the existing Theia image](#just-want-to-build-the-plugin-and-run-with-the-existing-theia-image)
+ - [Che-Theia development on che.openshift.io](#che-theia-development-on-cheopenshiftio)
  - [How to develop Che Theia remote plugin mechanism](#how-to-develop-che-theia-remote-plugin-mechanism)
 
 ## Introduction
@@ -42,7 +43,6 @@ For the whole workflows, we will need a workspace with such containers:
 
 All containers have `/projects` folder mounted, which is shared among them.
 
-
 Developer workflow:
 
 1. Start the workspace with the devfile, it is cloning Theia and the che-theia plugins.
@@ -55,7 +55,6 @@ Developer workflow:
 
 The following devfile provides examples of commands to build and run che-theia with factory and containers plugins.
 
-
 ### Step 1: Start the workspace
 In this section we are going to start a new workspace to work on che-theia. The new workspace will have few projects cloned: `theia` and `che-theia`. It will also setup the containers and commands in the `My workspace` view. We will use these commands in the next steps.
 
@@ -65,8 +64,6 @@ The devfile could be started using `chectl`:
 chectl workspace:start -f https://raw.githubusercontent.com/eclipse/che-theia/master/devfiles/che-theia-all.devfile.yaml
 ```
 At workspace start, Che will clone Theia and Che-theia.
-
-
 
 ### Step 2: Decorate Theia with Che-theia extensions: che-theia init
 
@@ -144,6 +141,81 @@ If you do not have any changes on Theia or Che-theia extension, you could just b
 and run these plugins with the existing che-theia app:
 `run ... HOSTED che-theia + container-plugin` or `run ... HOSTED che-theia + workspace-plugin`
 
+## Che-Theia development on che.openshift.io
+
+There is a [devfile](https://github.com/eclipse/che-theia/blob/master/devfiles/hosted-che-dogfooding.devfile.yaml) to develop Che-Theia on [che.openshift.io](https://che.openshift.io)
+
+Projects directory which is a Persistent Volume on [che.openshift.io](https://che.openshift.io) is limited to 1 gigabyte. It's not enough to build Che-Theia.
+The main idea is to use `/tmp/theia` directotry. Amount for this directory is limited to 3 gigabytes, which is enough to build Che-Theia and run.
+In comparing with `/projects`, temporary directory is not persisted and is cleared on workspace stop.
+
+### Create workspace
+
+Use the badge to create a workspace using factory
+
+[![Try it on che.openshift.io](https://img.shields.io/static/v1?label=che&message=openshift.io&color=orange)](https://che.openshift.io/f?url=https://raw.githubusercontent.com/eclipse/che-theia/master/devfiles/hosted-che-dogfooding.devfile.yaml)
+
+### Step 1: Initialize Che-Theia in `/tmp/theia` directory
+
+To initialize Che-Theia in `/tmp/theia` directory use `'1. Init che:theia'` command. With rsync it's become possible to edit sources in `/projects` with the following synchronizing with `/tmp/theia`.
+
+```
+[che-dev]
+$ mkdir -p /tmp/theia/che/che-theia
+$ rsync -rtv /projects/theia/ /tmp/theia/
+$ rsync -rtv /projects/che-theia/ /tmp/theia/che/che-theia/
+$ cd /tmp/theia
+$ che:theia init --alias https://github.com/eclipse/che-theia=/tmp/theia/che/che-theia
+
+```
+
+### Step 2: Do changes and synchronize
+
+After changing sources of Theia or Che-Theia use `'2. Rsync sources'` to synchronize the sources with a mirror in `/tmp/theia`.
+
+```
+[che-dev]
+$ rsync -rtv --exclude='node_mobules' --exclude='package.json' --exclude='root-compilation.tsconfig.json' /projects/theia/ /tmp/theia/; \
+$ rsync -rtv --exclude='node_mobules' --exclude='package.json' /projects/che-theia/ /tmp/theia/che/che-theia/; \
+
+```
+
+### Step 3: Build
+
+The `'3. Build che:theia'` command builds Che-Theia. It runs `yarn` in `/tmp/theia` directory.
+
+```
+[che-dev]
+$ cd /tmp/theia
+$ yarn
+```
+
+### Step 4: Launch
+
+Before launching Che-Theia we have to prepare dedicated directories for plugins, default plugins and for projects, which is used as workspace directory.
+
+Use `'4.1. Prepare theia-* dirs'` command to prepare all the directories in one click. The command will run the following in theia-editor container.
+
+```
+[theia-ide]
+$ mkdir /projects/theia-default-plugins
+$ mkdir /projects/theia-plugins
+$ mkdir /projects/theia-projects-dir
+$ cd /default-theia-plugins
+$ cp * /projects/theia-default-plugins/
+```
+
+To launch Che-Theia run `'4.2. Launch'` command. It will set necessary variables and start Che-Theia in `che-dev` container.
+
+```
+[che-dev]
+$ cd /tmp/theia/examples/assembly
+$ export CHE_PROJECTS_ROOT="/projects/theia-projects-dir"
+$ export THEIA_DEFAULT_PLUGINS="local-dir:///projects/theia-default-plugins"
+$ export THEIA_PLUGINS="local-dir:///projects/theia-plugins"
+$ export THEIA_PLUGIN_ENDPOINT_DISCOVERY_PORT="2506"
+$ yarn theia start /projects/theia-projects-dir --hostname=0.0.0.0 --port=3010
+```
 
 ## How to develop Che Theia remote plugin mechanism
 

--- a/devfiles/hosted-che-dogfooding.devfile.yaml
+++ b/devfiles/hosted-che-dogfooding.devfile.yaml
@@ -1,0 +1,145 @@
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# See: https://sipb.mit.edu/doc/safe-shell/
+#
+#
+# A devfile to develpop che-theia projects on https://che.openshift.io.
+# For developers who work on Theia or Che-Theia extensions and plugins.
+
+apiVersion: 1.0.0
+
+metadata:
+  name: theia-dogfooding
+  
+projects:
+  - name: theia
+    source:
+      location: 'https://github.com/eclipse-theia/theia.git'
+      type: git
+      branch: master
+
+  - name: che-theia
+    source:
+      location: 'https://github.com/eclipse/che-theia.git'
+      type: git
+      branch: master
+
+components:
+  - id: eclipse/che-theia/latest
+    memoryLimit: 1500M
+    type: cheEditor
+    alias: theia-editor
+
+  - type: chePlugin
+    id: che-incubator/typescript/latest
+    memoryLimit: 2048M
+
+  - type: chePlugin
+    id: redhat/vscode-yaml/latest
+
+  - type: chePlugin
+    id: eclipse/che-machine-exec-plugin/latest
+
+  - type: dockerimage
+    image: 'quay.io/eclipse/che-theia-dev:next'
+    alias: che-dev
+    mountSources: true
+    endpoints:
+      - name: theia-dev-flow
+        port: 3010
+        attributes:
+          protocol: http
+          public: 'true'
+    memoryLimit: 3Gi
+    env:
+      - name: BUILD_PATH
+        value: /tmp
+
+commands:
+  - name: '1. Init che:theia'
+    actions:
+      - workdir: /projects
+        type: exec
+        command: |
+          if [ ! -d "$BUILD_PATH/theia/che/che-theia" ]; then \
+            echo -e '\e[32mInitializing Che-Theia...\e[0m'; \
+            mkdir -p $BUILD_PATH/theia/che/che-theia; \
+            rsync -rtv /projects/theia/ $BUILD_PATH/theia/; \
+            rsync -rtv /projects/che-theia/ $BUILD_PATH/theia/che/che-theia/; \
+            cd $BUILD_PATH/theia; \
+            che:theia init --alias https://github.com/eclipse/che-theia=$BUILD_PATH/theia/che/che-theia; \
+            echo -e '\e[32mDone\e[0m'; \
+          else \
+            echo 'Che-Theia is already initialized.'; \
+          fi
+        component: che-dev
+
+  - name: '2. Rsync sources'
+    actions:
+      - workdir: /projects
+        type: exec
+        command: |
+          if [ -d "$BUILD_PATH/theia/che/che-theia" ]; then \
+            echo -e '\e[32mRsyncing sources...\e[0m'; \
+            rsync -rtv --exclude='node_mobules' --exclude='package.json' --exclude='root-compilation.tsconfig.json' /projects/theia/ $BUILD_PATH/theia/; \
+            rsync -rtv --exclude='node_mobules' --exclude='package.json' /projects/che-theia/ $BUILD_PATH/theia/che/che-theia/; \
+            echo -e '\e[32mDone\e[0m'; \
+          else \
+            echo 'Che-Theia is not initialized.'; \
+            echo -e 'You need to run \e[32m1. Init che:theia\e[0m command the first.'; \
+          fi
+        component: che-dev
+
+  - name: '3. Build che:theia'
+    actions:
+      - workdir: /projects
+        type: exec
+        command: |
+          if [ -d "$BUILD_PATH/theia/examples/assembly" ]; then \
+            echo -e '\e[32mBuilding che-theia...\e[0m'; \
+            cd $BUILD_PATH/theia; \
+            yarn; \
+            echo -e '\e[32mDone\e[0m'; \
+          else \
+            echo 'Che-Theia is not initialized.'; \
+            echo -e 'You need to run \e[32m1. Init che:theia\e[0m command the first.'; \
+          fi
+        component: che-dev
+
+  - name: '4.1. Prepare theia-* dirs'
+    actions:
+      - workdir: /projects
+        type: exec
+        command: |
+          echo -e '\e[32mPreparing theia-* dirs...\e[0m'; \
+          mkdir -p /projects/theia-default-plugins; \
+          mkdir -p /projects/theia-plugins; \
+          mkdir -p /projects/theia-projects-dir; \
+          cp -u /default-theia-plugins/* /projects/theia-default-plugins/; \
+          echo -e '\e[32mDone\e[0m'
+        component: theia-editor
+
+  - name: '4.2. Launch'
+    actions:
+      - workdir: /projects
+        type: exec
+        command: |
+          if [ -d "$BUILD_PATH/theia/examples/assembly" ]; then \
+            cd $BUILD_PATH/theia/examples/assembly; \
+            echo -e '\e[32mLaunching che-theia...\e[0m'; \
+            export CHE_PROJECTS_ROOT="/projects/theia-projects-dir"; \
+            export THEIA_DEFAULT_PLUGINS="local-dir:///projects/theia-default-plugins"; \
+            export THEIA_PLUGINS="local-dir:///projects/theia-plugins"; \
+            export THEIA_PLUGIN_ENDPOINT_DISCOVERY_PORT="2506"; \
+            yarn theia start /projects/theia-projects-dir --hostname=0.0.0.0 --port=3010; \
+            echo -e '\e[32mDone\e[0m'; \
+          else \
+            echo 'Che-Theia is not build.'; \
+            echo -e 'You need to initialize Che-Theia by \e[32m1. Init che:theia\e[0m command and then build by \e[32m3. Build che:theia\e[0m.'; \
+          fi
+        component: che-dev


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Devfile to develop che-theia on che.openshift.io

Considering to the disk space limitation for /projects directory, it's only possible to build che-theia inside /tmp directory, which has 3GB.
Sources are persisted in /projects directory, but copied and then built in /tmp/theia. 

The devfile has commands to
- copy (rsync) sources to /tmp/theia
- initialize che-theia
- build
- launch

### What issues does this PR fix or reference?
No issue
