### PR TITLE
Rework activity-tracker extension to work with Che Server over TLS

### DIFF
--- a/extensions/eclipse-che-theia-activity-tracker/src/node/activity-tracker-service.ts
+++ b/extensions/eclipse-che-theia-activity-tracker/src/node/activity-tracker-service.ts
@@ -15,10 +15,8 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
-import URI from '@theia/core/lib/common/uri';
 import { ActivityTrackerService } from '../common/activity-tracker-protocol';
 import { CheApiService } from '@eclipse-che/theia-plugin-ext/lib/common/che-protocol';
-import * as http from 'http';
 
 /**
  * Server side part of Theia activity tracker.
@@ -30,11 +28,7 @@ import * as http from 'http';
 @injectable()
 export class ActivityTrackerServiceImpl implements ActivityTrackerService {
 
-    private static WORKSPACE_ID_ENV_VAR_NAME = 'CHE_WORKSPACE_ID';
-    private static MACHINE_TOKEN_ENV_VAR_NAME = 'CHE_MACHINE_TOKEN';
-    private static CHE_API_ENV_VAR_NAME = 'CHE_API_INTERNAL';
-
-    // Time before sending next request. If a few requests from frontend(s) are recieved during this period,
+    // Time before sending next request. If a few requests from frontend(s) are received during this period,
     // only one request to workspace master will be sent.
     private static REQUEST_PERIOD_MS = 1 * 60 * 1000;
     // Time before resending request to workspace master if a network error occurs.
@@ -44,48 +38,13 @@ export class ActivityTrackerServiceImpl implements ActivityTrackerService {
 
     // Indicates state of the timer. If true timer is running.
     private isTimerRunning: boolean;
-    // Flag which is used to check if new requests were recieved during timer awaiting.
+    // Flag which is used to check if new requests were received during timer awaiting.
     private isNewRequest: boolean;
-
-    // http or https module to make requestst to Che API.
-    private pinger: { request(option: http.RequestOptions): http.ClientRequest };
-    private activityRequestOptions: http.RequestOptions;
 
     @inject(CheApiService)
     protected cheApiService: CheApiService;
 
     constructor() {
-        const workspaceId = process.env[ActivityTrackerServiceImpl.WORKSPACE_ID_ENV_VAR_NAME];
-        if (!workspaceId) {
-            throw new Error('Cannot retrieve workspace ID');
-        }
-
-        const apiUrlString = process.env[ActivityTrackerServiceImpl.CHE_API_ENV_VAR_NAME];
-        if (!apiUrlString) {
-            throw new Error('Cannot retrieve Che API uri');
-        }
-
-        const apiUrl = new URI(apiUrlString);
-        this.activityRequestOptions = {
-            path: apiUrl.path + '/activity/' + workspaceId,
-            method: 'PUT'
-        };
-        const authorityColonPos = apiUrl.authority.indexOf(':');
-        if (authorityColonPos === -1) {
-            this.activityRequestOptions.hostname = apiUrl.authority;
-            this.activityRequestOptions.port = apiUrl.scheme === 'http' ? 80 : 443;
-        } else {
-            this.activityRequestOptions.hostname = apiUrl.authority.substring(0, authorityColonPos);
-            this.activityRequestOptions.port = apiUrl.authority.substring(authorityColonPos + 1);
-        }
-
-        const token = process.env[ActivityTrackerServiceImpl.MACHINE_TOKEN_ENV_VAR_NAME];
-        if (token) {
-            this.activityRequestOptions.headers = { 'Authorization': 'Bearer ' + token };
-        }
-
-        this.pinger = apiUrl.scheme === 'http' ? require('http') : require('https');
-
         this.isTimerRunning = false;
         this.isNewRequest = false;
     }
@@ -120,15 +79,14 @@ export class ActivityTrackerServiceImpl implements ActivityTrackerService {
 
     private sendRequest(attemptsLeft: number = ActivityTrackerServiceImpl.RETRY_COUNT): void {
         this.cheApiService.submitTelemetryActivity();
-        const request = this.pinger.request(this.activityRequestOptions);
-        request.on('error', (error: Error) => {
+        try {
+            this.cheApiService.updateWorkspaceActivity();
+        } catch (error) {
             if (attemptsLeft > 0) {
                 setTimeout(() => this.sendRequest(), ActivityTrackerServiceImpl.RETRY_REQUEST_PERIOD_MS, --attemptsLeft);
             } else {
                 console.error('Activity tracker: Failed to ping workspace master: ', error.message);
             }
-        });
-        request.end();
+        }
     }
-
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -456,6 +456,7 @@ export interface CheApiService {
     findUniqueServerByAttribute(attributeName: string, attributeValue: string): Promise<cheApi.workspace.Server>;
 
     updateWorkspace(workspaceId: string, workspace: cheApi.workspace.Workspace): Promise<cheApi.workspace.Workspace>;
+    updateWorkspaceActivity(): Promise<void>;
     stop(): Promise<void>;
 
     getFactoryById(factoryId: string): Promise<cheApi.factory.Factory>;

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-api-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-api-service.ts
@@ -118,6 +118,16 @@ export class CheApiServiceImpl implements CheApiService {
         }
     }
 
+    async updateWorkspaceActivity(): Promise<void> {
+        try {
+            const cheApiClient = await this.getCheApiClient();
+            return cheApiClient.updateActivity(this.getWorkspaceIdFromEnv());
+        } catch (e) {
+            console.error(e);
+            throw new Error(e);
+        }
+    }
+
     async stop(): Promise<void> {
         const workspaceId = process.env.CHE_WORKSPACE_ID;
         if (!workspaceId) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -222,9 +222,9 @@
     "@eclipse-che/api" latest
 
 "@eclipse-che/workspace-client@latest":
-  version "0.0.1-1584656304"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1584656304.tgz#01c8668bed6d207bcadcef1464df13c51c83791e"
-  integrity sha512-QW/5UZukOY2yx5W5VKSxgHVE2+u901frZ5oGJkxiqoHUezsFauuc1lx+Dit5locJuCaV0Bnl1q1/99sq8luEfw==
+  version "0.0.1-1585324232"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1585324232.tgz#2d9c6d8b7b760173f3e194251196961150c3965d"
+  integrity sha512-65ZCRhdtG1oWYZdrCCVx9r5dk37ApTDY/xpBDjpCY6hfkMAnAUXb8PHqnm54SaqtGahojajobOBxPs2IZGKrDQ==
   dependencies:
     "@eclipse-che/api" "^7.0.0-beta-4.0"
     axios "0.19.0"
@@ -4386,7 +4386,7 @@ debug@3.1.0, debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -4608,7 +4608,7 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-detect-libc@^1.0.2, detect-libc@^1.0.3:
+detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -6406,7 +6406,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -9143,15 +9143,6 @@ ncp@~2.0.0:
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
-needle@^2.2.1:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.3.tgz#a041ad1d04a871b0ebb666f40baaf1fb47867117"
-  integrity sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -9288,22 +9279,6 @@ node-notifier@^5.2.1, node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 noop-logger@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
@@ -9404,7 +9379,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -9436,7 +9411,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npmlog@^4.0.1, npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.0.1, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -10410,7 +10385,7 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.1.6, rc@^1.2.7:
+rc@^1.1.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -11742,7 +11717,7 @@ tar-stream@^1.1.2, tar-stream@^1.5.0, tar-stream@^1.5.2:
     to-buffer "^1.1.1"
     xtend "^4.0.0"
 
-tar@^4.0.0, tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.0.0, tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Reworks activity-tracker extension to work with Che Server over TLS.
Instead of requesting Che API directly, activity-tracker extension will use [che-workspace-client](https://github.com/eclipse/che-workspace-client) which is already [configured in a proper way](https://github.com/eclipse/che-workspace-client/blob/7dfadc9105f9accd6917f5027f8ab81d01a7a072/src/index.ts#L55-L105).

### What issues does this PR fix or reference?
closes https://github.com/eclipse/che/issues/15991

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
