### PR TITLE
Temporary skip one of the cypress tests which is not stable

### DIFF
--- a/dockerfiles/theia/e2e/cypress/integration/theia/typescript.spec.ts
+++ b/dockerfiles/theia/e2e/cypress/integration/theia/typescript.spec.ts
@@ -21,7 +21,7 @@ context('TypeScript', () => {
     });
 
     // Create a typescript file and check we can use the editor
-    it('Check Invalid Syntax', () => {
+    it.skip('Check Invalid Syntax', () => {
 
         const FOLDER_NAME = 'typescripttest' + makeid();
         const FILENAME = 'HelloWorld.ts';


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Temporary, disable one of the cypress tests which is not stable.
Sometimes, it requires to just rerun the CI job several times for passing the test.
For example:
https://ci.centos.org/job/devtools-che-theia-che-release/ - jobs 156, 157
https://ci.centos.org/job/devtools-che-theia-che-release/ - jobs 24, 25

As HappyPath tests are passing successfully, I propose to skip this test temporarily while investigating how to make it more stable.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
