### PR TITLE
Apply singleton scope for BrowserRemoteHostedPluginSupport

### DIFF
--- a/extensions/eclipse-che-theia-plugin-remote/src/browser/plugin-remote-frontend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/browser/plugin-remote-frontend-module.ts
@@ -14,7 +14,7 @@ import { HostedPluginSupport } from '@theia/plugin-ext/lib/hosted/browser/hosted
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
-    bind(BrowserRemoteHostedPluginSupport).toSelf();
+    bind(BrowserRemoteHostedPluginSupport).toSelf().inSingletonScope();
     rebind(HostedPluginSupport).toService(BrowserRemoteHostedPluginSupport);
 
 });


### PR DESCRIPTION
### What does this PR do?
I noticed that `BrowserRemoteHostedPluginSupport` is created a few times.
But it should be a singleton.

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>