### PR TITLE
feat(plugin-remote): Allow to see plug-ins running in other containers

### DIFF
--- a/dockerfiles/theia-endpoint-runtime-binary/Dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/Dockerfile
@@ -8,14 +8,17 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
+FROM quay.io/eclipse/che-custom-nodejs-deasync:10.19.0-latest as custom-nodejs
+
 FROM #{INCLUDE:docker/${BUILD_IMAGE_TARGET}/builder-from.dockerfile}
 
 WORKDIR /home/theia
 
 # Apply node libs installed globally to the PATH
 ENV PATH=${HOME}/.yarn/bin:${PATH}
-ENV NEXE_FLAGS="-t alpine-x64-10.16.0"
+ENV NEXE_FLAGS="--asset ${HOME}/pre-assembly-nodejs-static"
 
+COPY --from=custom-nodejs /pre-assembly-nodejs-static ${HOME}/pre-assembly-nodejs-static
 
 # setup extra stuff
 #{INCLUDE:docker/${BUILD_IMAGE_TARGET}/builder-setup.dockerfile}

--- a/extensions/eclipse-che-theia-plugin-remote/package.json
+++ b/extensions/eclipse-che-theia-plugin-remote/package.json
@@ -8,11 +8,13 @@
     "src"
   ],
   "dependencies": {
+    "@theia/core": "next",
     "@theia/plugin-ext": "next",
     "@theia/plugin-ext-vscode": "next",
-    "@theia/core": "next"
+    "deasync": "^0.1.19"
   },
   "devDependencies": {
+    "@types/deasync": "^0.1.0",
     "@types/escape-html": "0.0.20",
     "concurrently": "^3.5.0",
     "typescript-formatter": "7.2.2"
@@ -29,6 +31,7 @@
   },
   "theiaExtensions": [
     {
+      "frontend": "lib/browser/plugin-remote-frontend-module",
       "backend": "lib/node/plugin-remote-backend-module"
     }
   ]

--- a/extensions/eclipse-che-theia-plugin-remote/src/browser/browser-remote-hosted-plugin-support.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/browser/browser-remote-hosted-plugin-support.ts
@@ -1,0 +1,87 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { HostedPluginSupport, PluginHost, PluginContributions } from '@theia/plugin-ext/lib/hosted/browser/hosted-plugin';
+import { DisposableCollection } from '@theia/core';
+import { injectable } from 'inversify';
+import { RPCProtocol } from '@theia/plugin-ext/lib/common/rpc-protocol';
+import { MAIN_REMOTE_RPC_CONTEXT } from '../common/plugin-remote-rpc';
+import { PluginRemoteBrowserImpl } from '../node/plugin-remote-browser-impl';
+import { DeployedPlugin, PluginManagerExt } from '@theia/plugin-ext/lib/common';
+
+/**
+ * Extends Theia hosted plugin to notify all sidecar hosts the list of other plug-ins that can be found in other places.
+ */
+@injectable()
+export class BrowserRemoteHostedPluginSupport extends HostedPluginSupport {
+
+    private rpcs: Map<string, RPCProtocol>;
+    private contributionsByHost: Map<PluginHost, PluginContributions[]>;
+    private pluginRemoteBrowser: PluginRemoteBrowserImpl;
+    private initializedPlugins: Promise<void>[];
+
+    constructor() {
+        super();
+        this.rpcs = new Map<string, RPCProtocol>();
+        this.pluginRemoteBrowser = new PluginRemoteBrowserImpl(this.rpcs);
+        this.initializedPlugins = [];
+    }
+
+    /**
+     * Send all hosts the plugins that are available
+     */
+    protected initRpc(host: PluginHost, pluginId: string): RPCProtocol {
+        const rpc = super.initRpc(host, pluginId);
+        rpc.set(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_BROWSER, this.pluginRemoteBrowser);
+        this.rpcs.set(host, rpc);
+
+        const pluginRemoteExt = rpc.getProxy(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_NODE);
+
+        // get all plugins that are not for a given host
+        const externalPlugins: DeployedPlugin[] = [];
+        Array.from(this.contributionsByHost.keys()).forEach(pluginHost => {
+            if (host !== pluginHost) {
+                const contribs: PluginContributions[] = this.contributionsByHost.get(pluginHost)!;
+                return contribs.forEach(contrib => {
+                    externalPlugins.push(contrib.plugin);
+                });
+            }
+        });
+        const initPromise = pluginRemoteExt.$initExternalPlugins(externalPlugins);
+        this.initializedPlugins.push(initPromise);
+        return rpc;
+    }
+
+    /**
+     * Wait promises of initialized plugins before returning manager.
+     */
+    protected async obtainManager(host: string, hostContributions: PluginContributions[], toDisconnect: DisposableCollection): Promise<PluginManagerExt | undefined> {
+        const manager = await super.obtainManager(host, hostContributions, toDisconnect);
+        await Promise.all(this.initializedPlugins);
+        return manager;
+    }
+
+    /**
+     * Add mapping before starting plugins
+     */
+    protected async startPlugins(contributionsByHost: Map<PluginHost, PluginContributions[]>, toDisconnect: DisposableCollection): Promise<void> {
+        this.contributionsByHost = contributionsByHost;
+
+        Array.from(this.contributionsByHost.values()).map(element => {
+            element.map((pluginContribution: PluginContributions) => {
+                const host = pluginContribution.plugin.metadata.host;
+                const id = pluginContribution.plugin.metadata.model.id;
+                this.pluginRemoteBrowser.addMapping(id, host);
+            });
+        });
+        return super.startPlugins(contributionsByHost, toDisconnect);
+    }
+
+}

--- a/extensions/eclipse-che-theia-plugin-remote/src/browser/plugin-remote-frontend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/browser/plugin-remote-frontend-module.ts
@@ -1,0 +1,20 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { BrowserRemoteHostedPluginSupport } from './browser-remote-hosted-plugin-support';
+import { HostedPluginSupport } from '@theia/plugin-ext/lib/hosted/browser/hosted-plugin';
+
+export default new ContainerModule((bind, unbind, isBound, rebind) => {
+
+    bind(BrowserRemoteHostedPluginSupport).toSelf();
+    rebind(HostedPluginSupport).toService(BrowserRemoteHostedPluginSupport);
+
+});

--- a/extensions/eclipse-che-theia-plugin-remote/src/common/plugin-remote-rpc.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/common/plugin-remote-rpc.ts
@@ -1,0 +1,40 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { createProxyIdentifier } from '@theia/plugin-ext/lib/common/rpc-protocol';
+import { DeployedPlugin, ConfigStorage, PluginPackage } from '@theia/plugin-ext/lib/common';
+
+export interface PluginRemoteNode {
+    $initExternalPlugins(externalPlugins: DeployedPlugin[]): Promise<void>;
+    $loadPlugin(pluginId: string, configStorage: ConfigStorage): Promise<void>;
+    $activatePlugin(pluginId: string): Promise<void>;
+    // tslint:disable-next-line: no-any
+    $callLocalMethod(callId: number, index: number, ...args: any[]): Promise<any>;
+    // tslint:disable-next-line: no-any
+    $callMethod(fromHostId: string, pluginId: string, callId: number, entryName: string, ...args: any[]): Promise<any>;
+    $definePluginExports(hostId: string, pluginId: string, proxyNames: string[]): Promise<void>;
+    $definePluginPackage(pluginId: string, rawModel: PluginPackage): Promise<void>;
+}
+
+export interface PluginRemoteBrowser {
+    $loadPlugin(pluginID: string, configStorage: ConfigStorage): Promise<void>;
+    $activatePlugin(pluginId: string): Promise<void>;
+    // tslint:disable-next-line: no-any
+    $callMethod(fromHostId: string, pluginId: string, callId: number, entryName: string, ...args: any[]): Promise<any>;
+    // tslint:disable-next-line: no-any
+    $callLocalMethod(hostId: string, callId: number, index: number, ...args: any[]): Promise<any>;
+    $definePluginExports(pluginId: string, proxyNames: string[]): Promise<void>;
+    $definePluginPackage(pluginId: string, rawModel: PluginPackage): Promise<void>;
+}
+
+export const MAIN_REMOTE_RPC_CONTEXT = {
+    PLUGIN_REMOTE_NODE: createProxyIdentifier<PluginRemoteNode>('PluginRemoteNode'),
+    PLUGIN_REMOTE_BROWSER: createProxyIdentifier<PluginRemoteBrowser>('PluginRemoteBrowser'),
+};

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-host-custom.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-host-custom.ts
@@ -1,0 +1,103 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+/**
+ * Copy of the upstream plugin-remote-init except that we add remote stuff
+ * const pluginRemoteBrowser = rpc.getProxy(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_BROWSER);
+ * const pluginRemoteNodeImpl = new PluginRemoteNodeImpl(pluginRemoteBrowser);
+ * rpc.set(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_NODE, pluginRemoteNodeImplt);
+ *
+ * and
+ *
+ * pluginRemoteNodeImpl.setPluginManager(pluginManager);
+ */
+import { Emitter } from '@theia/core/lib/common/event';
+import { RPCProtocolImpl } from '@theia/plugin-ext/lib/common/rpc-protocol';
+import { PluginHostRPC } from '@theia/plugin-ext/lib/hosted/node/plugin-host-rpc';
+import { PluginRemoteNodeImpl } from './plugin-remote-node-impl';
+import { MAIN_REMOTE_RPC_CONTEXT } from '../common/plugin-remote-rpc';
+console.log('PLUGIN_HOST_CHE_THEIA(' + process.pid + ') starting instance');
+
+// override exit() function, to do not allow plugin kill this node
+process.exit = function (code?: number): void {
+    const err = new Error('An plugin call process.exit() and it was prevented.');
+    console.warn(err.stack);
+} as (code?: number) => never;
+
+// same for 'crash'(works only in electron)
+// tslint:disable-next-line: no-any
+const proc = process as any;
+if (proc.crash) {
+    proc.crash = function (): void {
+        const err = new Error('An plugin call process.crash() and it was prevented.');
+        console.warn(err.stack);
+    };
+}
+
+process.on('uncaughtException', (err: Error) => {
+    console.error(err);
+});
+
+// tslint:disable-next-line: no-any
+const unhandledPromises: Promise<any>[] = [];
+
+// tslint:disable-next-line: no-any
+process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
+    unhandledPromises.push(promise);
+    setTimeout(() => {
+        const index = unhandledPromises.indexOf(promise);
+        if (index >= 0) {
+            promise.catch(err => {
+                unhandledPromises.splice(index, 1);
+                console.error(`Promise rejection not handled in one second: ${err} , reason: ${reason}`);
+                if (err && err.stack) {
+                    console.error(`With stack trace: ${err.stack}`);
+                }
+            });
+        }
+    }, 1000);
+});
+
+// tslint:disable-next-line: no-any
+process.on('rejectionHandled', (promise: Promise<any>) => {
+    const index = unhandledPromises.indexOf(promise);
+    if (index >= 0) {
+        unhandledPromises.splice(index, 1);
+    }
+});
+
+const emitter = new Emitter();
+const rpc = new RPCProtocolImpl({
+    onMessage: emitter.event,
+    send: (m: {}) => {
+        if (process.send) {
+            process.send(JSON.stringify(m));
+        }
+    }
+});
+
+process.on('message', (message: string) => {
+    try {
+        emitter.fire(JSON.parse(message));
+    } catch (e) {
+        console.error(e);
+    }
+});
+
+const pluginHostRPC = new PluginHostRPC(rpc);
+const pluginRemoteBrowser = rpc.getProxy(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_BROWSER);
+const pluginRemoteNodeImpl = new PluginRemoteNodeImpl(pluginRemoteBrowser);
+rpc.set(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_NODE, pluginRemoteNodeImpl);
+
+pluginHostRPC.initialize();
+
+// tslint:disable-next-line: no-any
+const pluginManager = (pluginHostRPC as any).pluginManager;
+pluginRemoteNodeImpl.setPluginManager(pluginManager);

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-backend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-backend-module.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2018-2019 Red Hat, Inc.
+ * Copyright (c) 2018-2020 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
+import * as path from 'path';
 import { ContainerModule, interfaces } from 'inversify';
 import { HostedPluginRemote } from './hosted-plugin-remote';
 import { ServerPluginProxyRunner } from './server-plugin-proxy-runner';
@@ -16,7 +17,7 @@ import { RemoteMetadataProcessor } from './remote-metadata-processor';
 import { HostedPluginMapping } from './plugin-remote-mapping';
 import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
 import { PluginReaderExtension } from './plugin-reader-extension';
-import { HostedPluginProcess } from '@theia/plugin-ext/lib/hosted/node/hosted-plugin-process';
+import { HostedPluginProcess, HostedPluginProcessConfiguration } from '@theia/plugin-ext/lib/hosted/node/hosted-plugin-process';
 import { LogHostedPluginProcess } from './hosted-plugin-process-log';
 
 const localModule = ConnectionContainerModule.create(({ bind, unbind, isBound, rebind }) => {
@@ -30,7 +31,7 @@ const localModule = ConnectionContainerModule.create(({ bind, unbind, isBound, r
     rebind(HostedPluginProcess).toService(LogHostedPluginProcess);
 });
 
-export default new ContainerModule(bind => {
+export default new ContainerModule((bind, unbind, isBound, rebind) => {
     try {
         // Force to include theia-plugin-ext inside node_modules
         require('@eclipse-che/theia-plugin-ext/lib/node/che-plugin-api-provider.js');
@@ -41,5 +42,6 @@ export default new ContainerModule(bind => {
     bind(MetadataProcessor).to(RemoteMetadataProcessor).inSingletonScope();
     bind(PluginReaderExtension).toSelf().inSingletonScope();
 
+    rebind(HostedPluginProcessConfiguration).toConstantValue({ path: path.resolve(__dirname, 'plugin-host-custom.js') });
     bind(ConnectionContainerModule).toConstantValue(localModule);
 });

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-browser-impl.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-browser-impl.ts
@@ -1,0 +1,97 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { PluginRemoteBrowser, MAIN_REMOTE_RPC_CONTEXT } from '../common/plugin-remote-rpc';
+import { RPCProtocol } from '@theia/plugin-ext/lib/common/rpc-protocol';
+import { ConfigStorage, PluginPackage } from '@theia/plugin-ext/lib/common';
+
+export class PluginRemoteBrowserImpl implements PluginRemoteBrowser {
+
+    private mappingPluginHost: Map<string, string>;
+
+    constructor(private readonly rpcs: Map<string, RPCProtocol>) {
+        this.mappingPluginHost = new Map();
+    }
+
+    public addMapping(pluginID: string, host: string) {
+        this.mappingPluginHost.set(pluginID, host);
+    }
+
+    async $loadPlugin(pluginId: string, configStorage: ConfigStorage): Promise<void> {
+
+        const matchingHost = this.mappingPluginHost.get(pluginId);
+        if (matchingHost) {
+            const rpc = this.rpcs.get(matchingHost)!;
+            const nodeRemote = rpc.getProxy(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_NODE);
+            await nodeRemote.$loadPlugin(pluginId, configStorage);
+        }
+    }
+
+    async $activatePlugin(pluginId: string): Promise<void> {
+
+        const matchingHost = this.mappingPluginHost.get(pluginId);
+        if (matchingHost) {
+            const rpc = this.rpcs.get(matchingHost)!;
+            const nodeRemote = rpc.getProxy(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_NODE);
+            await nodeRemote.$activatePlugin(pluginId);
+        }
+    }
+
+    // tslint:disable-next-line: no-any
+    async $callMethod(fromHostId: string, pluginId: string, callId: number, entryName: string, ...args: any[]): Promise<any> {
+
+        const matchingHost = this.mappingPluginHost.get(pluginId);
+        if (matchingHost) {
+            const rpc = this.rpcs.get(matchingHost)!;
+            const nodeRemote = rpc.getProxy(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_NODE);
+            const result = await nodeRemote.$callMethod(fromHostId, pluginId, callId, entryName, ...args);
+            return result;
+        }
+        throw new Error(`No matching host for the plugin with id ${pluginId}`);
+    }
+
+    // tslint:disable-next-line: no-any
+    async $callLocalMethod(hostId: string, callId: number, index: number, ...args: any[]): Promise<any> {
+        const rpc = this.rpcs.get(hostId)!;
+        const nodeRemote = rpc.getProxy(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_NODE);
+        const localCallResult = await nodeRemote.$callLocalMethod(callId, index, ...args);
+        return localCallResult;
+    }
+
+    async $definePluginExports(pluginId: string, proxyNames: string[]): Promise<void> {
+
+        this.getOtherHosts(pluginId).map(async host => {
+            const rpc = this.rpcs.get(host)!;
+            const nodeRemote = rpc.getProxy(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_NODE);
+            await nodeRemote.$definePluginExports(host, pluginId, proxyNames);
+        });
+    }
+
+    async $definePluginPackage(pluginId: string, pluginPackage: PluginPackage): Promise<void> {
+        this.getOtherHosts(pluginId).map(async host => {
+            const rpc = this.rpcs.get(host)!;
+            const nodeRemote = rpc.getProxy(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_NODE);
+            await nodeRemote.$definePluginPackage(pluginId, pluginPackage);
+        });
+    }
+
+    /**
+     * Provides all hosts that are not where the plugin is hosted.
+     */
+    protected getOtherHosts(pluginId: string): string[] {
+        const matchingHost = this.mappingPluginHost.get(pluginId);
+        if (matchingHost) {
+            return Array.from(this.rpcs.keys()).filter(host => host !== matchingHost);
+        } else {
+            return [];
+        }
+    }
+
+}

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-node-impl.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-node-impl.ts
@@ -1,0 +1,254 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import * as deasync from 'deasync';
+import { PluginRemoteNode, PluginRemoteBrowser } from '../common/plugin-remote-rpc';
+import { DeployedPlugin, Plugin, ConfigStorage, PluginPackage } from '@theia/plugin-ext/lib/common';
+import { PluginManagerExtImpl } from '@theia/plugin-ext/lib/plugin/plugin-manager';
+export class CallInfo {
+    // tslint:disable-next-line: no-any
+    public functions: Map<number, Function>;
+}
+
+export class PluginRemoteNodeImpl implements PluginRemoteNode {
+    private pluginManager: PluginManagerExtImpl;
+
+    private externalRegistry: Map<string, Plugin>;
+
+    private callId: number = 0;
+    private calls: Map<number, CallInfo>;
+
+    constructor(private readonly pluginRemoteBrowser: PluginRemoteBrowser) {
+        this.externalRegistry = new Map<string, Plugin>();
+        this.calls = new Map();
+    }
+
+    setPluginManager(pluginManager: PluginManagerExtImpl) {
+        this.pluginManager = pluginManager;
+
+        // tslint:disable-next-line: no-any
+        const originalLoadPlugin = (pluginManager as any).loadPlugin;
+        // tslint:disable-next-line: no-any
+        const originalActivatePlugin = (pluginManager as any).activatePlugin;
+        const pluginRemoteBrowser = this.pluginRemoteBrowser;
+        // tslint:disable-next-line: no-any
+        (pluginManager as any).loadPlugin = async (plugin: Plugin, configStorage: ConfigStorage, visited: any = new Set<string>()): Promise<boolean> => {
+            // if plug-in is in another container, redirect the call to that container
+            if (this.externalRegistry.has(plugin.model.id)) {
+                await pluginRemoteBrowser.$loadPlugin(plugin.model.id, configStorage);
+                return true;
+            }
+            return originalLoadPlugin.call(pluginManager, plugin, configStorage, visited);
+        };
+
+        // tslint:disable-next-line: no-any
+        (pluginManager as any).activatePlugin = async (pluginId: string): Promise<void> => {
+            if (this.externalRegistry.has(pluginId)) {
+                await pluginRemoteBrowser.$activatePlugin(pluginId);
+                return;
+            }
+            return originalActivatePlugin.call(pluginManager, pluginId);
+        };
+    }
+
+    async $loadPlugin(pluginId: string, configStorage: ConfigStorage): Promise<void> {
+        // tslint:disable-next-line: no-any
+        const pluginManagerInternal = (this.pluginManager as any);
+        let plugin = pluginManagerInternal.registry.get(pluginId);
+        let waited: number = 0;
+        // start is sent on all nodes, check the registry is populated for about 5seconds
+        if (!plugin && waited < 100) {
+            // loop to wait that plug-in is loaded into the registry as start should occur
+            await this.sleep(50);
+            waited++;
+            plugin = pluginManagerInternal.registry.get(pluginId);
+        }
+        if (waited >= 100) {
+            throw new Error(`Unable to load the plug-in ${pluginId}. Wait for being ready but was never loaded.`);
+        }
+        await pluginManagerInternal.loadPlugin(plugin, configStorage);
+        const activatedPlugin = pluginManagerInternal.activatedPlugins.get(pluginId);
+
+        // share the JSON with others
+        const rawModel = plugin.rawModel;
+        await this.pluginRemoteBrowser.$definePluginPackage(pluginId, rawModel);
+
+        if (activatedPlugin && activatedPlugin.exports) {
+
+            // do we have prototype ?
+            const exported = activatedPlugin.exports;
+
+            const prototype = Object.getPrototypeOf(exported);
+            let proxyNames: Array<string> = [];
+            if (prototype) {
+                proxyNames = proxyNames.concat(Object.getOwnPropertyNames(prototype));
+            }
+
+            // ok now need to send that back only if there are some exports
+            if (proxyNames.length > 0) {
+                await this.pluginRemoteBrowser.$definePluginExports(pluginId, proxyNames);
+            }
+        }
+    }
+
+    async $activatePlugin(pluginId: string): Promise<void> {
+        // tslint:disable-next-line: no-any
+        const pluginManagerInternal = (this.pluginManager as any);
+        await pluginManagerInternal.activatePlugin(pluginId);
+    }
+
+    async $definePluginPackage(pluginId: string, pluginPackage: PluginPackage): Promise<void> {
+        // tslint:disable-next-line: no-any
+        const plugin = (this.pluginManager as any).registry.get(pluginId);
+        if (plugin) {
+            plugin.rawModel = pluginPackage;
+        }
+    }
+
+    // Promise that will wait for the deasync result.
+    // tslint:disable-next-line: no-any
+    deasyncPromise(promise: Promise<any>) {
+        // tslint:disable-next-line: no-any
+        let result: any;
+        // tslint:disable-next-line: no-any
+        let error: any;
+        let done = false;
+        promise.then(res => {
+            result = res;
+        }, err => {
+            error = err;
+        }).then(() => {
+            done = true;
+        });
+        deasync.loopWhile(() => !done);
+        if (error) {
+            throw error;
+        }
+        return result;
+    }
+
+    async $definePluginExports(hostId: string, pluginId: string, proxyNames: string[]): Promise<void> {
+        // tslint:disable-next-line: no-any
+        const pluginManagerInternal = (this.pluginManager as any);
+
+        // add into the activatedPlugins stuff
+        // tslint:disable-next-line: no-any
+        const activatedPlugin: any = {};
+        // tslint:disable-next-line: no-any
+        const proxyExports: any = {};
+        activatedPlugin.exports = proxyExports;
+        const remoteBrowser = this.pluginRemoteBrowser;
+        const deasyncPromise = this.deasyncPromise;
+        // add proxy
+        const callId = this.callId++;
+        proxyNames.forEach(entryName => {
+            console.log(`Proxyfing exports ${hostId} ${pluginId}/${entryName}`);
+            // tslint:disable-next-line: no-any
+            proxyExports[entryName] = (...args: any[]) => {
+                // need to keep arguments only if arguments have functions as functions can't be propagated remotely
+                const hasFunctions = args.some(arg => typeof arg === 'function');
+                if (hasFunctions) {
+                    const functions = new Map<number, Function>();
+                    args.forEach((arg, index) => {
+                        const type = typeof arg;
+                        if (type === 'function') {
+                            functions.set(index, arg);
+                        }
+                    });
+                    // keep function arguments
+                    this.calls.set(callId, { functions });
+                }
+
+                // remote call for this method
+                return deasyncPromise(remoteBrowser.$callMethod(hostId, pluginId, callId, entryName, ...args));
+            };
+        });
+        pluginManagerInternal.activatedPlugins.set(pluginId, activatedPlugin);
+        await pluginManagerInternal.activatePlugin(pluginId);
+    }
+
+    // tslint:disable-next-line: no-any
+    async $callLocalMethod(callId: number, index: number, ...args: any[]): Promise<any> {
+        const callInfo = this.calls.get(callId);
+        if (callInfo) {
+            const functionToInvoke = callInfo.functions.get(index);
+            if (!functionToInvoke) {
+                throw new Error('Requesting a local-call method to an argument that is not defined');
+            }
+            return functionToInvoke(...args);
+
+        }
+        console.error(`Ignoring call with callId ${callId}`);
+    }
+
+    // tslint:disable-next-line: no-any
+    async $callMethod(fromHostId: string, pluginId: string, callId: number, entryName: string, ...args: any[]): Promise<any> {
+        // tslint:disable-next-line: no-any
+        const pluginManagerInternal = (this.pluginManager as any);
+        const activatedPlugin = pluginManagerInternal.activatedPlugins.get(pluginId);
+        const exports = activatedPlugin.exports;
+        if (exports) {
+            // tslint:disable-next-line: no-any
+            const updatedArgs: any[] = [];
+            if (args) {
+                const remoteBrowser = this.pluginRemoteBrowser;
+                const deasyncPromise = this.deasyncPromise;
+
+                // tslint:disable-next-line: no-any
+                args.forEach((arg: any, index: number) => {
+                    if (arg === undefined) {
+                        // proxify
+                        // tslint:disable-next-line: no-any
+                        const handler: ProxyHandler<any> = {
+                            // tslint:disable-next-line: no-any
+                            apply(target: any, thisArg: any, argArray?: any): any {
+                                return deasyncPromise(remoteBrowser.$callLocalMethod(fromHostId, callId, index, argArray));
+                            }
+                        };
+                        const functionProxy = () => { };
+                        const proxy = new Proxy(functionProxy, handler);
+                        updatedArgs.push(proxy);
+                    } else {
+                        updatedArgs.push(arg);
+                    }
+                });
+            }
+            return exports[entryName](...updatedArgs);
+        }
+    }
+
+    async sleep(ms: number): Promise<void> {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    async $initExternalPlugins(externalPlugins: DeployedPlugin[]): Promise<void> {
+        // tslint:disable-next-line: no-any
+        const registry: Map<string, Plugin> = (this.pluginManager as any).registry;
+
+        externalPlugins.map(deployedPlugin => {
+            const modelId = deployedPlugin.metadata.model.id;
+
+            // empty rawModel
+            const rawModel: PluginPackage = <PluginPackage>{};
+
+            const plugin = <Plugin>{
+                pluginPath: deployedPlugin.metadata.model.entryPoint.backend,
+                pluginFolder: deployedPlugin.metadata.model.packagePath,
+                model: deployedPlugin.metadata.model,
+                rawModel,
+                lifecycle: deployedPlugin.metadata.lifecycle
+            };
+            registry.set(modelId, plugin);
+
+            this.externalRegistry.set(modelId, plugin);
+        });
+    }
+
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1863,6 +1863,11 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
   integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
 
+"@types/deasync@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@types/deasync/-/deasync-0.1.0.tgz#b2bd6c3fcde3cf67b8be4c2f70136ba8f157b45a"
+  integrity sha512-jxUH53LtGvbIL3TX2hD/XQuAgYJeATtx9kDXq5XtCZrWQABsiCQPjWi/KQXECUF+p9FuR6/tawnEDjXlEr4rFA==
+
 "@types/diff@^3.2.2":
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/@types/diff/-/diff-3.5.3.tgz#7c6c3721ba454d838790100faf7957116ee7deab"
@@ -4291,6 +4296,14 @@ dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
+
+deasync@^0.1.19:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.19.tgz#e7ea89fcc9ad483367e8a48fe78f508ca86286e8"
+  integrity sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==
+  dependencies:
+    bindings "^1.5.0"
+    node-addon-api "^1.7.1"
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
@@ -9133,6 +9146,11 @@ node-abi@^2.2.0:
   integrity sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==
   dependencies:
     semver "^5.4.1"
+
+node-addon-api@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.1.tgz#cf813cd69bb8d9100f6bdca6755fc268f54ac492"
+  integrity sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==
 
 node-fetch-npm@^2.0.2:
   version "2.0.3"


### PR DESCRIPTION
### What does this PR do?
See plug-ins across containers

Also it handles:
- disallow automatic dependencies download from extension referencing other extensions
- proxify exports from one container to other containers
- make exports calls synchronous by using deasync library
- Handle function() parameters on root exported objects. In that case it's handled as callbacks. So the function will be called remotely when needed.
- make deasync module a nodejs module (by reusing a custom pre-assembly of nodejs so that the theia endpoint runtime can be statically compiled
- change plugin's host process to be able to customize the plug-in manager to handle remote containers

Can be tested with https://che.openshift.io/f/?url=https://gist.githubusercontent.com/benoitf/618ba31e7812a35f8f6569b94e1672e4/raw/f002e493bb5a465119aeee9ebcd8928d8dab7d6a/devfile-across-containers.yaml

it'll deploy:
- one sidecar container with only `kubernetes vsix plugin`
- one sidecar container with only `vscode-yaml plugin`

When workspace is loaded, you may try to create a new yaml file
Paste content of https://kubernetes.io/docs/tasks/run-application/run-stateless-application-deployment/#creating-and-exploring-an-nginx-deployment 

```
apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
kind: Deployment
metadata:
  name: nginx-deployment
spec:
  selector:
    matchLabels:
      app: nginx
  replicas: 2 # tells deployment to run 2 pods matching the template
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.7.9
        ports:
        - containerPort: 80
```

Some warnings should be there.
So kubernetes VS Code extension would have successfully register kubernetes schema into yaml VS Code extension.
![image](https://user-images.githubusercontent.com/436777/75564345-43d0e780-5a4c-11ea-8cbc-a0e9b416ee6d.png)


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/15826
Fixes https://github.com/eclipse/che/issues/15844

Change-Id: I8134e4f8a704ac2993ce0580b11d153de8bb64ed
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
