### PR TITLE
Update vscode-git in che-theia

### DIFF
--- a/generator/src/templates/theiaPlugins.json
+++ b/generator/src/templates/theiaPlugins.json
@@ -48,7 +48,7 @@
     "vscode-builtin-xml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/xml-1.39.1-prel.vsix",
     "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
     "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix",
-    "vscode-git": "https://github.com/che-incubator/vscode-git/releases/download/vscode-git-1.30.1_0.0.1/vscode-git-1.30.1_0.0.1.vsix",
+    "vscode-git": "https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-git/git-1.0.0-f356dc.vsix",
     "vscode-references-view": "https://github.com/theia-ide/vscode-references-view/releases/download/v0.0.47/references-view-0.0.47.vsix",
     "vscode-builtin-theme-abyss": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/theme-abyss-1.39.1-prel.vsix",
     "vscode-builtin-theme-defaults": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/theme-defaults-1.39.1-prel.vsix",


### PR DESCRIPTION
Update the git built-in extension to the latest version (1.43.0). Please note that I have not yet tested this change inside Che.

The sources for the built version can be found here:
https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-git/vscode-git-53810c-sources.tar.gz

See eclipse/che#16084

Signed-off-by: Eric Williams <ericwill@redhat.com>