### PR TITLE
Update dependencies

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/package.json
+++ b/extensions/eclipse-che-theia-plugin-ext/package.json
@@ -21,6 +21,7 @@
     "@theia/plugin-ext": "next",
     "axios": "0.19.0",
     "tunnel": "0.0.6",
+    "vscode-uri": "2.1.1",
     "js-yaml": "3.13.1",
     "@eclipse-che/workspace-telemetry-client": "latest"
   },

--- a/extensions/eclipse-che-theia-plugin-remote/package.json
+++ b/extensions/eclipse-che-theia-plugin-remote/package.json
@@ -11,7 +11,8 @@
     "@theia/core": "next",
     "@theia/plugin-ext": "next",
     "@theia/plugin-ext-vscode": "next",
-    "deasync": "^0.1.19"
+    "deasync": "^0.1.19",
+    "vscode-uri": "2.1.1"
   },
   "devDependencies": {
     "@types/deasync": "^0.1.0",

--- a/extensions/eclipse-che-theia-terminal/package.json
+++ b/extensions/eclipse-che-theia-terminal/package.json
@@ -23,7 +23,8 @@
     "@theia/terminal": "next",
     "reconnecting-websocket": "^4.2.0",
     "@eclipse-che/workspace-client": "latest",
-    "@eclipse-che/api": "latest"
+    "@eclipse-che/api": "latest",
+    "vscode-ws-jsonrpc": "0.2.0"
   },
   "license": "EPL-2.0",
   "devDependencies": {

--- a/plugins/task-plugin/package.json
+++ b/plugins/task-plugin/package.json
@@ -65,8 +65,8 @@
   "dependencies": {
     "inversify": "4.14.0",
     "reflect-metadata": "0.1.8",
-    "vscode-uri": "1.0.5",
-    "vscode-ws-jsonrpc": "^0.1.1",
+    "vscode-uri": "2.1.1",
+    "vscode-ws-jsonrpc": "0.2.0",
     "ws": "^5.2.2",
     "jsonc-parser": "^2.0.2"
   }

--- a/plugins/task-plugin/src/variable/project-path-variable-resolver.ts
+++ b/plugins/task-plugin/src/variable/project-path-variable-resolver.ts
@@ -9,7 +9,7 @@
  **********************************************************************/
 
 import { injectable } from 'inversify';
-import Uri from 'vscode-uri';
+import { URI as Uri } from 'vscode-uri';
 import * as che from '@eclipse-che/plugin';
 import * as theia from '@theia/plugin';
 import * as startPoint from '../task-plugin-backend';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12504,11 +12504,6 @@ vscode-debugprotocol@^1.32.0:
   resolved "https://registry.yarnpkg.com/vscode-debugprotocol/-/vscode-debugprotocol-1.40.0.tgz#63e1f670a6f5c4928f3f91b27b259a21c4db7861"
   integrity sha512-Fwze+9qbLDPuQUhtITJSu/Vk6zIuakNM1iR2ZiZRgRaMEgBpMs2JSKaT0chrhJHCOy6/UbpsUbUBIseF6msV+g==
 
-vscode-jsonrpc@^4.1.0-next:
-  version "4.1.0-next.3"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.3.tgz#05fe742959a2726020d4d0bfbc3d3c97873c7fde"
-  integrity sha512-Z6oxBiMks2+UADV1QHXVooSakjyhI+eHTnXzDyVvVMmegvSfkXk2w6mPEdSkaNHFBdtWW7n20H1yw2nA3A17mg==
-
 vscode-jsonrpc@^5.0.0, vscode-jsonrpc@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
@@ -12547,24 +12542,12 @@ vscode-textmate@^4.0.1:
   dependencies:
     oniguruma "^7.2.0"
 
-vscode-uri@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.5.tgz#3b899a8ef71c37f3054d79bdbdda31c7bf36f20d"
-  integrity sha1-O4majvccN/MFTXm9vdoxx7828g0=
-
-vscode-uri@^2.1.1:
+vscode-uri@2.1.1, vscode-uri@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.1.tgz#5aa1803391b6ebdd17d047f51365cf62c38f6e90"
   integrity sha512-eY9jmGoEnVf8VE8xr5znSah7Qt1P/xsCdErz+g8HYZtJ7bZqKH5E3d+6oVNm1AC/c6IHUDokbmVXKOi4qPAC9A==
 
-vscode-ws-jsonrpc@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-0.1.1.tgz#163ff05662635b4fd161ed132e112cec4d83f126"
-  integrity sha512-1O/FUORbb8dZAvh9AFF6HViLJ0Ja0RbF+sFRnUsoqkuKIRsXDDiiJpwYwT6fmglCLefE5afGPw9NoHvDVN/5yw==
-  dependencies:
-    vscode-jsonrpc "^4.1.0-next"
-
-vscode-ws-jsonrpc@^0.2.0:
+vscode-ws-jsonrpc@0.2.0, vscode-ws-jsonrpc@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-0.2.0.tgz#5e9c26e10da54a1a235da7d59e74508bbcb8edd9"
   integrity sha512-NE9HNRgPjCaPyTJvIudcpyIWPImxwRDtuTX16yks7SAiZgSXigxAiZOvSvVBGmD1G/OMfrFo6BblOtjVR9DdVA==


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

### What does this PR do?
- upgrade `vscode-uri` version to `^2.1.1` for `task-plugin`
- upgrade `vscode-ws-jsonrpc` to `^0.2.0` for `task-plugin`
- define explicitly `vscode-uri` and `vscode-ws-jsonrpc` in the corresponding `package.json` files  

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16552

