### PR TITLE
Fix incorrect usage of THEIA_GIT_REFS env. variable

### DIFF
--- a/dockerfiles/theia/README.md
+++ b/dockerfiles/theia/README.md
@@ -60,7 +60,7 @@ Parameter `${GITHUB_TOKEN}` is optional. It's necessary only when exceeding the 
 
 **`${THEIA_BRANCH}`**
 
-It specifies tag or branch for base Theia. Build script clones Theia sources, switches to that branch/tag, and only then clones Che-Theia.
+It specifies tag or branch for upstream Theia. Build script clones Theia sources, switches to that branch/tag, and only then clones Che-Theia.
 
 Parameter `${THEIA_BRANCH}` is optional. If it's not specified, the default value `'master'` will be used.
 
@@ -93,11 +93,11 @@ A newly created docker image will have this version. Passing `'--tag:1.0.0'` to 
 
 Parameter `${IMAGE_TAG}` is optioal. If it's not specified, the default value `'next'` will be used.
 
-## Theia Git Prefs
+## Theia Git refs
 
 **`${THEIA_GIT_REFS}`**
 
-Is used to invalidate docker cache when the current che-theia branch has been changed after last build of the dockerfile. If you are building che-theia from your branch, you have to set refs to `'refs\\/heads\\/${THE_BRANCH_NAME}'`.
+Is used to invalidate docker cache when upstream Theia has been changed in branch `${THEIA_BRANCH}` after last build of the image. If you are building che-theia based on upstream Theia from your branch, you have to set refs to `'refs\\/heads\\/${THEIA_BRANCH}'`.
 
 This parameter is optional. Default value is `'refs\\/heads\\/master'`.
 

--- a/set_theia_version.sh
+++ b/set_theia_version.sh
@@ -71,8 +71,6 @@ change_change_che_theia_init_baranch () {
         fi
     done < "che-theia-init-sources.yml";
     printf "%b\n" "$content" > "che-theia-init-sources.yml";
-
-    sed -i 's~@api.github.com/repos/eclipse/che-theia/git/${GIT_REF}~@api.github.com/repos/eclipse/che-theia/git/refs/heads/'${branchName}'~' ./dockerfiles/theia/Dockerfile 
 }
 
 # first is path to dir which contains 'package.json', second is Theia version


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes incorrect usage of `THEIA_GIT_REFS` env. variable.
`THEIA_GIT_REFS` env. variable is used for invalidating docker cache when upstream Theia has been changed.
But there're some places when the variable is used as if it relates to `eclipse/che-theia` repo.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
