### PR TITLE
Add robustness in CDN support,when CDN URLs trigger client-side errors (#15382 Fix)

### DIFF
--- a/generator/src/cdn/base.ts
+++ b/generator/src/cdn/base.ts
@@ -87,8 +87,13 @@ export class CheCdnSupport {
                     result = withCDN;
                 }
             };
-            request.open('HEAD', withCDN, false);
-            request.send();
+            try {
+                request.open('HEAD', withCDN, false);
+                request.send();
+            } catch (err) {
+                console.log(`Error trying to access the CDN artifact '${withCDN}' : ${err}`);
+                this.noCDN = true;
+            }
         }
         return result;
     }


### PR DESCRIPTION
### What does this PR do?

This PR catches exceptions on synchronous HEAD request and disable CDN.

This is important to avoid breaking the editor when CDN URLs
fail with either timeout or browser-side errors
(DNS, CORS, etc ...)

Signed-off-by: David Festal <dfestal@redhat.com>

Co-authored-by: Florent BENOIT <fbenoit@redhat.com>
(cherry picked from commit 4ae1b217371a6de6ca8f167ed9dc96c46f5d5fe4)

### What issues does this PR fix or reference?

This PR fixes issue eclipse/che#15382