### PR TITLE
fix(electron): really get rid of any electron dependency

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -63,6 +63,8 @@ RUN rm -rf ${HOME}/theia-source-code/examples/browser && \
     sed -i 's|  "resolutions": {|  "resolutions": {\n    "**/electron": "7.0.0",|' ${HOME}/theia-source-code/package.json && \
     # remove all electron-browser module to not compile them
     find . -name "electron-browser"  | xargs rm -rf {} && \
+    rm -rf ${HOME}/theia-source-code/dev-packages/electron/native && \
+    echo "" > ${HOME}/theia-source-code/dev-packages/electron/scripts/post-install.js && \
     # Remove linter/formatters of theia
     sed -i 's|concurrently -n compile,lint -c blue,green \\"theiaext compile\\" \\"theiaext lint\\"|concurrently -n compile -c blue \\"theiaext compile\\"|' ${HOME}/theia-source-code/dev-packages/ext-scripts/package.json && \
     # Remove external configs removed


### PR DESCRIPTION
### What does this PR do?
When playing with multi-arch and Theia I faced a new issue on electron being still accessed.
Get rid of it.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16742
https://github.com/eclipse/che-theia/pull/726

Change-Id: I8610a31ba58ae2b9a3e8afc49e0c542f5b286c66
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
