### PR TITLE
Optimize Dockerfiles to remove the redundant steps in the release script

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -72,21 +72,6 @@ Set `master` to the following rows:
 THEIA_VERSION="master"
 ```
 
-- `dockerfiles/theia/Dockerfile`
-
-Set `THEIA_VERSION` to `master`:
-
-```
-ARG THEIA_VERSION=master
-```
-
-- `dockerfiles/theia-dev/e2e/Dockerfile`
-
-Set the branch to `master`, in cloning command:
-```
-RUN git clone -b 'master' --single-branch --depth 1 https://github.com/eclipse-theia/theia theia
-```
-
 - `dockerfiles/theia/docker/alpine/builder-clone-theia.dockerfile`
 
 Replace with the following to checkout to the specified commit: 

--- a/dockerfiles/theia-dev/e2e/Dockerfile
+++ b/dockerfiles/theia-dev/e2e/Dockerfile
@@ -13,7 +13,7 @@ ARG GITHUB_TOKEN=''
 ENV GITHUB_TOKEN=$GITHUB_TOKEN
 
 # Just try to build the latest theia with current image
-RUN git clone -b 'master' --single-branch --depth 1 https://github.com/eclipse-theia/theia theia
+RUN git clone -b ${GIT_BRANCH_NAME} --single-branch --depth 1 https://github.com/eclipse-theia/theia theia
 
 # setup extra step
 #{INCLUDE:docker/${BUILD_IMAGE_TARGET}/post-clone.dockerfile}

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -20,9 +20,6 @@ ENV GITHUB_TOKEN=$GITHUB_TOKEN
 
 ARG THEIA_GITHUB_REPO=eclipse-theia/theia
 
-# Define upstream version of theia to use
-ARG THEIA_VERSION=master
-
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 #{IF:DO_REMOTE_CHECK}

--- a/set_theia_version.sh
+++ b/set_theia_version.sh
@@ -93,9 +93,6 @@ ask_for_change_che_theia_init_baranch
 
 read -p "Enter Theia version : "  theiaVersion
 
-sed -i -e "s/RUN git clone -b 'master'/RUN git clone -b 'v${theiaVersion}'/" ./dockerfiles/theia-dev/e2e/Dockerfile
-sed -i -e "s/ARG THEIA_VERSION=..*/ARG THEIA_VERSION=${theiaVersion}/" ./dockerfiles/theia/Dockerfile
-
 for dir in extensions/*
 do
     echo ${dir}


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds a couple of minor optimizations to the Dockerfiles in order to get rid of the redundant steps in the existing release script and to avoid it in the new one I'm currently working on.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
