### PR TITLE
Fix import of zip project in case the archive is hosted on the same cluster which uses self-signed certificate

### DIFF
--- a/plugins/workspace-plugin/src/theia-commands.ts
+++ b/plugins/workspace-plugin/src/theia-commands.ts
@@ -204,7 +204,7 @@ export class TheiaImportZipCommand implements TheiaImportCommand {
         const importZip = async (progress: theia.Progress<{ message?: string; increment?: number }>, token: theia.CancellationToken): Promise<void> => {
             try {
                 // download
-                const curlArgs = ['-L', '--output', this.zipfilePath];
+                const curlArgs = ['-sL', '--output', this.zipfilePath];
                 if (fs.existsSync(SS_CRT_PATH)) {
                     curlArgs.push('-k');
                 }

--- a/plugins/workspace-plugin/src/theia-commands.ts
+++ b/plugins/workspace-plugin/src/theia-commands.ts
@@ -17,6 +17,7 @@ import * as fileuri from './file-uri';
 import { execute } from './exec';
 import * as git from './git';
 
+const SS_CRT_PATH = '/tmp/che/secret/ca.crt';
 const CHE_TASK_TYPE = 'che';
 
 /**
@@ -204,6 +205,9 @@ export class TheiaImportZipCommand implements TheiaImportCommand {
             try {
                 // download
                 const wgetArgs = [this.locationURI!, '-O', this.zipfilePath];
+                if (fs.existsSync(SS_CRT_PATH)) {
+                    wgetArgs.push('--no-check-certificate');
+                }
                 await execute('wget', wgetArgs);
 
                 // expand

--- a/plugins/workspace-plugin/src/theia-commands.ts
+++ b/plugins/workspace-plugin/src/theia-commands.ts
@@ -204,11 +204,12 @@ export class TheiaImportZipCommand implements TheiaImportCommand {
         const importZip = async (progress: theia.Progress<{ message?: string; increment?: number }>, token: theia.CancellationToken): Promise<void> => {
             try {
                 // download
-                const wgetArgs = [this.locationURI!, '-O', this.zipfilePath];
+                const curlArgs = ['-L', '--output', this.zipfilePath];
                 if (fs.existsSync(SS_CRT_PATH)) {
-                    wgetArgs.push('--no-check-certificate');
+                    curlArgs.push('-k');
                 }
-                await execute('wget', wgetArgs);
+                curlArgs.push(this.locationURI!);
+                await execute('curl', curlArgs);
 
                 // expand
                 fs.mkdirSync(this.projectDir);

--- a/plugins/workspace-plugin/src/theia-commands.ts
+++ b/plugins/workspace-plugin/src/theia-commands.ts
@@ -204,7 +204,7 @@ export class TheiaImportZipCommand implements TheiaImportCommand {
         const importZip = async (progress: theia.Progress<{ message?: string; increment?: number }>, token: theia.CancellationToken): Promise<void> => {
             try {
                 // download
-                const curlArgs = ['-sL', '--output', this.zipfilePath];
+                const curlArgs = ['-sSL', '--output', this.zipfilePath];
                 if (fs.existsSync(SS_CRT_PATH)) {
                     curlArgs.push('-k');
                 }


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Fixes import of zip project when it is hosted in the same cluster as Che and the cluster uses self-signed certificate.