### PR TITLE
Added buildx support in cico scripts

### DIFF
--- a/cico_build_master.sh
+++ b/cico_build_master.sh
@@ -26,6 +26,7 @@ export CDN_PREFIX=https://static.developers.redhat.com/che/theia_artifacts/
 export MONACO_CDN_PREFIX=https://cdn.jsdelivr.net/npm/
 
 install_deps
+buildx_support
 set +x
 load_jenkins_vars
 set -x

--- a/cico_build_pr.sh
+++ b/cico_build_pr.sh
@@ -19,6 +19,7 @@ set -e
 . ./cico_common.sh
 
 install_deps
+buildx_support
 load_jenkins_vars
 
 #Set images tag to current commit id. 

--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -58,6 +58,7 @@ init() {
   OPTIONS=""
   DOCKERFILE=""
   BUILD_ARGS=""
+  PLATFORM="linux/amd64"
 
   PARENT_IMAGE=""
   BRANCH=""
@@ -108,6 +109,9 @@ init() {
         shift ;;
       --git-ref:*)
         GIT_REF="${1#*:}"
+        shift ;;
+      --platform:*)
+        PLATFORM="${1#*:}"
         shift ;;
       --*)
         printf "${RED}Unknown parameter: $1${NC}\n"; exit 2 ;;
@@ -218,7 +222,8 @@ build_image() {
   done
 
   if ! dry_run; then
-    cd "${DIR}" && docker build --cache-from ${IMAGE_NAME} -f ${DIR}/.Dockerfile -t ${IMAGE_NAME} ${BUILD_ARGS} ${DOCKER_BUILD_TARGET} .
+      #Build the images locally for any architecture using docker buildx
+    cd "${DIR}" && docker buildx build --cache-from ${IMAGE_NAME} --platform ${PLATFORM} -f ${DIR}/.Dockerfile -t ${IMAGE_NAME} ${BUILD_ARGS} ${DOCKER_BUILD_TARGET} --progress plain --load .
     rm ${DIR}/.Dockerfile
   fi
   


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Added buildx support in cico scripts
`--platform` has been added as an additional flag that a user can provide, in order to build the theia docker images using `buildx`. This flag, if enabled with any architecture, will build the dockerfiles for the mentioned architecture and by default, will build the images on `linux/amd64`.


### What issues does this PR fix or reference?
Reference: https://github.com/eclipse/che/issues/17124
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
