### PR TITLE
Remove unnecessary console output when loading a list of plugins

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -108,7 +108,6 @@ export class ChePluginServiceImpl implements ChePluginService {
 
     private getAxiosInstance(): AxiosInstance {
         if (!this.isItNode()) {
-            this.addLogInterceptorsIfEnabled(axios);
             return axios;
         }
 
@@ -141,21 +140,18 @@ export class ChePluginServiceImpl implements ChePluginService {
                 } else {
                     axiosRequestConfig.httpAgent = proxyIsHttps ? httpOverHttpsAgent : httpOverHttpAgent;
                 }
-                const axiosInstance = axios.create(axiosRequestConfig);
-                this.addLogInterceptorsIfEnabled(axiosInstance);
-                return axiosInstance;
+                return axios.create(axiosRequestConfig);
             }
         }
+
         if (certificateAuthority) {
-            const axiosInstance = axios.create({
+            return axios.create({
                 httpsAgent: new https.Agent({
                     ca: certificateAuthority
                 })
             });
-            this.addLogInterceptorsIfEnabled(axiosInstance);
-            return axiosInstance;
         }
-        this.addLogInterceptorsIfEnabled(axios);
+
         return axios;
     }
 
@@ -198,18 +194,6 @@ export class ChePluginServiceImpl implements ChePluginService {
 
     private isItNode(): boolean {
         return (typeof process !== 'undefined') && (typeof process.versions.node !== 'undefined');
-    }
-
-    private addLogInterceptorsIfEnabled(axiosInstance: AxiosInstance): void {
-        axiosInstance.interceptors.request.use(request => {
-            console.log('Starting Request', request);
-            return request;
-        });
-
-        axiosInstance.interceptors.response.use(response => {
-            console.log('Response:', response);
-            return response;
-        });
     }
 
     private getCertificateAuthority(): Buffer | undefined {


### PR DESCRIPTION
Signed-off-by: Vitaliy Guliy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Cleanups the code, removes extra console output when Plugins view is reading the list ofplugins

![Screenshot from 2020-04-17 00-30-52](https://user-images.githubusercontent.com/1655894/79561048-52816580-80b1-11ea-8303-c0c829f4652a.png) 

### What issues does this PR fix or reference?
no issue, just cleanup the code
