### PR TITLE
Configure application.confirmExit to always as default

### DIFF
--- a/generator/src/templates/assembly-package.mst
+++ b/generator/src/templates/assembly-package.mst
@@ -7,7 +7,8 @@
       "config": {
         "preferences": {
           "editor.autoSave": "on",
-          "git.defaultCloneDirectory": "/projects"
+          "git.defaultCloneDirectory": "/projects",
+          "application.confirmExit": "always"
         }
       }
     }


### PR DESCRIPTION
### What does this PR do?
Configure property `application.confirmExit` to `always` by default.

![image](https://user-images.githubusercontent.com/1968177/74922706-49895600-53d8-11ea-8330-ef0ed5422a3c.png)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13580
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
