### PR TITLE
Bump minimist from 1.2.0 to 1.2.5 to fix the vulnerability reported by GitHub

### DIFF
--- a/dockerfiles/theia/e2e/src/package.json
+++ b/dockerfiles/theia/e2e/src/package.json
@@ -44,7 +44,7 @@
         "jquery": "3.4.1",
         "json-server": "0.14.0",
         "lodash": "4.17.15",
-        "minimist": "1.2.0",
+        "minimist": "1.2.5",
         "morgan": "1.9.1",
         "react": "16.7.0",
         "react-dom": "16.7.0"


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7598 reported by GitHub:

![image](https://user-images.githubusercontent.com/1636395/76803902-97308d00-67e3-11ea-8225-d9b74ab451c8.png)


### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
