### PR TITLE
Add oAuth plugin API methods

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-api-provider.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-api-provider.ts
@@ -24,6 +24,7 @@ import { CheProductMainImpl } from './che-product-main';
 import { CheSideCarContentReaderMainImpl } from './che-sidecar-content-reader-main';
 import { CheGithubMainImpl } from './che-github-main';
 import { CheOpenshiftMainImpl } from './che-openshift-main';
+import { CheOauthMainImpl } from './che-oauth-main';
 
 @injectable()
 export class CheApiProvider implements MainPluginApiProvider {
@@ -38,6 +39,7 @@ export class CheApiProvider implements MainPluginApiProvider {
         rpc.set(PLUGIN_RPC_CONTEXT.CHE_SSH_MAIN, new CheSshMainImpl(container));
         rpc.set(PLUGIN_RPC_CONTEXT.CHE_GITHUB_MAIN, new CheGithubMainImpl(container));
         rpc.set(PLUGIN_RPC_CONTEXT.CHE_OPENSHIFT_MAIN, new CheOpenshiftMainImpl(container));
+        rpc.set(PLUGIN_RPC_CONTEXT.CHE_OAUTH_MAIN, new CheOauthMainImpl(container));
         rpc.set(PLUGIN_RPC_CONTEXT.CHE_USER_MAIN, new CheUserMainImpl(container));
         rpc.set(PLUGIN_RPC_CONTEXT.CHE_PRODUCT_MAIN, new CheProductMainImpl(container, rpc));
         rpc.set(PLUGIN_RPC_CONTEXT.CHE_SIDERCAR_CONTENT_READER_MAIN, new CheSideCarContentReaderMainImpl(container, rpc));

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-oauth-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-oauth-main.ts
@@ -1,0 +1,29 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { CheOauthMain } from '../common/che-protocol';
+import { interfaces } from 'inversify';
+import { OauthUtils } from './oauth-utils';
+
+export class CheOauthMainImpl implements CheOauthMain {
+    private readonly oAuthUtils: OauthUtils;
+
+    constructor(container: interfaces.Container) {
+        this.oAuthUtils = new OauthUtils(container);
+    }
+
+    $getProviders(): Promise<string[]> {
+        return this.oAuthUtils.getProviders();
+    }
+
+    $isAuthenticated(provider: string): Promise<boolean> {
+        return this.oAuthUtils.isAuthenticated(provider);
+    }
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -79,6 +79,16 @@ export interface CheGithubMain {
     $getToken(): Promise<string>;
 }
 
+export interface CheOauth {
+    getProviders(): Promise<string[]>;
+    isAuthenticated(provider: string): Promise<boolean>;
+}
+
+export interface CheOauthMain {
+    $getProviders(): Promise<string[]>;
+    $isAuthenticated(provider: string): Promise<boolean>;
+}
+
 /**
  * Telemetry plugin API
  */
@@ -414,6 +424,9 @@ export const PLUGIN_RPC_CONTEXT = {
     CHE_GITHUB: <ProxyIdentifier<CheGithub>>createProxyIdentifier<CheGithub>('CheGithub'),
     CHE_GITHUB_MAIN: <ProxyIdentifier<CheGithubMain>>createProxyIdentifier<CheGithubMain>('CheGithubMain'),
 
+    CHE_OAUTH: <ProxyIdentifier<CheOauth>>createProxyIdentifier<CheOauth>('CheOauth'),
+    CHE_OAUTH_MAIN: <ProxyIdentifier<CheOauthMain>>createProxyIdentifier<CheOauthMain>('CheOauthMain'),
+
     CHE_OPENSHIFT: <ProxyIdentifier<CheOpenshift>>createProxyIdentifier<CheOpenshift>('CheOpenshift'),
     CHE_OPENSHIFT_MAIN: <ProxyIdentifier<CheOpenshiftMain>>createProxyIdentifier<CheOpenshiftMain>('CheOpenshiftMain'),
 
@@ -464,6 +477,7 @@ export interface CheApiService {
     submitTelemetryEvent(id: string, ownerId: string, ip: string, agent: string, resolution: string, properties: [string, string][]): Promise<void>;
     submitTelemetryActivity(): Promise<void>;
     getOAuthToken(oAuthProvider: string): Promise<string | undefined>;
+    getOAuthProviders(): Promise<string[]>;
 }
 
 export const CHE_TASK_SERVICE_PATH = '/che-task-service';

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-api-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-api-service.ts
@@ -295,6 +295,15 @@ export class CheApiServiceImpl implements CheApiService {
         }
     }
 
+    async getOAuthProviders(): Promise<string[]> {
+        const cheApiClient = await this.getCheApiClient();
+        try {
+            return await cheApiClient.getOAuthProviders();
+        } catch (e) {
+            return [];
+        }
+    }
+
     private getWorkspaceTelemetryClient(): TelemetryClient | undefined {
 
         if (!this.telemetryClient) {

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
@@ -26,6 +26,7 @@ import { CheUserImpl } from './che-user';
 import { CheVariablesImpl } from './che-variables';
 import { CheWorkspaceImpl } from './che-workspace';
 import { CheOpenshiftImpl } from './che-openshift';
+import { CheOauthImpl } from './che-oauth';
 
 export interface CheApiFactory {
     (plugin: Plugin): typeof che;
@@ -40,6 +41,7 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
     const cheSshImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_SSH, new CheSshImpl(rpc));
     const cheGithubImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_GITHUB, new CheGithubImpl(rpc));
     const cheOpenshiftImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_OPENSHIFT, new CheOpenshiftImpl(rpc));
+    const cheOauthImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_OAUTH, new CheOauthImpl(rpc));
     const cheUserImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_USER, new CheUserImpl(rpc));
     rpc.set(PLUGIN_RPC_CONTEXT.CHE_SIDERCAR_CONTENT_READER, new CheSideCarContentReaderImpl(rpc));
 
@@ -137,6 +139,15 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
             }
         };
 
+        const oAuth: typeof che.oAuth = {
+            getProviders(): Promise<string[]> {
+                return cheOauthImpl.getProviders();
+            },
+            isAuthenticated(provider: string): Promise<boolean> {
+                return cheOauthImpl.isAuthenticated(provider);
+            }
+        };
+
         const ssh: typeof che.ssh = {
             deleteKey(service: string, name: string): Promise<void> {
                 return cheSshImpl.delete(service, name);
@@ -221,6 +232,7 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
             product,
             github,
             openshift,
+            oAuth,
             telemetry,
             TaskStatus
         };

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-oauth.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-oauth.ts
@@ -1,0 +1,29 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { RPCProtocol } from '@theia/plugin-ext/lib/common/rpc-protocol';
+import { PLUGIN_RPC_CONTEXT, CheOauthMain, CheOauth } from '../common/che-protocol';
+
+export class CheOauthImpl implements CheOauth {
+
+    private readonly oAuthMain: CheOauthMain;
+
+    constructor(rpc: RPCProtocol) {
+        this.oAuthMain = rpc.getProxy(PLUGIN_RPC_CONTEXT.CHE_OAUTH_MAIN);
+    }
+
+    getProviders(): Promise<string[]> {
+        return this.oAuthMain.$getProviders();
+    }
+
+    isAuthenticated(provider: string): Promise<boolean> {
+        return this.oAuthMain.$isAuthenticated(provider);
+    }
+}

--- a/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
+++ b/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
@@ -53,6 +53,11 @@ declare module '@eclipse-che/plugin' {
         export function getToken(): Promise<string>;
     }
 
+    export namespace oAuth {
+        export function getProviders(): Promise<string[]>;
+        export function isAuthenticated(provider: string): Promise<boolean>;
+    }
+
     export namespace ssh {
         export function generate(service: string, name: string): Promise<cheApi.ssh.SshPair>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,9 +164,9 @@
     "@eclipse-che/api" latest
 
 "@eclipse-che/workspace-client@latest":
-  version "0.0.1-1579077578"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1579077578.tgz#0fc322b536eb46bf271effc3f00a0435038b5966"
-  integrity sha512-j3hPUaMcld6cw0wuqQd/EjjUAkkq7J5iri8MCJYJf2eSylLnjYRabNfnfVS4REgj3b02VXLx3kuDGmNPLacSEw==
+  version "0.0.1-1584025415"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1584025415.tgz#0e6a87ccf28115c1f80a727572b732d89cc21283"
+  integrity sha512-kg04SVEw85HDfmT1fLkaz0hqMCGDmBUwVmzBRtCXjBZg9pPEKdVbFWDSMg0Ef/ITkdXa2MNAd1nAQN8AL1bg+A==
   dependencies:
     "@eclipse-che/api" "^7.0.0-beta-4.0"
     axios "0.19.0"


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add `getProviders()` and `isAuthenticated()` oAuth methods to plugin API.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15261

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
