### PR TITLE
Do not display Plugins widget of Theia 

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-frontend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-frontend-module.ts
@@ -30,7 +30,7 @@ import {
     ChePluginServiceClient
 } from '../common/che-plugin-protocol';
 import { ChePluginServiceClientImpl } from './plugin/che-plugin-service-client';
-import { WebSocketConnectionProvider, bindViewContribution, WidgetFactory } from '@theia/core/lib/browser';
+import { WebSocketConnectionProvider, WidgetFactory } from '@theia/core/lib/browser';
 import { CommandContribution, ResourceResolver } from '@theia/core/lib/common';
 import { CheTaskClientImpl } from './che-task-client';
 import { ChePluginViewContribution } from './plugin/che-plugin-view-contribution';
@@ -46,6 +46,7 @@ import { MiniBrowserOpenHandler } from '@theia/mini-browser/lib/browser/mini-bro
 import { WebviewEnvironment } from '@theia/plugin-ext/lib/main/browser/webview/webview-environment';
 import { CheWebviewEnvironment } from './che-webview-environment';
 import { TaskStatusHandler } from './task-status-handler';
+import { PluginFrontendViewContribution } from '@theia/plugin-ext/lib/main/browser/plugin-frontend-view-contribution';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(CheApiProvider).toSelf().inSingletonScope();
@@ -78,7 +79,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(ChePluginFrontentService).toSelf().inSingletonScope();
     bind(ChePluginManager).toSelf().inSingletonScope();
 
-    bindViewContribution(bind, ChePluginViewContribution);
+    rebind(PluginFrontendViewContribution).to(ChePluginViewContribution);
 
     bind(ChePluginMenu).toSelf().inSingletonScope();
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
@@ -15,12 +15,11 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
-import { MenuModelRegistry, CommandRegistry, CommandContribution } from '@theia/core/lib/common';
+import { CommandRegistry, CommandContribution } from '@theia/core/lib/common';
 import { MessageService, Command } from '@theia/core/lib/common';
 import { ChePluginManager } from './che-plugin-manager';
-import { CommonMenus, QuickInputService } from '@theia/core/lib/browser';
+import { QuickInputService } from '@theia/core/lib/browser';
 import { MonacoQuickOpenService } from '@theia/monaco/lib/browser/monaco-quick-open-service';
-import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
 
 function cmd(id: string, label: string): Command {
     return {
@@ -58,23 +57,6 @@ export class ChePluginCommandContribution implements CommandContribution {
     @inject(ChePluginManager)
     protected readonly chePluginManager: ChePluginManager;
 
-    /**
-     * TEMPORARY SOLUTION
-     *
-     * Following code removes 'View/Plugins' menu item and the command that displays/hides Plugins view.
-     * In the future we will try to refactor Che Plugins view and move it to the 'plugin-ext'.
-     */
-    constructor(
-        @inject(MenuModelRegistry) menuModelRegistry: MenuModelRegistry,
-        @inject(CommandRegistry) commandRegistry: CommandRegistry,
-        @inject(FrontendApplicationStateService) stateService: FrontendApplicationStateService
-    ) {
-        stateService.reachedState('initialized_layout').then(() => {
-            menuModelRegistry.unregisterMenuAction('pluginsView:toggle', CommonMenus.VIEW_VIEWS);
-            commandRegistry.unregisterCommand('pluginsView:toggle');
-        });
-    }
-
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(ChePluginManagerCommands.ADD_REGISTRY, {
             execute: () => this.addPluginRegistry()
@@ -109,5 +91,4 @@ export class ChePluginCommandContribution implements CommandContribution {
 
         this.chePluginManager.addRegistry(registry);
     }
-
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-view.tsx
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-view.tsx
@@ -14,9 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from 'inversify';
+import { injectable, inject, postConstruct } from 'inversify';
 import { Message } from '@phosphor/messaging';
-import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { AlertMessage } from '@theia/core/lib/browser/widgets/alert-message';
 import * as React from 'react';
 import { ChePlugin } from '../../common/che-plugin-protocol';
@@ -26,6 +25,7 @@ import { ChePluginMenu } from './che-plugin-menu';
 import { ConfirmDialog } from '@theia/core/lib/browser';
 import { ChePluginViewToolbar } from './che-plugin-view-toolbar';
 import { ChePluginViewList } from './che-plugin-view-list';
+import { PluginWidget } from '@theia/plugin-ext/lib/main/browser/plugin-ext-widget';
 
 export type PluginViewState =
     'updating_cache' |
@@ -34,7 +34,7 @@ export type PluginViewState =
     'failed';
 
 @injectable()
-export class ChePluginView extends ReactWidget {
+export class ChePluginView extends PluginWidget {
 
     protected initialized = false;
 
@@ -58,34 +58,7 @@ export class ChePluginView extends ReactWidget {
     ) {
         super();
         this.id = 'che-plugins';
-        this.title.label = 'Plugins';
-        this.title.caption = 'Plugins';
         this.title.iconClass = 'fa che-plugins-tab-icon';
-        this.title.closable = true;
-        this.addClass('theia-plugins');
-
-        this.node.tabIndex = 0;
-
-        chePluginManager.onWorkspaceConfigurationChanged(
-            needToRestart => this.onWorkspaceConfigurationChanged());
-
-        chePluginManager.onPluginRegistryListChanged(
-            () => this.updateCache());
-
-        chePluginMenu.onChangeFilter(
-            filter => this.onChangeFilter(filter));
-
-        chePluginMenu.onRefreshPluginList(
-            () => this.updateCache());
-
-        chePluginServiceClient.onPluginCacheSizeChanged(
-            plugins => this.onPluginCacheSizeChanged(plugins));
-
-        chePluginServiceClient.onPluginCached(
-            plugins => this.onPluginCached(plugins));
-
-        chePluginServiceClient.onCachingComplete(
-            () => this.onCachingComplete());
 
         this.node.ondrop = event => {
             event.preventDefault();
@@ -98,9 +71,15 @@ export class ChePluginView extends ReactWidget {
         };
     }
 
-    protected onActivateRequest(msg: Message) {
-        super.onActivateRequest(msg);
-        this.node.focus();
+    @postConstruct()
+    protected init(): void {
+        this.toDispose.push(this.chePluginManager.onWorkspaceConfigurationChanged(needToRestart => this.onWorkspaceConfigurationChanged()));
+        this.toDispose.push(this.chePluginManager.onPluginRegistryListChanged(() => this.updateCache()));
+        this.toDispose.push(this.chePluginMenu.onChangeFilter(filter => this.onChangeFilter(filter)));
+        this.toDispose.push(this.chePluginMenu.onRefreshPluginList(() => this.updateCache()));
+        this.toDispose.push(this.chePluginServiceClient.onPluginCacheSizeChanged(plugins => this.onPluginCacheSizeChanged(plugins)));
+        this.toDispose.push(this.chePluginServiceClient.onPluginCached(plugins => this.onPluginCached(plugins)));
+        this.toDispose.push(this.chePluginServiceClient.onCachingComplete(() => this.onCachingComplete()));
     }
 
     protected onAfterShow(msg: Message) {


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

### What does this PR do?
Recently we found that `Plugins` view doesn't display any plugins: https://github.com/eclipse/che/issues/16452

As it turned out, we have two `Plugins` widgets:
- one comes from `Theia`
- we provide another one to display `Che` plugins

At the moment it's still possible to open both widgets, `View`-> `Open View` displays two `Plugins` items with the same label.
Please see the current behavior for `master` branch:

![Plugins_view_master](https://user-images.githubusercontent.com/5676062/78507307-074d8580-7788-11ea-8aa0-755cd83aa479.gif)

There is an issue to remove `Theia` `Plugins` widget and display `Che` `Plugins` view only: https://github.com/eclipse/che/issues/13670

I can see two approaches to resolve the issue:
- `che` widget extends `theia` widget and we can apply `rebind` (`PluginFrontendViewContribution` of `theia` by `ChePluginViewContribution`)
This way allows us to remove a [temporary solution](https://github.com/eclipse/che-theia/pull/425/files) as well. 
- another one: we keep a [temporary solution](https://github.com/eclipse/che-theia/pull/425/files) + provide the ability to unregister the corresponding item from `QuickViewService` of `theia`. 

The current PR is applying the first approach, but proposals and constructive criticism are welcome!

![Plugins_after_update](https://user-images.githubusercontent.com/5676062/78507744-880d8100-778a-11ea-814d-c82147ba518c.gif)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16452
https://github.com/eclipse/che/issues/13670

