### PR TITLE
feat(docker): Optimize the build to be able to reuse cache layering

### DIFF
--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -33,7 +33,7 @@ ENV HOME=/home/theia-dev \
 #{INCLUDE:docker/${BUILD_IMAGE_TARGET}/post-env.dockerfile}
 
 # Define package of the theia generator to use
-COPY asset-eclipse-che-theia-generator.tgz ${HOME}/eclipse-che-theia-generator.tgz
+COPY asset-unpacked-generator ${HOME}/eclipse-che-theia-generator
 
 WORKDIR ${HOME}
 
@@ -44,8 +44,8 @@ EXPOSE 3000 3030
 RUN npm config set prefix "${HOME}/.npm-global" && \
     echo "--global-folder \"${HOME}/.yarn-global\"" > ${HOME}/.yarnrc && \
     # add eclipse che theia generator
-    yarn ${YARN_FLAGS} global add yo generator-code vsce @theia/generator-plugin@0.0.1-1562578105 file:${HOME}/eclipse-che-theia-generator.tgz && \
-    rm -rf ${HOME}/eclipse-che-theia-generator.tgz && \
+    yarn ${YARN_FLAGS} global add yo generator-code vsce @theia/generator-plugin@0.0.1-1562578105 file:${HOME}/eclipse-che-theia-generator && \
+    rm -rf ${HOME}/eclipse-che-theia-generator && \
     # Generate .passwd.template \
     cat /etc/passwd | \
     sed s#root:x.*#theia-dev:x:\${USER_ID}:\${GROUP_ID}::${HOME}:/bin/bash#g \

--- a/dockerfiles/theia-dev/build.sh
+++ b/dockerfiles/theia-dev/build.sh
@@ -32,5 +32,8 @@ fi
 echo "Copying Che Theia generator"
 cp "${CHE_THEIA_GENERATOR_PACKAGE}" "${base_dir}/asset-${CHE_THEIA_GENERATOR_PACKAGE_NAME}"
 
+rm -rf ${base_dir}/asset-unpacked-generator && mkdir ${base_dir}/asset-unpacked-generator
+tar zxf "${base_dir}/asset-${CHE_THEIA_GENERATOR_PACKAGE_NAME}" --strip-components=1 -C ${base_dir}/asset-unpacked-generator
+
 init --name:theia-dev "$@"
 build


### PR DESCRIPTION
### What does this PR do?

tgz was containing timestamp + owner + group properties which was different at each run on different platform
thus tgz never got the same checksum and then it's always invalidate

with this change using --cache-from could help


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16463


Change-Id: Ia3edc92cfeb932227dc603cd22e6dca89ec8ddc4
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
