### PR TITLE
Add robustness in CDN support,when CDN URLs trigger client-side errors (#15382 Fix)

### DIFF
--- a/generator/src/cdn/base.ts
+++ b/generator/src/cdn/base.ts
@@ -91,7 +91,7 @@ export class CheCdnSupport {
                 request.open('HEAD', withCDN, false);
                 request.send();
             } catch (err) {
-                console.log("Error trying to access the CDN artifact '" + withCDN + "' : " + err);
+                console.log(`Error trying to access the CDN artifact '${withCDN}' : ${err}`);
                 this.noCDN = true;
             }
         }

--- a/generator/src/cdn/base.ts
+++ b/generator/src/cdn/base.ts
@@ -87,8 +87,13 @@ export class CheCdnSupport {
                     result = withCDN;
                 }
             };
-            request.open('HEAD', withCDN, false);
-            request.send();
+            try {
+                request.open('HEAD', withCDN, false);
+                request.send();
+            } catch (err) {
+                console.log("Error trying to access the CDN artifact '" + withCDN + "' : " + err);
+                this.noCDN = true;
+            }
         }
         return result;
     }


### PR DESCRIPTION
### What does this PR do?

This PR catches exceptions on synchronous HEAD requests used for CDN availability tests, and disable CDN in this case.

This is important to avoid breaking the editor when CDN URLs
fail with either timeout or browser-side errors
(DNS, CORS, etc ...)

### What issues does this PR fix or reference?

This PR fixes issue https://github.com/eclipse/che/issues/15382

This would be important to include this fix in CRW 2.1, since we just enabled CDN support on CRW for the 2.1 release.
