### PR TITLE
fix(plugin-remote): upstream theia is now requiring EnvVariables

### DIFF
--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-init.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-init.ts
@@ -37,6 +37,8 @@ import { DocumentContainerAware } from './document-container-aware';
 import { LanguagesContainerAware } from './languages-container-aware';
 import { PluginManagerExtImpl } from '@theia/plugin-ext/lib/plugin/plugin-manager';
 import { ExecuteCommandContainerAware } from './execute-command-container-aware';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { EnvVariablesServerImpl } from '@theia/core/lib/node/env-variables';
 
 interface CheckAliveWS extends ws {
     alive: boolean;
@@ -100,6 +102,8 @@ export class PluginRemoteInit {
 
         // Bind VsCode system
         inversifyContainer.load(pluginVscodeBackendModule);
+
+        inversifyContainer.bind(EnvVariablesServer).to(EnvVariablesServerImpl).inSingletonScope();
 
         // override handler to our own class
         inversifyContainer.bind(PluginDeployerHandlerImpl).toSelf().inSingletonScope();
@@ -475,6 +479,7 @@ class PluginDeployerHandlerImpl implements PluginDeployerHandler {
             const deployed: DeployedPlugin = { metadata, type };
             deployed.contributes = this.reader.readContribution(manifest);
             this.deployedBackendPlugins.set(metadata.model.id, deployed);
+            currentBackendDeployedPlugins.push(deployed);
             this.logger.info(`Deploying ${entryPoint} plugin "${metadata.model.name}@${metadata.model.version}" from "${metadata.model.entryPoint[entryPoint] || pluginPath}"`);
         } catch (e) {
             console.error(`Failed to deploy ${entryPoint} plugin from '${pluginPath}' path`, e);


### PR DESCRIPTION
### What does this PR do?
upstream theia introduce a new required dependency in plugin-ext to EnvVariablesServer

### What issues does this PR fix or reference?
Fix https://github.com/eclipse/che/issues/16412


Change-Id: Ia6f06ec4591b78e08263330b8c47457d04e3c2ab
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
