### PR TITLE
feat(endpoint): Bump endpoint to the same version of nodejs than the current theia image

### DIFF
--- a/dockerfiles/theia-endpoint-runtime-binary/Dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/Dockerfile
@@ -8,7 +8,7 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
-FROM quay.io/eclipse/che-custom-nodejs-deasync:10.19.0-latest as custom-nodejs
+FROM quay.io/eclipse/che-custom-nodejs-deasync:10.20.1 as custom-nodejs
 
 FROM #{INCLUDE:docker/${BUILD_IMAGE_TARGET}/builder-from.dockerfile}
 


### PR DESCRIPTION
### What does this PR do?
bump from 10.19.0 to 10.21.0

### What issues does this PR fix or reference?
N/A

Change-Id: I4e5de0128752adff0bdd19b6789f463179b63fc6
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
