### PR TITLE
fix(requirements): stick to nodejs 10.0 api in plugin

### DIFF
--- a/generator/package.json
+++ b/generator/package.json
@@ -25,7 +25,7 @@
     "@types/jest": "25.2.1",
     "@types/js-yaml": "3.11.2",
     "@types/mustache": "0.8.32",
-    "@types/node": "10.12.10",
+    "@types/node": "^10.0.0",
     "@types/read-pkg": "3.0.0",
     "@types/tmp": "^0.0.33",
     "@types/webpack": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "publish:next": "lerna run publish:next"
   },
   "resolutions": {
+    "**/**/@types/node": "^10.0.0",
     "**/**/minimist": "^1.2.0",
     "**/**/nsfw": "1.2.7",
     "**/mkdirp": "^0.5.1"

--- a/plugins/ports-plugin/package.json
+++ b/plugins/ports-plugin/package.json
@@ -20,7 +20,7 @@
     "@theia/plugin": "next",
     "@theia/plugin-packager": "latest",
     "@types/jest": "25.2.1",
-    "@types/node": "11.9.4"
+    "@types/node": "^10.0.0"
   },
   "scripts": {
     "prepare": "yarn clean && yarn build && yarn lint:fix && yarn test",

--- a/plugins/ssh-plugin/package.json
+++ b/plugins/ssh-plugin/package.json
@@ -32,6 +32,7 @@
         "@eclipse-che/plugin": "0.0.1"
       },
       "devDependencies": {
+        "@types/node": "^10.0.0",
         "@eclipse-che/api": "latest",
         "@eclipse-che/plugin": "0.0.1",
         "@theia/plugin": "next",

--- a/plugins/ssh-plugin/src/ssh-plugin-backend.ts
+++ b/plugins/ssh-plugin/src/ssh-plugin-backend.ts
@@ -13,9 +13,8 @@ import * as che from '@eclipse-che/plugin';
 import { RemoteSshKeyManager, SshKeyManager } from './node/ssh-key-manager';
 import { che as cheApi } from '@eclipse-che/api';
 import { resolve, join } from 'path';
-import { pathExists, unlink, ensureFile, chmod, readFile, writeFile, appendFile } from 'fs-extra';
+import { pathExists, unlink, ensureFile, chmod, readFile, writeFile, appendFile, access, remove, mkdtemp } from 'fs-extra';
 import * as os from 'os';
-import { accessSync, mkdtempSync, readFileSync, rmdirSync, unlinkSync } from 'fs';
 import { R_OK } from 'constants';
 
 export async function start(): Promise<void> {
@@ -246,7 +245,7 @@ const uploadPrivateKey = async (sshkeyManager: SshKeyManager) => {
         hostName = `default-${Date.now()}`;
     }
 
-    const tempDir = mkdtempSync(join(os.tmpdir(), 'private-key-'));
+    const tempDir = await mkdtemp(join(os.tmpdir(), 'private-key-'));
     const uploadedFilePaths = await theia.window.showUploadDialog({ defaultUri: theia.Uri.file(tempDir) });
 
     if (!uploadedFilePaths || uploadPrivateKey.length === 0) {
@@ -256,9 +255,9 @@ const uploadPrivateKey = async (sshkeyManager: SshKeyManager) => {
 
     const privateKeyPath = uploadedFilePaths[0];
 
-    accessSync(privateKeyPath.path, R_OK);
+    await access(privateKeyPath.path, R_OK);
 
-    const privateKeyContent = readFileSync(privateKeyPath.path).toString();
+    const privateKeyContent = (await readFile(privateKeyPath.path)).toString();
 
     try {
         await sshkeyManager.create({ name: hostName, service: 'vcs', privateKey: privateKeyContent });
@@ -270,8 +269,8 @@ const uploadPrivateKey = async (sshkeyManager: SshKeyManager) => {
         theia.window.showErrorMessage(error);
     }
 
-    unlinkSync(privateKeyPath.path);
-    rmdirSync(tempDir, { recursive: true });
+    await unlink(privateKeyPath.path);
+    await remove(tempDir);
 };
 
 const getKeys = async (sshKeyManager: SshKeyManager): Promise<cheApi.ssh.SshPair[]> => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2177,22 +2177,7 @@
   resolved "https://registry.yarnpkg.com/@types/mustache/-/mustache-0.8.32.tgz#7db3b81f2bf450bd38805f596d20eca97c4ed595"
   integrity sha512-RTVWV485OOf4+nO2+feurk0chzHkSjkjALiejpHltyuMf/13fGymbbNNFrSKdSSUg1TIwzszXdWsVirxgqYiFA==
 
-"@types/node@*", "@types/node@>= 8":
-  version "13.13.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.2.tgz#160d82623610db590a64e8ca81784e11117e5a54"
-  integrity sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==
-
-"@types/node@10.12.10":
-  version "10.12.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.10.tgz#4fa76e6598b7de3f0cb6ec3abacc4f59e5b3a2ce"
-  integrity sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w==
-
-"@types/node@11.9.4":
-  version "11.9.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.9.4.tgz#ceb0048a546db453f6248f2d1d95e937a6f00a14"
-  integrity sha512-Zl8dGvAcEmadgs1tmSPcvwzO1YRsz38bVJQvH1RvRqSR9/5n61Q1ktcDL0ht3FXWR+ZpVmXVwN1LuH4Ax23NsA==
-
-"@types/node@^10.0.0":
+"@types/node@*", "@types/node@10.0.0", "@types/node@>= 8", "@types/node@^10.0.0", "@types/node@^10.17.21":
   version "10.17.21"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.21.tgz#c00e9603399126925806bed2d9a1e37da506965e"
   integrity sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ==
@@ -4594,7 +4579,7 @@ debug@3.1.0, debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -4821,7 +4806,7 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-detect-libc@^1.0.2, detect-libc@^1.0.3:
+detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -6677,7 +6662,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -9297,15 +9282,6 @@ ncp@~2.0.0:
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
-needle@^2.2.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.1.tgz#14af48732463d7475696f937626b1b993247a56a"
-  integrity sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -9432,22 +9408,6 @@ node-notifier@^6.0.0:
     shellwords "^0.1.1"
     which "^1.3.1"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 noop-logger@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
@@ -9531,7 +9491,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -9570,7 +9530,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.1, npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.0.1, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -10528,7 +10488,7 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.1.6, rc@^1.2.7:
+rc@^1.1.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -11951,7 +11911,7 @@ tar-stream@^1.1.2, tar-stream@^1.5.0, tar-stream@^1.5.2:
     to-buffer "^1.1.1"
     xtend "^4.0.0"
 
-tar@^4.0.0, tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.0.0, tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
### What does this PR do?
ssh plugin was using a nodejs 12.x api.
Remove it, ensure that node API is stuck to 10.x and switch from fs to fs-extra to avoid to use sync methods

Change-Id: Ia2a63363e532566e612c0ab3e6c9064f8c655163
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
