### PR TITLE
fix(build): Due to new electron module, fix removal

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -65,6 +65,7 @@ RUN rm -rf ${HOME}/theia-source-code/examples/browser && \
     sed -i 's|  "resolutions": {|  "resolutions": {\n    "**/electron": "7.0.0",|' ${HOME}/theia-source-code/package.json && \
     # remove all electron-browser module to not compile them
     find . -name "electron-browser"  | xargs rm -rf {} && \
+    find . -name "*-electron-module.ts"  | xargs rm -rf {} && \
     rm -rf ${HOME}/theia-source-code/dev-packages/electron/native && \
     echo "" > ${HOME}/theia-source-code/dev-packages/electron/scripts/post-install.js && \
     # Remove linter/formatters of theia


### PR DESCRIPTION
### What does this PR do?
Fix remaining electron file not removed so it tries to be compiled and failed
This is because new files have been introduced upstream

### What issues does this PR fix or reference?
N/A

Change-Id: I9d1087e4e4288f31d7e367d36088084ff1486a9d
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
