### PR TITLE
Fix release script to keep the same Theia versions for bugfix releases

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -92,18 +92,24 @@ apply_files_edits () {
 
   # Update extensions/plugins package.json files:
   # - set packages' version
-  # - update versions of Theia and Che dependencies
+  # - update versions of Che dependencies
   for m in "extensions/*" "plugins/*"; do
     PACKAGE_JSON="${m}"/package.json
     # shellcheck disable=SC2086
     sed_in_place -r -e "s/(\"version\": )(\".*\")/\1\"$VERSION\"/" ${PACKAGE_JSON}
     # shellcheck disable=SC2086
-    sed_in_place -r -e "/plugin-packager/!s/(\"@theia\/..*\": )(\".*\")/\1\"${THEIA_VERSION}\"/" ${PACKAGE_JSON}
-    # shellcheck disable=SC2086
     sed_in_place -r -e "/@eclipse-che\/api|@eclipse-che\/workspace-client|@eclipse-che\/workspace-telemetry-client/!s/(\"@eclipse-che\/..*\": )(\".*\")/\1\"$VERSION\"/" ${PACKAGE_JSON}
   done
 
   if [[ ${VERSION} == *".0" ]]; then
+    # Update extensions/plugins package.json files:
+    # - update versions of Theia dependencies
+    for m in "extensions/*" "plugins/*"; do
+      PACKAGE_JSON="${m}"/package.json
+      # shellcheck disable=SC2086
+      sed_in_place -r -e "/plugin-packager/!s/(\"@theia\/..*\": )(\".*\")/\1\"${THEIA_VERSION}\"/" ${PACKAGE_JSON}
+    done
+
     sed_in_place -e "$ a RUN cd ${HOME} \&\& tar zcf ${HOME}/theia-source-code.tgz theia-source-code" dockerfiles/theia/docker/ubi8/builder-clone-theia.dockerfile
   fi
 }


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes release script to set the latest Theia version when doing x.y.0 releases only.
But when doing other bugfix releases (e.g. x.y.1), Theia version must be the same as for corresponding y-release.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17188

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
