### PR TITLE
Ignore warnings when self-signed certificates are used

### DIFF
--- a/devfiles/che-theia-all.devfile.yaml
+++ b/devfiles/che-theia-all.devfile.yaml
@@ -42,6 +42,9 @@ components:
     alias: theia-editor
     id: eclipse/che-theia/next
     memoryLimit: "1Gi"
+    env:
+      - name: NODE_TLS_REJECT_UNAUTHORIZED
+        value: "0"
 commands:
 
   - name: init ... DEV che-theia

--- a/devfiles/hosted-che-dogfooding.devfile.yaml
+++ b/devfiles/hosted-che-dogfooding.devfile.yaml
@@ -34,6 +34,9 @@ components:
     memoryLimit: 1500M
     type: cheEditor
     alias: theia-editor
+    env:
+      - name: NODE_TLS_REJECT_UNAUTHORIZED
+        value: "0"
 
   - type: chePlugin
     id: che-incubator/typescript/latest

--- a/devfiles/vscode-extensions.devfile.yaml
+++ b/devfiles/vscode-extensions.devfile.yaml
@@ -17,6 +17,9 @@ components:
   - id: eclipse/che-theia/next
     type: cheEditor
     alias: che-theia
+    env:
+      - name: NODE_TLS_REJECT_UNAUTHORIZED
+        value: "0"
 
   - alias: che-dev
     type: dockerimage


### PR DESCRIPTION
### What does this PR do?
This changes proposal configures `cheEditor` component to ignore warnings when self-signed certificates are used.

When `cheEditor` component is used, it needs to be modified by adding additional environment variable:

```
  - id: eclipse/che-theia/next
    type: cheEditor
    alias: che-theia
    env:
      - name: NODE_TLS_REJECT_UNAUTHORIZED
        value: "0"
```

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16604

#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
