### PR TITLE
fix(nodejs): bump nodejs and alpine/ubi8 versions

### DIFF
--- a/dockerfiles/theia-dev/docker/alpine/builder-image-from.dockerfile
+++ b/dockerfiles/theia-dev/docker/alpine/builder-image-from.dockerfile
@@ -1,1 +1,1 @@
-FROM node:10.19.0-alpine3.11
+FROM node:10.20.1-alpine3.11

--- a/dockerfiles/theia-dev/docker/ubi8/builder-image-from.dockerfile
+++ b/dockerfiles/theia-dev/docker/ubi8/builder-image-from.dockerfile
@@ -1,2 +1,2 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10
-FROM registry.access.redhat.com/ubi8/nodejs-10:1-66
+FROM registry.access.redhat.com/ubi8/nodejs-10:1-81

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/runtime-from.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/runtime-from.dockerfile
@@ -1,1 +1,1 @@
-FROM alpine:3.10.2 as runtime
+FROM alpine:3.11.5 as runtime

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/runtime-from.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/runtime-from.dockerfile
@@ -1,2 +1,2 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.1-398 as runtime
+FROM registry.access.redhat.com/ubi8-minimal:8.1-409 as runtime

--- a/dockerfiles/theia/docker/alpine/runtime-from.dockerfile
+++ b/dockerfiles/theia/docker/alpine/runtime-from.dockerfile
@@ -1,1 +1,1 @@
-FROM node:10.19.0-alpine3.11 as runtime
+FROM node:10.20.1-alpine3.11 as runtime

--- a/dockerfiles/theia/docker/ubi8/runtime-from.dockerfile
+++ b/dockerfiles/theia/docker/ubi8/runtime-from.dockerfile
@@ -1,2 +1,2 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10
-FROM registry.access.redhat.com/ubi8/nodejs-10:1-66 as runtime
+FROM registry.access.redhat.com/ubi8/nodejs-10:1-81 as runtime


### PR DESCRIPTION
### What does this PR do?
bump nodejs and alpine/ubi8 versions

### What issues does this PR fix or reference?
Fix https://github.com/eclipse/che/issues/16599

Change-Id: Ic2499fe22dae84a7ce855f7a6cc8ab81005a2892
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
