### PR TITLE
chore(docker): Use --cache-from by default

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,4 +41,6 @@ jobs:
     - name: build
       run: |
         docker image prune -a -f
+        docker pull quay.io/eclipse/che-theia-dev:next
+        docker tag quay.io/eclipse/che-theia-dev:next eclipse/che-theia-dev:next
         ./build.sh --root-yarn-opts:--ignore-scripts --build-args:THEIA_VERSION=master --tag:next --branch:master --git-ref:refs\\/heads\\/master --dockerfile:Dockerfile.${{matrix.dist}}

--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -218,7 +218,7 @@ build_image() {
   done
 
   if ! dry_run; then
-    cd "${DIR}" && docker build -f ${DIR}/.Dockerfile -t ${IMAGE_NAME} ${BUILD_ARGS} ${DOCKER_BUILD_TARGET} .
+    cd "${DIR}" && docker build --cache-from ${IMAGE_NAME} -f ${DIR}/.Dockerfile -t ${IMAGE_NAME} ${BUILD_ARGS} ${DOCKER_BUILD_TARGET} .
     rm ${DIR}/.Dockerfile
   fi
   


### PR DESCRIPTION
### What does this PR do?
Use --cache-from by default when building images
basically, theia-dev image shouldn't be rebuilt if there is no change in generator or in Dockerfile of theia-dev

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16463


Change-Id: Iad02615369764934460406d978879bff863195f9
Signed-off-by: Florent Benoit <fbenoit@redhat.com>