### PR TITLE
chore(cleanup): Clean docker images before running the build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,4 +28,6 @@ jobs:
       with:
         node-version: '10.x'
     - name: build
-      run: ./build.sh --build-args:THEIA_VERSION=master --tag:next --branch:master --git-ref:refs\\/heads\\/master --dockerfile:Dockerfile.${{matrix.dist}}
+      run: |
+        docker image prune -a -f
+        ./build.sh --build-args:THEIA_VERSION=master --tag:next --branch:master --git-ref:refs\\/heads\\/master --dockerfile:Dockerfile.${{matrix.dist}}


### PR DESCRIPTION
### What does this PR do?
Cleanup github action node before running the build of theia

### What issues does this PR fix or reference?
previous github actions are failing with 'no space left on device'

Change-Id: I1b5549dfe46ffca88f67595da1e6f22b84aa6e45
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

