### PR TITLE
Better detection when registry.npmjs.org doesn't return Theia version

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -76,8 +76,8 @@ fi
 
 apply_files_edits () {
   THEIA_VERSION=$(curl --silent http://registry.npmjs.org/-/package/@theia/core/dist-tags | sed 's/.*"next":"\(.*\)".*/\1/')
-  if [[ ! ${THEIA_VERSION} ]]; then
-    echo "Failed to get Theia next version from npmjs.org"; echo
+  if [[ ! ${THEIA_VERSION} ]] || [[ ${THEIA_VERSION} == \"Unauthorized\" ]]; then
+    echo "Failed to get Theia next version from npmjs.org. Try again."; echo
     exit 1
   fi
 


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds better detection when registry.npmjs.org doesn't return Theia version.

### What issues does this PR fix or reference?
closes https://github.com/eclipse/che/issues/17181

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
