### PR TITLE
feat(multi-arch): Avoid the usage of electron in our builds as electron is not available on all arch/platforms

### DIFF
--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -27,6 +27,7 @@ ENV HOME=/home/theia-dev \
     LOCAL_GIT_DIRECTORY=/usr \
     GIT_EXEC_PATH=/usr/libexec/git-core \
     THEIA_ELECTRON_SKIP_REPLACE_FFMPEG=true \
+    ELECTRON_SKIP_BINARY_DOWNLOAD=1 \
     YARN_FLAGS=""
 
 # setup extra stuff

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -59,6 +59,10 @@ RUN rm -rf ${HOME}/theia-source-code/examples/browser && \
     rm -rf ${HOME}/theia-source-code/packages/java-debug && \
     rm -rf ${HOME}/theia-source-code/packages/python && \
     rm -rf ${HOME}/theia-source-code/packages/typescript && \
+    # Allow the usage of ELECTRON_SKIP_BINARY_DOWNLOAD=1 by using a more recent version of electron \
+    sed -i 's|  "resolutions": {|  "resolutions": {\n    "**/electron": "7.0.0",|' ${HOME}/theia-source-code/package.json && \
+    # remove all electron-browser module to not compile them
+    find . -name "electron-browser"  | xargs rm -rf {} && \
     # Remove linter/formatters of theia
     sed -i 's|concurrently -n compile,lint -c blue,green \\"theiaext compile\\" \\"theiaext lint\\"|concurrently -n compile -c blue \\"theiaext compile\\"|' ${HOME}/theia-source-code/dev-packages/ext-scripts/package.json && \
     # Remove external configs removed


### PR DESCRIPTION
### What does this PR do?
When playing with multi-arch and theia I faced an issue with electron not being available on all platforms.
But as we don't need electron, let's remove all dependency from that.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16742

