### PR TITLE
Reanimates the plugin manager for workspace created from minimal devfile

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -469,15 +469,17 @@ export class ChePluginServiceImpl implements ChePluginService {
         } else if (workspace.devfile) {
             const plugins: string[] = [];
 
-            workspace.devfile.components!.forEach(component => {
-                if (component.type === 'chePlugin') {
-                    if (component.reference) {
-                        plugins.push(this.normalizeId(component.reference));
-                    } else if (component.id) {
-                        plugins.push(component.id);
+            if (workspace.devfile.components) {
+                workspace.devfile.components.forEach(component => {
+                    if (component.type === 'chePlugin') {
+                        if (component.reference) {
+                            plugins.push(this.normalizeId(component.reference));
+                        } else if (component.id) {
+                            plugins.push(component.id);
+                        }
                     }
-                }
-            });
+                });
+            }
 
             return plugins;
         }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes running of plugin manager when the workspace is created from devfile like this
```
apiVersion: 1.0.0
components: []
projects: []
metadata:
  name: wksp-custom-m8zf
```

Solves issue https://github.com/eclipse/che/issues/16519

