### PR TITLE
switch to use ubi8/nodejs-10:latest instead...

### DIFF
--- a/dockerfiles/theia-dev/docker/ubi8/builder-image-from.dockerfile
+++ b/dockerfiles/theia-dev/docker/ubi8/builder-image-from.dockerfile
@@ -1,2 +1,1 @@
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10
-FROM registry.access.redhat.com/ubi8/nodejs-10:1-81
+FROM registry.access.redhat.com/ubi8/nodejs-10:latest

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/runtime-from.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/runtime-from.dockerfile
@@ -1,2 +1,1 @@
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.1-409 as runtime
+FROM registry.access.redhat.com/ubi8-minimal:latest as runtime

--- a/dockerfiles/theia/docker/ubi8/build-result-from.dockerfile
+++ b/dockerfiles/theia/docker/ubi8/build-result-from.dockerfile
@@ -1,3 +1,2 @@
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10
-FROM registry.access.redhat.com/ubi8/nodejs-10:1-81 as build-result
+FROM registry.access.redhat.com/ubi8/nodejs-10:latest as build-result
 USER root

--- a/dockerfiles/theia/docker/ubi8/runtime-from.dockerfile
+++ b/dockerfiles/theia/docker/ubi8/runtime-from.dockerfile
@@ -1,2 +1,1 @@
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-10
-FROM registry.access.redhat.com/ubi8/nodejs-10:1-81 as runtime
+FROM registry.access.redhat.com/ubi8/nodejs-10:latest as runtime


### PR DESCRIPTION
switch to use ubi8/nodejs-10:latest instead of locking to a tag

Intent is to work around OSBS problems we're having right now (unable to resolve tags), and keep the builds always using the latest ubi base images without *ME* having to keep submitting PRs to update it. 

We can go back to tag locking later but for now it's a nuisance / extra maintenance burden.

Note that these files are already outdated: latest nodejs-10 tag is https://access.redhat.com/containers/?architecture=AMD64#/registry.access.redhat.com/ubi8/nodejs-10/images/1-82.1589298623 not 1-81. Kinda proves my point :D 

Change-Id: I922cd0248e2383131437831f00b459565b880964
Signed-off-by: nickboldt <nboldt@redhat.com>