### PR TITLE
Update monaco-editor-core dependency

### DIFF
--- a/generator/src/conf/.yarnclean
+++ b/generator/src/conf/.yarnclean
@@ -32,7 +32,7 @@ monaco-css
 react-dom
 font-awesome
 monaco-html
-@typefox/monaco-editor-core
+@theia/monaco-editor-core
 @theia/terminal/node_modules/xterm/dist/xterm.js
 
 # MD files

--- a/generator/src/init.ts
+++ b/generator/src/init.ts
@@ -20,7 +20,7 @@ import { Logger } from './logger';
  */
 export class Init {
     public static readonly GET_PACKAGE_WITH_VERSION_CMD = 'yarn --json --non-interactive --no-progress list --pattern=';
-    public static readonly MONACO_CORE_PKG = '@typefox/monaco-editor-core';
+    public static readonly MONACO_CORE_PKG = '@theia/monaco-editor-core';
     public static readonly MONACO_HTML_CONTRIB_PKG = 'monaco-html';
     public static readonly MONACO_CSS_CONTRIB_PKG = 'monaco-css';
 

--- a/generator/src/production.ts
+++ b/generator/src/production.ts
@@ -40,7 +40,7 @@ export class Production {
         'react-dom',
         'font-awesome',
         'monaco-html',
-        '@typefox/monaco-editor-core'];
+        '@theia/monaco-editor-core'];
 
     private dependencies: string[] = [];
     private toCopyFiles: string[] = [];


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

### What does this PR do?
After upgrade `monaco` version in upstream `monaco-editor-core` comes from `theia`, not from `typefox`.
So, I think, we should update it for `che-theia`.

