### PR TITLE
fix(git): Add correct permissions for shell scripts like git

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -98,7 +98,10 @@ RUN if [ -z $GITHUB_TOKEN ]; then unset GITHUB_TOKEN; fi && \
 COPY asset-untagged-theia_yeoman_plugin.theia /home/theia-dev/theia-source-code/production/plugins/theia_yeoman_plugin.theia
 
 # change permissions
-RUN find production -exec sh -c "chgrp 0 {}; chmod g+rwX {}" \; 2>log.txt
+RUN find production -exec sh -c "chgrp 0 {}; chmod g+rwX {}" \; 2>log.txt && \
+    # Add missing permissions on shell scripts of plug-ins
+    find /home/theia-dev/theia-source-code/production/plugins -name "*.sh" | xargs chmod +x
+
 
 
 ###


### PR DESCRIPTION
### What does this PR do?
Alternate fix of https://github.com/eclipse/che-theia/pull/669
fix permissions on *.sh scripts
bump as well vscode-git extension


### What issues does this PR fix or reference?
Fix https://github.com/eclipse/che/issues/16084


Can be tried with http://che.openshift.io/f/?url=https://gist.githubusercontent.com/benoitf/b6f95a9c89e5083c7a30a8dd258fd1cb/raw/73e57a7ae648120d16346c3ae364d835641d86e9/git-devfile.yaml


Change-Id: Icfb72fab088cce07c3b0b55a16a25d8cb6e2cf8e
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

