### PR TITLE
feat(docker-image): Add intermediate layer with result of the che-theia build

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -106,12 +106,16 @@ RUN if [ -z $GITHUB_TOKEN ]; then unset GITHUB_TOKEN; fi && \
 # Add yeoman generator & vscode git plug-ins
 COPY asset-untagged-theia_yeoman_plugin.theia /home/theia-dev/theia-source-code/production/plugins/theia_yeoman_plugin.theia
 
+
+# Use node image
+#{INCLUDE:docker/${BUILD_IMAGE_TARGET}/build-result-from.dockerfile}
+
+COPY --from=builder /home/theia-dev/theia-source-code/production /che-theia-build
+
 # change permissions
-RUN find production -exec sh -c "chgrp 0 {}; chmod g+rwX {}" \; 2>log.txt && \
+RUN find /che-theia-build -exec sh -c "chgrp 0 {}; chmod g+rwX {}" \; 2>log.txt && \
     # Add missing permissions on shell scripts of plug-ins
-    find /home/theia-dev/theia-source-code/production/plugins -name "*.sh" | xargs chmod +x
-
-
+    find /che-theia-build/plugins -name "*.sh" | xargs chmod +x
 
 ###
 # Runtime Image
@@ -136,7 +140,7 @@ ENV USE_LOCAL_GIT=true \
 
 EXPOSE 3100 3130
 
-COPY --from=builder /home/theia-dev/theia-source-code/production/plugins /default-theia-plugins
+COPY --from=build-result /che-theia-build/plugins /default-theia-plugins
 
 #{INCLUDE:docker/${BUILD_IMAGE_TARGET}/runtime-install-dependencies.dockerfile}
 
@@ -174,7 +178,7 @@ COPY --from=builder /home/theia-dev/theia-source-code/production/plugins /defaul
     # Change permissions to allow editing of files for openshift user
     && find ${HOME} -exec sh -c "chgrp 0 {}; chmod g+rwX {}" \;
 
-COPY --chown=theia:root --from=builder /home/theia-dev/theia-source-code/production /home/theia
+COPY --chown=theia:root --from=build-result /che-theia-build /home/theia
 USER theia
 WORKDIR /projects
 COPY src/entrypoint.sh /entrypoint.sh

--- a/dockerfiles/theia/docker/alpine/build-result-from.dockerfile
+++ b/dockerfiles/theia/docker/alpine/build-result-from.dockerfile
@@ -1,0 +1,1 @@
+FROM node:10.20.1-alpine3.11 as build-result

--- a/dockerfiles/theia/docker/ubi8/build-result-from.dockerfile
+++ b/dockerfiles/theia/docker/ubi8/build-result-from.dockerfile
@@ -1,0 +1,3 @@
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10
+FROM registry.access.redhat.com/ubi8/nodejs-10:1-81 as build-result
+USER root


### PR DESCRIPTION
### What does this PR do?
Use intermediate layer in the build so we can keep result of the build easily with `--target=build-result`

Change-Id: I0dc16416774553b724c3550d1c17e444ec4110ed
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

