### PR TITLE
chore(github): Add GH action that allow to use parallel builds

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# Che-Theia workflow
+# matrix jobs with alpine and ubi8
+name: CI
+
+# Trigger the workflow on push or pull request
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        dist: [ 'alpine', 'ubi8' ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout che-theia source code
+    - uses: actions/setup-node@v1
+      name: Configuring nodejs 10.x version
+      with:
+        node-version: '10.x'
+    - name: build
+      run: ./build.sh --build-args:THEIA_VERSION=master --tag:next --branch:master --git-ref:refs\\/heads\\/master --dockerfile:Dockerfile.${{matrix.dist}}


### PR DESCRIPTION
### What does this PR do?
Introduce as experimental usage of github action for PR-build-check

It should be much more faster than ci.centos to perform the build check as we can use matrix jobs (and then build in parallel) and we don't need to setup the image/install software to run docker builds, etc.

if it works well, then we could switch to this check

### What issues does this PR fix or reference?
N/A

Change-Id: I19f9db266294cd68e99a7d7c5b0e57ceaafae17a
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

