### PR TITLE
Add in vscode-builtin-php

### DIFF
--- a/generator/src/templates/theiaPlugins.json
+++ b/generator/src/templates/theiaPlugins.json
@@ -32,6 +32,7 @@
     "vscode-builtin-perl": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/perl-1.39.1-prel.vsix",
     "vscode-builtin-powershell": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/powershell-1.39.1-prel.vsix",
     "vscode-builtin-pug": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/pug-1.39.1-prel.vsix",
+    "vscode-builtin-php": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/php-1.39.1-prel.vsix",
     "vscode-builtin-python": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/python-1.39.1-prel.vsix",
     "vscode-builtin-r": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/r-1.39.1-prel.vsix",
     "vscode-builtin-razor": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/razor-1.39.1-prel.vsix",


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR adds in the vscode-builtin-php. I believe the reason we didn't originally add this was because of https://github.com/eclipse-theia/theia/issues/6672 but from playing around with and investigating the Theia code I don't think it's really an issue. Also, cpp and yaml (when you have vscode-yaml activated) both show these errors as well. This builtin is needed otherwise PHP highlighting and language features won't work in any of the PHP stacks.

To test use the PHP symphony devfile and add in:
```
  - type: chePlugin
    reference: >-
      https://gist.githubusercontent.com/JPinkney/5cad64651e4f609f019be617d2098129/raw/ac7ad2ccc95ae743a57f4e9f285b1f69c287ec4f/meta.yaml
```

Then open up a PHP file and you should have highlighting, outline, etc working.

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16196
https://github.com/eclipse/che/issues/16114

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
