### PR TITLE
allow to provide yarn root options on build.sh + new job in github action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,18 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  node-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout che-theia source code
+    - uses: actions/setup-node@v1
+      name: Configuring nodejs 10.x version
+      with:
+        node-version: '10.x'
+    - name: build
+      run: yarn
+  docker-build:
     strategy:
       matrix:
         dist: [ 'alpine', 'ubi8' ]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,4 +30,4 @@ jobs:
     - name: build
       run: |
         docker image prune -a -f
-        ./build.sh --build-args:THEIA_VERSION=master --tag:next --branch:master --git-ref:refs\\/heads\\/master --dockerfile:Dockerfile.${{matrix.dist}}
+        ./build.sh --root-yarn-opts:--ignore-scripts --build-args:THEIA_VERSION=master --tag:next --branch:master --git-ref:refs\\/heads\\/master --dockerfile:Dockerfile.${{matrix.dist}}

--- a/build.include
+++ b/build.include
@@ -16,8 +16,16 @@ THEIA_BRANCH="master"
 THEIA_GIT_REFS="refs\\/heads\\/master"
 THEIA_DOCKER_IMAGE_VERSION=
 
+prepare_yarn_root_args() {
+    IFS=',' read -r -a YARN_ARGS_ARRAY <<< "$@"
+    for i in ${YARN_ARGS_ARRAY[@]+"${YARN_ARGS_ARRAY[@]}"}; do
+    YARN_OPTS+="$i "
+    done
+}
+
 parse() {
   PUBLISH_IMAGES=false
+  YARN_OPTS=""
   FILTERED_ARGS=""
   while [ $# -gt 0 ]; do
     case $1 in
@@ -27,6 +35,10 @@ parse() {
       --push)
         PUBLISH_IMAGES=true
       shift ;;
+      --root-yarn-opts*:*)
+        ROOT_YARN_CSV="${1#*:}"
+        prepare_yarn_root_args $ROOT_YARN_CSV
+        shift ;;
       *)
         FILTERED_ARGS="${FILTERED_ARGS} $1"
       shift;;

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ set -e
 set -o pipefail
 
 parse "$@"
-yarn
+yarn ${YARN_OPTS}
 
 buildImages
 


### PR DESCRIPTION
### What does this PR do?
allow to provide yarn root options on build.sh: it's allowing us to skip lot of post-scripts from the first `yarn` call
When building the images we don't need to build all modules and to grab and build all native dependencies.

Then, add a new job to perform this check separately

one job to check full nodejs build of che-theia
two parallel jobs: one for alpine, one for ubi8


