### PR TITLE
Patch main.js to proper handling hotkeys in webviews

### DIFF
--- a/dockerfiles/theia/src/patches/master/webviews_prevent_default_hotkeys.patch
+++ b/dockerfiles/theia/src/patches/master/webviews_prevent_default_hotkeys.patch
@@ -1,0 +1,26 @@
+diff --git a/packages/plugin-ext/src/main/browser/webview/pre/main.js b/packages/plugin-ext/src/main/browser/webview/pre/main.js
+index 383d400a3..5096b6cf2 100644
+--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
++++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
+@@ -271,6 +271,21 @@
+ 		 * @param {KeyboardEvent} e
+ 		 */
+         const handleInnerKeydown = (e) => {
++            // F1
++            if (e.keyCode === 112) {
++                e.preventDefault();
++            }
++
++            // Prevent handling CtrlCmd+O,P,S
++            if (e.ctrlKey || e.metaKey) {
++                switch (e.keyCode) {
++                    case 79: // "O"
++                    case 80: // "P"
++                    case 83: // "S"
++                        e.preventDefault();
++                }
++            }
++
+             host.postMessage('did-keydown', {
+                 key: e.key,
+                 keyCode: e.keyCode,


### PR DESCRIPTION
### What does this PR do?
Add patch that filters `CtrlCmd+O`, `CtrlCmd+P`, `CtrlCmd+S` and `F1` hotkeys to prevent their default execution in webviews.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15763
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
