### PR TITLE
Don't update @eclipse-che/workspace-telemetry-client version for release

### DIFF
--- a/set_theia_version.sh
+++ b/set_theia_version.sh
@@ -87,7 +87,7 @@ updateVersion() {
 
 # first is path to dir which contains 'package.json', second is che-Theia version
 updateChePluginDependencies() {
-    sed -i -r -e '/@eclipse-che\/api|@eclipse-che\/workspace-client/!s/("@eclipse-che\/..*": )(".*")/\1"'$2'"/' ./$1/package.json
+    sed -i -r -e '/@eclipse-che\/api|@eclipse-che\/workspace-client|@eclipse-che\/workspace-telemetry-client/!s/("@eclipse-che\/..*": )(".*")/\1"'$2'"/' ./$1/package.json
 }
 
 


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
When executing release script, we don't need to set version of `@eclipse-che/workspace-telemetry-client` as a releasing Che Theia version but leave it `latest` instead, since it's not a part of Che Theia repo.

### What issues does this PR fix or reference?
closes https://github.com/eclipse/che/issues/16301

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
