### PR TITLE
Don't use 'alias' for 'che-theia init' as it breaks the build

### DIFF
--- a/devfiles/che-theia-all.devfile.yaml
+++ b/devfiles/che-theia-all.devfile.yaml
@@ -52,8 +52,7 @@ commands:
       - type: exec
         component: che-dev
         command: >
-                 che-theia init --alias
-                 https://github.com/eclipse/che-theia=/projects/che-theia && echo -e
+                 che-theia init && echo -e
                  "\e[32mDone.\e[0m che-theia init"
         workdir: /projects/theia
 


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Removes linking `che-theia` to the existing `/projects/che-theia` while doing `che-theia init`, as yarn requires to pre-build whole `che-theia` sources before doing Theia sources build. Otherwise, we've got:
```
lerna ERR! execute callback with error
lerna ERR! Error: Command failed: yarn run lint
lerna ERR! 
lerna ERR! Oops! Something went wrong! :(
lerna ERR! 
lerna ERR! ESLint: 6.8.0.
lerna ERR! 
lerna ERR! ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin".
```

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/16413

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
