### PR TITLE
move Che specific instructions to alpine and...

### DIFF
--- a/dockerfiles/theia-endpoint-runtime-binary/Dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/Dockerfile
@@ -8,17 +8,12 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
-FROM quay.io/eclipse/che-custom-nodejs-deasync:10.20.1 as custom-nodejs
-
-FROM #{INCLUDE:docker/${BUILD_IMAGE_TARGET}/builder-from.dockerfile}
+#{INCLUDE:docker/${BUILD_IMAGE_TARGET}/builder-from.dockerfile}
 
 WORKDIR /home/theia
 
 # Apply node libs installed globally to the PATH
 ENV PATH=${HOME}/.yarn/bin:${PATH}
-ENV NEXE_FLAGS="--asset ${HOME}/pre-assembly-nodejs-static"
-
-COPY --from=custom-nodejs /pre-assembly-nodejs-static ${HOME}/pre-assembly-nodejs-static
 
 # setup extra stuff
 #{INCLUDE:docker/${BUILD_IMAGE_TARGET}/builder-setup.dockerfile}

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/builder-from.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/builder-from.dockerfile
@@ -1,1 +1,2 @@
+FROM quay.io/eclipse/che-custom-nodejs-deasync:10.20.1 as custom-nodejs
 FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia:${BUILD_TAG} as builder

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/builder-setup.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/builder-setup.dockerfile
@@ -1,0 +1,3 @@
+ENV NEXE_FLAGS="--asset ${HOME}/pre-assembly-nodejs-static"
+
+COPY --from=custom-nodejs /pre-assembly-nodejs-static ${HOME}/pre-assembly-nodejs-static

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/builder-from.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/builder-from.dockerfile
@@ -1,1 +1,2 @@
+FROM quay.io/eclipse/che-custom-nodejs-deasync:10.20.1 as custom-nodejs
 FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia:${BUILD_TAG} as builder

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/builder-setup.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/builder-setup.dockerfile
@@ -1,1 +1,6 @@
+ENV NEXE_FLAGS="--asset ${HOME}/pre-assembly-nodejs-static"
+
+COPY --from=custom-nodejs /pre-assembly-nodejs-static ${HOME}/pre-assembly-nodejs-static
+
 USER root
+


### PR DESCRIPTION
move Che specific instructions to alpine and ubi dockerfile fragments so they can be more easily overridden/skipped in Brew (#16951)

Change-Id: I3eb4ea38410ca91d32030f89db77c821e3764e2c
Signed-off-by: nickboldt <nboldt@redhat.com>