### PR TITLE
Open Che workspace with multiple workspace root

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-debug-configuration-manager.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-debug-configuration-manager.ts
@@ -1,0 +1,32 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { injectable, postConstruct } from 'inversify';
+
+import { DebugConfigurationManager } from '@theia/debug/lib/browser/debug-configuration-manager';
+
+@injectable()
+export class CheDebugConfigurationManager extends DebugConfigurationManager {
+  @postConstruct()
+  protected async init(): Promise<void> {
+    super.init();
+
+    /**
+     * Theia creates a DebugConfigurationModel for each workspace folder in a workspace at starting the IDE.
+     * For the CHE multi-root workspace there no workspace folders at that step:
+     * CHE clones projects at starting the IDE and adds a workspace folder directly after cloning a project.
+     * That's why we need the following logic -
+     * DebugConfigurationManager should create the corresponding model when a workspace is changed (a workspace folder is added)
+     */
+    this.workspaceService.onWorkspaceChanged(() => {
+      this.updateModels();
+    });
+  }
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-frontend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-frontend-module.ts
@@ -22,9 +22,11 @@ import {
 } from '../common/che-protocol';
 import { CheSideCarContentReaderRegistryImpl, CheSideCarResourceResolver } from './che-sidecar-resource';
 import { CommandContribution, ResourceResolver } from '@theia/core/lib/common';
+import { ContainerModule, interfaces } from 'inversify';
 import { WebSocketConnectionProvider, WidgetFactory } from '@theia/core/lib/browser';
 
 import { CheApiProvider } from './che-api-provider';
+import { CheDebugConfigurationManager } from './che-debug-configuration-manager';
 import { CheLanguagesMainTestImpl } from './che-languages-test-main';
 import { ChePluginCommandContribution } from './plugin/che-plugin-command-contribution';
 import { ChePluginFrontentService } from './plugin/che-plugin-frontend-service';
@@ -38,8 +40,8 @@ import { CheTaskClientImpl } from './che-task-client';
 import { CheTaskResolver } from './che-task-resolver';
 import { CheTaskTerminalWidgetManager } from './che-task-terminal-widget-manager';
 import { CheWebviewEnvironment } from './che-webview-environment';
-import { ContainerModule } from 'inversify';
 import { ContainerPicker } from './container-picker';
+import { DebugConfigurationManager } from '@theia/debug/lib/browser/debug-configuration-manager';
 import { LanguagesMainFactory } from '@theia/plugin-ext';
 import { MainPluginApiProvider } from '@theia/plugin-ext/lib/common/plugin-ext-api-contribution';
 import { PluginFrontendViewContribution } from '@theia/plugin-ext/lib/main/browser/plugin-frontend-view-contribution';
@@ -50,7 +52,6 @@ import { TaskStatusHandler } from './task-status-handler';
 import { TaskTerminalWidgetManager } from '@theia/task/lib/browser/task-terminal-widget-manager';
 import { WebviewEnvironment } from '@theia/plugin-ext/lib/main/browser/webview/webview-environment';
 import { bindChePluginPreferences } from './plugin/che-plugin-preferences';
-import { interfaces } from 'inversify';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(CheApiProvider).toSelf().inSingletonScope();
@@ -124,4 +125,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     child.bind(RPCProtocol).toConstantValue(rpc);
     return child.get(CheLanguagesMainTestImpl);
   });
+
+  bind(CheDebugConfigurationManager).toSelf().inSingletonScope();
+  rebind(DebugConfigurationManager).to(CheDebugConfigurationManager).inSingletonScope();
 });

--- a/extensions/eclipse-che-theia-workspace/package.json
+++ b/extensions/eclipse-che-theia-workspace/package.json
@@ -9,6 +9,7 @@
     "src"
   ],
   "dependencies": {
+    "@theia/core": "next",
     "@eclipse-che/api": "latest",
     "@theia/workspace": "next",
     "@eclipse-che/theia-remote-api": "^0.0.1",
@@ -31,7 +32,8 @@
   "license": "EPL-2.0",
   "theiaExtensions": [
     {
-      "frontend": "lib/browser/che-workspace-module"
+      "frontend": "lib/browser/che-workspace-module",
+      "backend": "lib/node/workspace-backend-module"
     }
   ]
 }

--- a/extensions/eclipse-che-theia-workspace/src/browser/che-navigator-widget.tsx
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-navigator-widget.tsx
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as React from 'react';
+
+import { injectable } from 'inversify';
+
+import { FileNavigatorWidget } from '@theia/navigator/lib/browser/navigator-widget';
+
+@injectable()
+export class CheFileNavigatorWidget extends FileNavigatorWidget {
+  protected renderEmptyMultiRootWorkspace(): React.ReactNode {
+    return (
+      <div className="theia-navigator-container">
+        <div className="center">No projects in the workspace yet</div>
+      </div>
+    );
+  }
+}

--- a/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-module.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-module.ts
@@ -7,15 +7,31 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
-
 import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
+import { Container, ContainerModule, interfaces } from 'inversify';
+import { FileTree, FileTreeModel, FileTreeWidget, createFileTreeContainer } from '@theia/filesystem/lib/browser';
+import {
+  FrontendApplicationContribution,
+  Tree,
+  TreeDecoratorService,
+  TreeModel,
+  TreeProps,
+} from '@theia/core/lib/browser';
+import {
+  NavigatorDecoratorService,
+  NavigatorTreeDecorator,
+} from '@theia/navigator/lib/browser/navigator-decorator-service';
 
+import { CheFileNavigatorWidget } from './che-navigator-widget';
 import { CheWorkspaceContribution } from './che-workspace-contribution';
 import { CheWorkspaceController } from './che-workspace-controller';
-import { ContainerModule } from 'inversify';
 import { ExplorerContribution } from './explorer-contribution';
-import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { FILE_NAVIGATOR_PROPS } from '@theia/navigator/lib/browser/navigator-container';
+import { FileNavigatorModel } from '@theia/navigator/lib/browser/navigator-model';
+import { FileNavigatorTree } from '@theia/navigator/lib/browser/navigator-tree';
+import { FileNavigatorWidget } from '@theia/navigator/lib/browser/navigator-widget';
 import { QuickOpenCheWorkspace } from './che-quick-open-workspace';
+import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(QuickOpenCheWorkspace).toSelf().inSingletonScope();
@@ -27,4 +43,33 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
   bind(ExplorerContribution).toSelf().inSingletonScope();
   bind(FrontendApplicationContribution).to(ExplorerContribution);
+
+  rebind(FileNavigatorWidget).toDynamicValue(ctx => createFileNavigatorWidget(ctx.container));
 });
+
+export function createFileNavigatorContainer(parent: interfaces.Container): Container {
+  const child = createFileTreeContainer(parent);
+
+  child.unbind(FileTree);
+  child.bind(FileNavigatorTree).toSelf();
+  child.rebind(Tree).toService(FileNavigatorTree);
+
+  child.unbind(FileTreeModel);
+  child.bind(FileNavigatorModel).toSelf();
+  child.rebind(TreeModel).toService(FileNavigatorModel);
+
+  child.unbind(FileTreeWidget);
+  child.bind(CheFileNavigatorWidget).toSelf();
+
+  child.rebind(TreeProps).toConstantValue(FILE_NAVIGATOR_PROPS);
+
+  child.bind(NavigatorDecoratorService).toSelf().inSingletonScope();
+  child.rebind(TreeDecoratorService).toService(NavigatorDecoratorService);
+  bindContributionProvider(child, NavigatorTreeDecorator);
+
+  return child;
+}
+
+export function createFileNavigatorWidget(parent: interfaces.Container): CheFileNavigatorWidget {
+  return createFileNavigatorContainer(parent).get(CheFileNavigatorWidget);
+}

--- a/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
+++ b/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
@@ -8,71 +8,72 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-import { injectable, inject } from 'inversify';
-import { DefaultWorkspaceServer } from '@theia/workspace/lib/node/default-workspace-server';
-import { CheApiService } from '@eclipse-che/theia-plugin-ext/lib/common/che-protocol';
-import { FileUri } from '@theia/core/lib/node';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
+import { inject, injectable } from 'inversify';
+
+import { DefaultWorkspaceServer } from '@theia/workspace/lib/node/default-workspace-server';
+import { FileUri } from '@theia/core/lib/node';
+import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
+
 interface TheiaWorkspace {
-    folders: TheiaWorkspacePath[]
-};
+  folders: TheiaWorkspacePath[];
+}
 
 interface TheiaWorkspacePath {
-    path: string
-};
+  path: string;
+}
 
 @injectable()
 export class CheWorkspaceServer extends DefaultWorkspaceServer {
+  @inject(WorkspaceService)
+  protected workspaceService: WorkspaceService;
 
-    @inject(CheApiService)
-    private cheApiService: CheApiService;
-
-    // override any workspace that could have been defined through CLI and use entries from the devfile
-    // if not possible, use default method
-    protected async getRoot(): Promise<string | undefined> {
-
-        let projectsRoot: string;
-        if (process.env.CHE_PROJECTS_ROOT) {
-            projectsRoot = process.env.CHE_PROJECTS_ROOT;
-        } else {
-            projectsRoot = '/projects';
-        }
-
-        // first, check if we have a che.theia-workspace file
-        const cheTheiaWorkspaceFile = path.resolve(projectsRoot, 'che.theia-workspace');
-        const exists = await fs.pathExists(cheTheiaWorkspaceFile);
-        if (exists) {
-            return FileUri.create(cheTheiaWorkspaceFile).toString();
-        }
-
-        // no, then create the file
-
-        const workspace = await this.cheApiService.currentWorkspace();
-        const devfile = workspace.devfile;
-        if (devfile) {
-            const projects = devfile.projects;
-            if (projects) {
-                // create a struc for each project
-                const theiaWorkspace: TheiaWorkspace = { folders: [] };
-                for (const project of projects) {
-                    const projectPath = project.clonePath ? path.join(projectsRoot, project.clonePath) : path.join(projectsRoot, project.name!);
-                    // check parent folder exists
-                    const parentDir = path.resolve(projectPath, '..');
-                    await fs.ensureDir(parentDir);
-                    theiaWorkspace.folders.push({ path: FileUri.create(projectPath).toString() });
-                }
-
-                // now, need to write the content of this file
-                await fs.writeFile(cheTheiaWorkspaceFile, JSON.stringify(theiaWorkspace), { encoding: 'utf8' });
-
-                // return this content
-                return FileUri.create(cheTheiaWorkspaceFile).toString();
-            }
-        }
-
-        return super.getRoot();
+  // override any workspace that could have been defined through CLI and use entries from the devfile
+  // if not possible, use default method
+  protected async getRoot(): Promise<string | undefined> {
+    let projectsRoot: string;
+    if (process.env.CHE_PROJECTS_ROOT) {
+      projectsRoot = process.env.CHE_PROJECTS_ROOT;
+    } else {
+      projectsRoot = '/projects';
     }
 
+    // first, check if we have a che.theia-workspace file
+    const cheTheiaWorkspaceFile = path.resolve(projectsRoot, 'che.theia-workspace');
+    const exists = await fs.pathExists(cheTheiaWorkspaceFile);
+    if (exists) {
+      return FileUri.create(cheTheiaWorkspaceFile).toString();
+    }
+
+    // no, then create the file
+
+    const workspace = await this.workspaceService.currentWorkspace();
+    const devfile = workspace.devfile;
+    if (devfile) {
+      const projects = devfile.projects;
+      if (projects) {
+        // create a struc for each project
+        const theiaWorkspace: TheiaWorkspace = { folders: [] };
+        for (const project of projects) {
+          const projectPath = project.clonePath
+            ? path.join(projectsRoot, project.clonePath)
+            : path.join(projectsRoot, project.name!);
+          // check parent folder exists
+          const parentDir = path.resolve(projectPath, '..');
+          await fs.ensureDir(parentDir);
+          theiaWorkspace.folders.push({ path: FileUri.create(projectPath).toString() });
+        }
+
+        // now, need to write the content of this file
+        await fs.writeFile(cheTheiaWorkspaceFile, JSON.stringify(theiaWorkspace), { encoding: 'utf8' });
+
+        // return this content
+        return FileUri.create(cheTheiaWorkspaceFile).toString();
+      }
+    }
+
+    return super.getRoot();
+  }
 }

--- a/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
+++ b/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { DefaultWorkspaceServer } from '@theia/workspace/lib/node/default-workspace-server';
+import { CheApiService } from '@eclipse-che/theia-plugin-ext/lib/common/che-protocol';
+import { FileUri } from '@theia/core/lib/node';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+interface TheiaWorkspace {
+    folders: TheiaWorkspacePath[]
+};
+
+interface TheiaWorkspacePath {
+    path: string
+};
+
+@injectable()
+export class CheWorkspaceServer extends DefaultWorkspaceServer {
+
+    @inject(CheApiService)
+    private cheApiService: CheApiService;
+
+    // override any workspace that could have been defined through CLI and use entries from the devfile
+    // if not possible, use default method
+    protected async getRoot(): Promise<string | undefined> {
+
+        let projectsRoot: string;
+        if (process.env.CHE_PROJECTS_ROOT) {
+            projectsRoot = process.env.CHE_PROJECTS_ROOT;
+        } else {
+            projectsRoot = '/projects';
+        }
+
+        // first, check if we have a che.theia-workspace file
+        const cheTheiaWorkspaceFile = path.resolve(projectsRoot, 'che.theia-workspace');
+        const exists = await fs.pathExists(cheTheiaWorkspaceFile);
+        if (exists) {
+            return FileUri.create(cheTheiaWorkspaceFile).toString();
+        }
+
+        // no, then create the file
+
+        const workspace = await this.cheApiService.currentWorkspace();
+        const devfile = workspace.devfile;
+        if (devfile) {
+            const projects = devfile.projects;
+            if (projects) {
+                // create a struc for each project
+                const theiaWorkspace: TheiaWorkspace = { folders: [] };
+                for (const project of projects) {
+                    const projectPath = project.clonePath ? path.join(projectsRoot, project.clonePath) : path.join(projectsRoot, project.name!);
+                    // check parent folder exists
+                    const parentDir = path.resolve(projectPath, '..');
+                    await fs.ensureDir(parentDir);
+                    theiaWorkspace.folders.push({ path: FileUri.create(projectPath).toString() });
+                }
+
+                // now, need to write the content of this file
+                await fs.writeFile(cheTheiaWorkspaceFile, JSON.stringify(theiaWorkspace), { encoding: 'utf8' });
+
+                // return this content
+                return FileUri.create(cheTheiaWorkspaceFile).toString();
+            }
+        }
+
+        return super.getRoot();
+    }
+
+}

--- a/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
+++ b/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
@@ -54,22 +54,8 @@ export class CheWorkspaceServer extends DefaultWorkspaceServer {
     if (devfile) {
       const projects = devfile.projects;
       if (projects) {
-        // create a struc for each project
         const theiaWorkspace: TheiaWorkspace = { folders: [] };
-        for (const project of projects) {
-          const projectPath = project.clonePath
-            ? path.join(projectsRoot, project.clonePath)
-            : path.join(projectsRoot, project.name!);
-          // check parent folder exists
-          const parentDir = path.resolve(projectPath, '..');
-          await fs.ensureDir(parentDir);
-          theiaWorkspace.folders.push({ path: FileUri.create(projectPath).toString() });
-        }
-
-        // now, need to write the content of this file
         await fs.writeFile(cheTheiaWorkspaceFile, JSON.stringify(theiaWorkspace), { encoding: 'utf8' });
-
-        // return this content
         return FileUri.create(cheTheiaWorkspaceFile).toString();
       }
     }

--- a/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
+++ b/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
@@ -11,11 +11,11 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
+import { Workspace, WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
 import { inject, injectable } from 'inversify';
 
 import { DefaultWorkspaceServer } from '@theia/workspace/lib/node/default-workspace-server';
 import { FileUri } from '@theia/core/lib/node';
-import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
 
 interface TheiaWorkspace {
   folders: TheiaWorkspacePath[];
@@ -33,33 +33,29 @@ export class CheWorkspaceServer extends DefaultWorkspaceServer {
   // override any workspace that could have been defined through CLI and use entries from the devfile
   // if not possible, use default method
   protected async getRoot(): Promise<string | undefined> {
-    let projectsRoot: string;
-    if (process.env.CHE_PROJECTS_ROOT) {
-      projectsRoot = process.env.CHE_PROJECTS_ROOT;
-    } else {
-      projectsRoot = '/projects';
+    const workspace = await this.workspaceService.currentWorkspace();
+    if (!isMultiRoot(workspace)) {
+      return super.getRoot();
     }
+
+    const projectsRootEnvVariable = process.env.CHE_PROJECTS_ROOT;
+    const projectsRoot = projectsRootEnvVariable ? projectsRootEnvVariable : '/projects';
 
     // first, check if we have a che.theia-workspace file
     const cheTheiaWorkspaceFile = path.resolve(projectsRoot, 'che.theia-workspace');
+    const cheTheiaWorkspaceFileUri = FileUri.create(cheTheiaWorkspaceFile);
     const exists = await fs.pathExists(cheTheiaWorkspaceFile);
-    if (exists) {
-      return FileUri.create(cheTheiaWorkspaceFile).toString();
+    if (!exists) {
+      // no, then create the file
+      const theiaWorkspace: TheiaWorkspace = { folders: [] };
+      await fs.writeFile(cheTheiaWorkspaceFile, JSON.stringify(theiaWorkspace), { encoding: 'utf8' });
     }
 
-    // no, then create the file
-
-    const workspace = await this.workspaceService.currentWorkspace();
-    const devfile = workspace.devfile;
-    if (devfile) {
-      const projects = devfile.projects;
-      if (projects) {
-        const theiaWorkspace: TheiaWorkspace = { folders: [] };
-        await fs.writeFile(cheTheiaWorkspaceFile, JSON.stringify(theiaWorkspace), { encoding: 'utf8' });
-        return FileUri.create(cheTheiaWorkspaceFile).toString();
-      }
-    }
-
-    return super.getRoot();
+    return cheTheiaWorkspaceFileUri.toString();
   }
+}
+
+function isMultiRoot(workspace: Workspace): boolean {
+  const devfile = workspace.devfile;
+  return !!devfile && !!devfile.attributes && !!devfile.attributes.multiRoot && devfile.attributes.multiRoot === 'on';
 }

--- a/extensions/eclipse-che-theia-workspace/src/node/index.ts
+++ b/extensions/eclipse-che-theia-workspace/src/node/index.ts
@@ -1,0 +1,11 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+export * from './workspace-backend-module';

--- a/extensions/eclipse-che-theia-workspace/src/node/workspace-backend-module.ts
+++ b/extensions/eclipse-che-theia-workspace/src/node/workspace-backend-module.ts
@@ -1,0 +1,18 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { CheWorkspaceServer } from './che-workspace-server';
+import { WorkspaceServer } from '@theia/workspace/lib/common';
+
+export default new ContainerModule((bind, unbind, isBound, rebind) => {
+    bind(CheWorkspaceServer).toSelf().inSingletonScope();
+    rebind(WorkspaceServer).toService(CheWorkspaceServer);
+});

--- a/extensions/eclipse-che-theia-workspace/src/node/workspace-backend-module.ts
+++ b/extensions/eclipse-che-theia-workspace/src/node/workspace-backend-module.ts
@@ -8,11 +8,11 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-import { ContainerModule } from 'inversify';
 import { CheWorkspaceServer } from './che-workspace-server';
+import { ContainerModule } from 'inversify';
 import { WorkspaceServer } from '@theia/workspace/lib/common';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(CheWorkspaceServer).toSelf().inSingletonScope();
-    rebind(WorkspaceServer).toService(CheWorkspaceServer);
+  bind(CheWorkspaceServer).toSelf().inSingletonScope();
+  rebind(WorkspaceServer).toService(CheWorkspaceServer);
 });

--- a/plugins/task-plugin/package.json
+++ b/plugins/task-plugin/package.json
@@ -70,6 +70,7 @@
     "vscode-uri": "2.1.1",
     "vscode-ws-jsonrpc": "0.2.0",
     "ws": "^5.2.2",
+    "fs-extra": "^8.1.0",
     "jsonc-parser": "^2.0.2"
   }
 }

--- a/plugins/task-plugin/src/che-task-backend-module.ts
+++ b/plugins/task-plugin/src/che-task-backend-module.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -49,6 +49,7 @@ container.bind(ProjectPathVariableResolver).toSelf().inSingletonScope();
 container.bind(CheWorkspaceClient).toSelf().inSingletonScope();
 container.bind(CheTaskPreviewMode).toSelf().inSingletonScope();
 container.bind(PreviewUrlOpenService).toSelf().inSingletonScope();
+container.bind(LaunchConfigurationsExporter).toSelf().inSingletonScope();
 container.bind<ConfigurationsExporter>(ConfigurationsExporter).to(TaskConfigurationsExporter).inSingletonScope();
 container.bind<ConfigurationsExporter>(ConfigurationsExporter).to(LaunchConfigurationsExporter).inSingletonScope();
 container.bind(ExportConfigurationsManager).toSelf().inSingletonScope();

--- a/plugins/task-plugin/src/export/export-configs-manager.ts
+++ b/plugins/task-plugin/src/export/export-configs-manager.ts
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+import * as startPoint from '../task-plugin-backend';
+import * as theia from '@theia/plugin';
+
 import { inject, injectable, multiInject } from 'inversify';
 
 import { CheWorkspaceClient } from '../che-workspace-client';
@@ -41,6 +44,21 @@ export class ExportConfigurationsManager {
 
   @multiInject(ConfigurationsExporter)
   protected readonly exporters: ConfigurationsExporter[];
+
+  init(): void {
+    this.export();
+
+    theia.workspace.onDidChangeWorkspaceFolders(
+      event => {
+        const workspaceFolders = event.added;
+        if (workspaceFolders && workspaceFolders.length > 0) {
+          this.export();
+        }
+      },
+      undefined,
+      startPoint.getSubscriptions()
+    );
+  }
 
   async export(): Promise<void> {
     const exportPromises = [];

--- a/plugins/task-plugin/src/export/launch-configs-exporter.ts
+++ b/plugins/task-plugin/src/export/launch-configs-exporter.ts
@@ -10,8 +10,8 @@
 
 import * as theia from '@theia/plugin';
 
+import { ensureDirExists, modify, writeFile } from '../utils';
 import { inject, injectable } from 'inversify';
-import { modify, writeFileSync } from '../utils';
 
 import { ConfigFileLaunchConfigsExtractor } from '../extract/config-file-launch-configs-extractor';
 import { ConfigurationsExporter } from './export-configs-manager';
@@ -46,23 +46,23 @@ export class LaunchConfigurationsExporter implements ConfigurationsExporter {
   }
 
   async doExport(workspaceFolder: theia.WorkspaceFolder, commands: cheApi.workspace.Command[]): Promise<void> {
-    const launchConfigFileUri = this.getConfigFileUri(workspaceFolder.uri.path);
-    const configFileConfigs = this.configFileLaunchConfigsExtractor.extract(launchConfigFileUri);
+    const workspaceFolderPath = workspaceFolder.uri.path;
+    const launchConfigFilePath = resolve(workspaceFolderPath, CONFIG_DIR, LAUNCH_CONFIG_FILE);
+    const configFileConfigs = await this.configFileLaunchConfigsExtractor.extract(launchConfigFilePath);
     const vsCodeConfigs = this.vsCodeLaunchConfigsExtractor.extract(commands);
 
     const configFileContent = configFileConfigs.content;
     if (configFileContent) {
-      this.saveConfigs(
-        launchConfigFileUri,
+      return this.saveConfigs(
+        workspaceFolderPath,
         configFileContent,
         this.merge(configFileConfigs.configs, vsCodeConfigs.configs, this.getConsoleConflictLogger())
       );
-      return;
     }
 
     const vsCodeConfigsContent = vsCodeConfigs.content;
     if (vsCodeConfigsContent) {
-      this.saveConfigs(launchConfigFileUri, vsCodeConfigsContent, vsCodeConfigs.configs);
+      return this.saveConfigs(workspaceFolderPath, vsCodeConfigsContent, vsCodeConfigs.configs);
     }
   }
 
@@ -100,13 +100,32 @@ export class LaunchConfigurationsExporter implements ConfigurationsExporter {
     return JSON.stringify(properties1) === JSON.stringify(properties2);
   }
 
-  private getConfigFileUri(rootDir: string): string {
-    return resolve(rootDir.toString(), CONFIG_DIR, LAUNCH_CONFIG_FILE);
-  }
+  private async saveConfigs(
+    workspaceFolderPath: string,
+    content: string,
+    configurations: theia.DebugConfiguration[]
+  ): Promise<void> {
+    /*
+        There is an issue related to file watchers: the watcher only reports the first directory when creating recursively directories.
+        For example:
+            - we would like to create /projects/someProject/.theia/launch.json recursively
+            - /projects/someProject directory already exists
+            - .theia directory and launch.json file should be created
+            - as result file watcher fires an event that .theia directory was created, there is no an event about launch.json file
 
-  private saveConfigs(launchConfigFileUri: string, content: string, configurations: theia.DebugConfiguration[]): void {
+        The issue is reproduced not permanently.
+
+        We had to use the workaround to avoid the issue: first we create the directory and then - config file
+    */
+
+    const configDirPath = resolve(workspaceFolderPath, CONFIG_DIR);
+    await ensureDirExists(configDirPath);
+
+    const launchConfigFilePath = resolve(configDirPath, LAUNCH_CONFIG_FILE);
+    await ensureDirExists(launchConfigFilePath);
+
     const result = modify(content, ['configurations'], configurations, formattingOptions);
-    writeFileSync(launchConfigFileUri, result);
+    return writeFile(launchConfigFilePath, result);
   }
 
   private getConsoleConflictLogger(): (config1: theia.DebugConfiguration, config2: theia.DebugConfiguration) => void {

--- a/plugins/task-plugin/src/extract/config-file-launch-configs-extractor.ts
+++ b/plugins/task-plugin/src/extract/config-file-launch-configs-extractor.ts
@@ -10,7 +10,7 @@
 
 import * as theia from '@theia/plugin';
 
-import { parse, readFileSync } from '../utils';
+import { parse, readFile } from '../utils';
 
 import { Configurations } from '../export/export-configs-manager';
 import { injectable } from 'inversify';
@@ -18,8 +18,8 @@ import { injectable } from 'inversify';
 /** Extracts launch configurations from config file by given uri. */
 @injectable()
 export class ConfigFileLaunchConfigsExtractor {
-  extract(launchConfigFileUri: string): Configurations<theia.DebugConfiguration> {
-    const configsContent = readFileSync(launchConfigFileUri);
+  async extract(launchConfigFileUri: string): Promise<Configurations<theia.DebugConfiguration>> {
+    const configsContent = await readFile(launchConfigFileUri);
     const configsJson = parse(configsContent);
     if (!configsJson || !configsJson.configurations) {
       return { content: '', configs: [] };

--- a/plugins/task-plugin/src/extract/config-file-task-configs-extractor.ts
+++ b/plugins/task-plugin/src/extract/config-file-task-configs-extractor.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-import { parse, readFileSync } from '../utils';
+import { parse, readFile } from '../utils';
 
 import { Configurations } from '../export/export-configs-manager';
 import { TaskConfiguration } from '@eclipse-che/plugin';
@@ -17,8 +17,8 @@ import { injectable } from 'inversify';
 /** Extracts configurations of tasks from config file by given uri. */
 @injectable()
 export class ConfigFileTasksExtractor {
-  extract(tasksConfigFileUri: string): Configurations<TaskConfiguration> {
-    const tasksContent = readFileSync(tasksConfigFileUri);
+  async extract(tasksConfigFileUri: string): Promise<Configurations<TaskConfiguration>> {
+    const tasksContent = await readFile(tasksConfigFileUri);
     const tasksJson = parse(tasksContent);
     if (!tasksJson || !tasksJson.tasks) {
       return { content: '', configs: [] };

--- a/plugins/task-plugin/src/task-plugin-backend.ts
+++ b/plugins/task-plugin/src/task-plugin-backend.ts
@@ -53,7 +53,7 @@ export async function start(context: theia.PluginContext): Promise<void> {
   await che.task.addTaskSubschema(CHE_TASK_SCHEMA);
 
   const exportConfigurationsManager = container.get<ExportConfigurationsManager>(ExportConfigurationsManager);
-  exportConfigurationsManager.export();
+  exportConfigurationsManager.init();
 
   const taskStatusHandler = container.get<TaskStatusHandler>(TaskStatusHandler);
   taskStatusHandler.init();

--- a/plugins/task-plugin/src/utils.ts
+++ b/plugins/task-plugin/src/utils.ts
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+import * as fs from 'fs-extra';
 import * as jsoncparser from 'jsonc-parser';
 import * as path from 'path';
 
@@ -15,8 +16,6 @@ import { FormattingOptions, JSONPath, ParseError } from 'jsonc-parser';
 
 import { URL } from 'url';
 import { resolve } from 'path';
-
-const fs = require('fs');
 
 /** Allows to get attribute by given name, returns `undefined` if attribute is not found */
 export function getAttribute(attributeName: string, attributes?: { [key: string]: string }): string | undefined {
@@ -102,10 +101,29 @@ export function readFileSync(filePath: string): string {
   }
 }
 
+/** Asynchronously reads the file by given path. Returns content of the file or empty string if file doesn't exist */
+export async function readFile(filePath: string): Promise<string> {
+  try {
+    if (await fs.pathExists(filePath)) {
+      return fs.readFile(filePath, 'utf8');
+    }
+    return '';
+  } catch (e) {
+    console.error(e);
+    return '';
+  }
+}
+
 /** Synchronously writes  given content to the file. Creates directories to the file if they don't exist */
 export function writeFileSync(filePath: string, content: string): void {
   ensureDirExistence(filePath);
   fs.writeFileSync(filePath, content);
+}
+
+/** Asynchronously writes given content to the file. Creates directories to the file if they don't exist */
+export async function writeFile(filePath: string, content: string): Promise<void> {
+  await ensureDirExists(filePath);
+  return fs.writeFile(filePath, content);
 }
 
 /** Synchronously creates a directory to the file if they don't exist */
@@ -115,4 +133,13 @@ export function ensureDirExistence(filePath: string): void {
     return;
   }
   fs.mkdirSync(dirName, { recursive: true });
+}
+
+/** Creates a directory containing the file if they don't exist */
+export async function ensureDirExists(filePath: string): Promise<void> {
+  const dirName = path.dirname(filePath);
+  if (await fs.pathExists(dirName)) {
+    return;
+  }
+  return fs.mkdirp(dirName);
 }

--- a/plugins/welcome-plugin/src/welcome-plugin.ts
+++ b/plugins/welcome-plugin/src/welcome-plugin.ts
@@ -53,8 +53,7 @@ async function getHtmlForWebview(context: theia.PluginContext): Promise<string> 
 }
 
 // Open Readme file is there is one
-export async function handleReadmeFiles(): Promise<void> {
-  const roots: theia.WorkspaceFolder[] | undefined = theia.workspace.workspaceFolders;
+export async function handleReadmeFiles(roots: theia.WorkspaceFolder[]): Promise<void> {
   // In case of only one workspace
   if (roots && roots.length === 1) {
     const children = await theia.workspace.findFiles('README.md', 'node_modules/**', 1);
@@ -126,12 +125,9 @@ export function start(context: theia.PluginContext): void {
     setTimeout(async () => {
       addPanel(context);
 
-      const workspacePlugin = theia.plugins.getPlugin('Eclipse Che.@eclipse-che/workspace-plugin');
-      if (workspacePlugin) {
-        workspacePlugin.exports.onDidCloneSources(() => handleReadmeFiles());
-      } else {
-        handleReadmeFiles();
-      }
+      theia.workspace.onDidChangeWorkspaceFolders(event => {
+        handleReadmeFiles(event.added);
+      }, context.subscriptions);
     }, 100);
   }
 }

--- a/plugins/welcome-plugin/src/welcome-plugin.ts
+++ b/plugins/welcome-plugin/src/welcome-plugin.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2020-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -53,22 +53,33 @@ async function getHtmlForWebview(context: theia.PluginContext): Promise<string> 
 }
 
 // Open Readme file is there is one
-export async function handleReadmeFiles(roots: theia.WorkspaceFolder[]): Promise<void> {
-  // In case of only one workspace
-  if (roots && roots.length === 1) {
-    const children = await theia.workspace.findFiles('README.md', 'node_modules/**', 1);
-    const updatedChildren = children.filter((child: theia.Uri) => {
-      if (child.fsPath.indexOf('node_modules') === -1) {
-        return child;
-      }
-    });
+export async function handleReadmeFiles(
+  readmeHandledCallback?: () => void,
+  roots?: theia.WorkspaceFolder[]
+): Promise<void> {
+  roots = roots ? roots : theia.workspace.workspaceFolders;
+  if (!roots || roots.length < 1) {
+    return;
+  }
 
-    if (updatedChildren.length >= 1) {
-      const openPath = theia.Uri.parse(updatedChildren[0] + '?open-handler=code-editor-preview');
-      const doc: theia.TextDocument | undefined = await theia.workspace.openTextDocument(openPath);
-      if (doc) {
-        theia.window.showTextDocument(doc);
-      }
+  const children = await theia.workspace.findFiles('README.md', 'node_modules/**', 1);
+  const updatedChildren = children.filter((child: theia.Uri) => {
+    if (child.fsPath.indexOf('node_modules') === -1) {
+      return child;
+    }
+  });
+
+  if (updatedChildren.length < 1) {
+    return;
+  }
+
+  const openPath = theia.Uri.parse(updatedChildren[0] + '?open-handler=code-editor-preview');
+  const doc: theia.TextDocument | undefined = await theia.workspace.openTextDocument(openPath);
+  if (doc) {
+    theia.window.showTextDocument(doc);
+
+    if (readmeHandledCallback) {
+      readmeHandledCallback();
     }
   }
 }
@@ -121,15 +132,42 @@ export function start(context: theia.PluginContext): void {
     showWelcomePage = configuration.get(Settings.SHOW_WELCOME_PAGE);
   }
 
-  if (showWelcomePage && theia.window.visibleTextEditors.length === 0) {
-    setTimeout(async () => {
-      addPanel(context);
-
-      theia.workspace.onDidChangeWorkspaceFolders(event => {
-        handleReadmeFiles(event.added);
-      }, context.subscriptions);
-    }, 100);
+  if (!showWelcomePage || theia.window.visibleTextEditors.length > 0) {
+    return;
   }
+
+  let cloneSourcesDisposable: theia.Disposable | undefined = undefined;
+  setTimeout(async () => {
+    addPanel(context);
+
+    const workspacePlugin = theia.plugins.getPlugin('Eclipse Che.@eclipse-che/workspace-plugin');
+    if (workspacePlugin && workspacePlugin.exports) {
+      // it handles the case when the multi-root mode is OFF
+      // we should remove this logic when we switch to the multi-root mode is ON by default
+      cloneSourcesDisposable = workspacePlugin.exports.onDidCloneSources(
+        () => handleReadmeFiles(readmeHandledCallback),
+        undefined,
+        context.subscriptions
+      );
+    } else {
+      handleReadmeFiles();
+    }
+  }, 100);
+
+  // handles the case when the multi-root mode is ON
+  const changeWorkspaceFoldersDisposable = theia.workspace.onDidChangeWorkspaceFolders(
+    event => handleReadmeFiles(readmeHandledCallback, event.added),
+    undefined,
+    context.subscriptions
+  );
+
+  const readmeHandledCallback = () => {
+    changeWorkspaceFoldersDisposable.dispose();
+
+    if (cloneSourcesDisposable) {
+      cloneSourcesDisposable.dispose();
+    }
+  };
 }
 
 export function stop(): void {}

--- a/plugins/workspace-plugin/src/theia-commands.ts
+++ b/plugins/workspace-plugin/src/theia-commands.ts
@@ -45,6 +45,7 @@ function isDevfileProjectConfig(
 
 export interface TheiaImportCommand {
   execute(): Promise<void>;
+  getProjectPath(): string;
 }
 
 export function buildProjectImportCommand(
@@ -117,6 +118,10 @@ export class TheiaGitCloneCommand implements TheiaImportCommand {
     }
 
     this.projectsRoot = projectsRoot;
+  }
+
+  getProjectPath(): string {
+    return this.projectPath;
   }
 
   clone(): PromiseLike<void> {
@@ -314,6 +319,10 @@ export class TheiaImportZipCommand implements TheiaImportCommand {
       // legacy project config
       theia.window.showErrorMessage('Legacy workspace config is not supported. Please use devfile instead.');
     }
+  }
+
+  getProjectPath(): string {
+    return this.projectDir;
   }
 
   async execute(): Promise<void> {

--- a/plugins/workspace-plugin/src/workspace-folder-updater.ts
+++ b/plugins/workspace-plugin/src/workspace-folder-updater.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/plugins/workspace-plugin/src/workspace-folder-updater.ts
+++ b/plugins/workspace-plugin/src/workspace-folder-updater.ts
@@ -1,0 +1,85 @@
+/**********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as theia from '@theia/plugin';
+const UPDATE_WORKSPACE_FOLDER_TIMEOUT = 5000;
+
+export class WorkspaceFolderUpdater {
+  private pendingFolders: string[] = [];
+  private addingWorkspaceFolderPromise: Promise<void> | undefined;
+
+  async addWorkspaceFolder(path: string): Promise<void> {
+    const workspaceFolderPath = this.toValidWorkspaceFolderPath(path);
+    if (this.pendingFolders.includes(workspaceFolderPath)) {
+      return Promise.resolve();
+    }
+
+    if (this.addingWorkspaceFolderPromise) {
+      this.pendingFolders.push(workspaceFolderPath);
+    } else {
+      try {
+        this.addingWorkspaceFolderPromise = this.addFolder(workspaceFolderPath);
+        await this.addingWorkspaceFolderPromise;
+      } catch (error) {
+        console.error(error);
+      } finally {
+        this.addingWorkspaceFolderPromise = undefined;
+      }
+
+      const next = this.pendingFolders.shift();
+      if (next) {
+        this.addWorkspaceFolder(next);
+      }
+    }
+    return Promise.resolve();
+  }
+
+  protected addFolder(projectPath: string): Promise<void> {
+    const isProjectFolder = (folder: theia.WorkspaceFolder) => folder.uri.path === projectPath;
+    const workspaceFolders = theia.workspace.workspaceFolders || [];
+    if (workspaceFolders.some(isProjectFolder)) {
+      return Promise.resolve(undefined);
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const disposable = theia.workspace.onDidChangeWorkspaceFolders(event => {
+        const existingWorkspaceFolders = theia.workspace.workspaceFolders || [];
+        if (event.added.some(isProjectFolder) || existingWorkspaceFolders.some(isProjectFolder)) {
+          clearTimeout(addFolderTimeout);
+
+          disposable.dispose();
+
+          resolve();
+        }
+      });
+
+      const addFolderTimeout = setTimeout(() => {
+        disposable.dispose();
+
+        reject(
+          new Error(
+            `Adding workspace folder ${projectPath} was cancelled by timeout ${UPDATE_WORKSPACE_FOLDER_TIMEOUT} ms`
+          )
+        );
+      }, UPDATE_WORKSPACE_FOLDER_TIMEOUT);
+
+      theia.workspace.updateWorkspaceFolders(workspaceFolders ? workspaceFolders.length : 0, undefined, {
+        uri: theia.Uri.file(projectPath),
+      });
+    });
+  }
+
+  protected toValidWorkspaceFolderPath(path: string): string {
+    if (path.endsWith('/')) {
+      return path.slice(0, -1);
+    }
+    return path;
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Handle multiple workspace roots
Checks if there is a che.theia-workspace file.
  if there is one, returns that file as being a workspace root
  if none, generate the file by getting all clonedPath/path of the devfile projects

enhancements:
 - [x] make it optional for now (like if there is a special attribute in devfile, use that mode)
 - [ ] track new folders in /projects and add them to the che.theia-workspace file automatically (and if we delete folders)
 - [ ] allow to customize/provide different projects to be added in workspace root. Could be useful for a maven project to see only sub-folders/modules
 
 I think we could resolve those items ^^ in a separate issue: by default a workspace starts in `OFF` multi-root mode - so no breaking changes for the `master` branch
 
The current state of the PR - a workspace starts in `OFF` multi-root mode - so the behavior should be exactly as for `master` branch.
A user should add the following section to a `devfile` to turn on multi-root mode:
 ```
attributes:
  multiRoot: 'on'

 ```
 Please let me know if you have a better idea for the attribute and value as marker for multi-root mode - it's easy to change on the current step.


Change-Id: Idfb9370dc503bcfb5504ba37446f7f1ab171b515
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17212

### TODO
- [x] Adding a workspace folder directly **after** cloning a project (not before, not during)
- [x] Align the corresponding plugin API of Theia with VS Code to provide the ability to display progress for views from plugin side (the PR on `Theia` side)
- [x] Minor: Replace CheApiService by WorkspaceService
- [x] Import a debug configuration from the devfile to a multi-root workspace https://github.com/eclipse/che-theia/pull/778#issuecomment-740552451
- [x] Fix config storage paths https://github.com/eclipse/che/issues/18548
- [x] Adapt handling of `Readme` files to multi-root workspace changes 
- [x] A debug configuration is not available for running
- [x] Add workspace folders in turn (there is a problem related to plugin API at adding project as workspace folder - a project is not displayed in `Projects` view when there are few projects are adding as workspace folders at the same time)  
- [x] Investigate if it's possible to export configurations on `Workspace` level https://github.com/eclipse/che-theia/pull/778#issuecomment-768936441
- [x] `Open Configurations` and `Add configuration` actions are not working for a multi-root workspace
- [x] Adapt Happy Path Tests to multi-root workspace changes
- [x] An ability to switch (turn on and turn off ) multi-root mode on a `devfile` level

Try it with two go projects, one with go modules, another without:
http://che.openshift.io/f/?url=https://gist.githubusercontent.com/benoitf/57ffa7e39e2e16a6a2f6756a44693e43/raw/5afea100c012fe05e325358f0a58577821a3cb99/golang-example.devfile.yaml

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next