### PR TITLE
Adapt terminal widget to the upstream

### DIFF
--- a/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
@@ -37,6 +37,11 @@ export interface RemoteTerminalWidgetFactoryOptions extends Partial<TerminalWidg
     created: string
 }
 
+export interface TerminalProcessInfo {
+    executable: string
+    arguments: string[]
+}
+
 @injectable()
 export class RemoteTerminalWidget extends TerminalWidgetImpl {
     public static OUTPUT_CHANNEL_NAME = 'remote-terminal';
@@ -196,6 +201,15 @@ export class RemoteTerminalWidget extends TerminalWidgetImpl {
             }
             // Exec server side unable to return real process pid. This information is encapsulated.
             return this.terminalId;
+        })();
+    }
+
+    get processInfo(): Promise<TerminalProcessInfo> {
+        return (async () => {
+            if (!IBaseTerminalServer.validateId(this.terminalId)) {
+                throw new Error('terminal is not started');
+            }
+            return { executable: '/bin/bash', arguments: [] };
         })();
     }
 

--- a/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
@@ -10,7 +10,7 @@
 
 import { injectable, inject, postConstruct } from 'inversify';
 import { TerminalWidgetImpl } from '@theia/terminal/lib/browser/terminal-widget-impl';
-import { IBaseTerminalServer } from '@theia/terminal/lib/common/base-terminal-protocol';
+import { IBaseTerminalServer, TerminalProcessInfo } from '@theia/terminal/lib/common/base-terminal-protocol';
 import { TerminalProxyCreatorProvider } from '../server-definition/terminal-proxy-creator';
 import { ATTACH_TERMINAL_SEGMENT, RemoteTerminalServerProxy, RemoteTerminalWatcher } from '../server-definition/remote-terminal-protocol';
 import { RemoteWebSocketConnectionProvider } from '../server-definition/remote-connection';
@@ -35,11 +35,6 @@ export interface RemoteTerminalWidgetOptions extends Partial<TerminalWidgetOptio
 export interface RemoteTerminalWidgetFactoryOptions extends Partial<TerminalWidgetOptions> {
     /* a unique string per terminal */
     created: string
-}
-
-export interface TerminalProcessInfo {
-    executable: string
-    arguments: string[]
 }
 
 @injectable()


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds `get processInfo(): Promise<TerminalProcessInfo>` method to make it possible to run debug commands in internalTerminal.

Upstream changes: https://github.com/eclipse-theia/theia/commit/5e45d2b8ad4b27832c976aa406db03c561da9588#diff-29ae8bb3747051f34ef7d32716b705e6 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16805