### PR TITLE
chore(generator): Use Gnu Tar to get rid of specific options

### DIFF
--- a/dockerfiles/theia-dev/build.sh
+++ b/dockerfiles/theia-dev/build.sh
@@ -12,7 +12,29 @@ base_dir=$(cd "$(dirname "$0")"; pwd)
 
 
 DIR=$(cd "$(dirname "$0")"; pwd)
+init --name:theia-dev "$@"
 
+
+# Build gnu tar image
+GNUTAR_IMAGE_NAME="eclipse-che-theia-tar-build"
+build_tar_image() {
+  printf "Building image ${GNUTAR_IMAGE_NAME}${NC}..."
+  if docker build -t eclipse-che-theia-tar-build > docker-build-log 2>&1 -<<EOF
+  FROM alpine:3.11.3
+  WORKDIR /workdir/
+  RUN apk add --no-cache --update tar
+EOF
+then
+  printf "%b[OK]%b\n" "${GREEN}" "${NC}"
+  rm docker-build-log
+else
+  printf "%bFailure%b\n" "${RED}" "${NC}"
+  cat docker-build-log
+  exit 1
+fi
+}
+
+build_tar_image
 CHE_THEIA_GENERATOR_PACKAGE_NAME=eclipse-che-theia-generator.tgz
 CHE_THEIA_GENERATOR_PACKAGE="${base_dir}/../../generator/${CHE_THEIA_GENERATOR_PACKAGE_NAME}"
 # Rebuild Che Theia generator if:
@@ -28,11 +50,13 @@ then
     rm -f $CHE_THEIA_GENERATOR_PACKAGE
     echo "Building Che Theia generator"
     cd "${base_dir}"/../../generator/ && yarn && yarn pack --filename $CHE_THEIA_GENERATOR_PACKAGE_NAME
+    # Build the file in a way that it's agnostic of timestamp/user who is doing it
+    docker run --rm -it -v "${base_dir}/../../generator:/workdir" ${GNUTAR_IMAGE_NAME} sh -c 'mkdir -p unpacked && tar zxf eclipse-che-theia-generator.tgz -C unpacked && tar czf eclipse-che-theia-generator.tgz -C unpacked package --owner=che-theia --group=che-theia --sort=name --clamp-mtime --mtime="CET 2020-01-01 00:00:00" && rm -rf unpacked'
 fi
 echo "Copying Che Theia generator"
 cp "${CHE_THEIA_GENERATOR_PACKAGE}" "${base_dir}/asset-${CHE_THEIA_GENERATOR_PACKAGE_NAME}"
 
-init --name:theia-dev "$@"
+
 build
 if ! dry_run; then
   if ! skip_tests; then


### PR DESCRIPTION
### What does this PR do?
Use a specific owner/group and mtime to avoid changes in the tgz if there are no changes in the generator.

It will help to benefit from docker layers if checksum is not modified if file content are not changed.

### What issues does this PR fix or reference?
N/A

Change-Id: I8aea55a3cc62fe75eef2490fc891d3b0dbe65554
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
