### PR TITLE
Add getCurrentUser function for Plugin API

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-user-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-user-main.ts
@@ -9,15 +9,22 @@
  **********************************************************************/
 
 import { interfaces } from 'inversify';
-import { CheApiService, CheUserMain } from '../common/che-protocol';
+import { CheApiService, CheUserMain, User } from '../common/che-protocol';
 import { Preferences } from '@eclipse-che/plugin';
+import { OauthUtils } from './oauth-utils';
 
 export class CheUserMainImpl implements CheUserMain {
 
     private readonly cheApiService: CheApiService;
+    private readonly oAuthUtils: OauthUtils;
 
     constructor(container: interfaces.Container) {
         this.cheApiService = container.get(CheApiService);
+        this.oAuthUtils = container.get(OauthUtils);
+    }
+
+    async $getCurrentUser(): Promise<User> {
+        return this.cheApiService.getCurrentUser(await this.oAuthUtils.getUserToken());
     }
 
     $getUserPreferences(filter?: string): Promise<Preferences> {

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -398,6 +398,11 @@ export interface Preferences {
     [key: string]: string;
 }
 
+export interface User {
+    id: string;
+    name: string;
+}
+
 export interface WorkspaceSettings {
     [key: string]: string;
 }
@@ -463,7 +468,9 @@ export interface CheApiService {
 
     getFactoryById(factoryId: string): Promise<cheApi.factory.Factory>;
 
+    /** @deprecated use {@link getCurrentUser} instead. */
     getUserId(token?: string): Promise<string>;
+    getCurrentUser(token?: string): Promise<User>;
     getUserPreferences(): Promise<Preferences>;
     getUserPreferences(filter: string | undefined): Promise<Preferences>;
     updateUserPreferences(update: Preferences): Promise<Preferences>;
@@ -504,6 +511,7 @@ export interface CheTaskClient {
 export interface CheUser { }
 
 export interface CheUserMain {
+    $getCurrentUser(): Promise<User>;
     $getUserPreferences(filter?: string): Promise<Preferences>;
     $updateUserPreferences(preferences: Preferences): Promise<Preferences>;
     $replaceUserPreferences(preferences: Preferences): Promise<Preferences>;

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-api-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-api-service.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { CheApiService, Preferences, WorkspaceSettings } from '../common/che-protocol';
+import { CheApiService, Preferences, User, WorkspaceSettings } from '../common/che-protocol';
 import { che as cheApi } from '@eclipse-che/api';
 import WorkspaceClient, { IRestAPIConfig, IRemoteAPI } from '@eclipse-che/workspace-client';
 import { injectable } from 'inversify';
@@ -36,6 +36,11 @@ export class CheApiServiceImpl implements CheApiService {
         const cheApiClient = await this.getCheApiClient();
         const user = await cheApiClient.getCurrentUser(token);
         return user.id;
+    }
+
+    async getCurrentUser(token?: string): Promise<User> {
+        const cheApiClient = await this.getCheApiClient();
+        return cheApiClient.getCurrentUser(token);
     }
 
     async getUserPreferences(filter?: string): Promise<Preferences> {

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
@@ -193,6 +193,9 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
         };
 
         const user: typeof che.user = {
+            getCurrentUser(): Promise<che.User> {
+                return cheUserImpl.getCurrentUser();
+            },
             getUserPreferences(filter?: string): Promise<che.Preferences> {
                 return cheUserImpl.getUserPreferences(filter);
             },

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-user.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-user.ts
@@ -13,6 +13,7 @@ import { Preferences } from '@eclipse-che/plugin';
 import {
     CheUser,
     CheUserMain,
+    User,
     PLUGIN_RPC_CONTEXT,
 } from '../common/che-protocol';
 
@@ -22,6 +23,10 @@ export class CheUserImpl implements CheUser {
 
     constructor(rpc: RPCProtocol) {
         this.userMain = rpc.getProxy(PLUGIN_RPC_CONTEXT.CHE_USER_MAIN);
+    }
+
+    getCurrentUser(): Promise<User> {
+        return this.userMain.$getCurrentUser();
     }
 
     getUserPreferences(filter?: string): Promise<Preferences> {

--- a/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
+++ b/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
@@ -256,12 +256,18 @@ declare module '@eclipse-che/plugin' {
     }
 
     export namespace user {
+        export function getCurrentUser(): Promise<User>;
         export function getUserPreferences(): Promise<Preferences>;
         export function getUserPreferences(filter: string | undefined): Promise<Preferences>;
         export function updateUserPreferences(update: Preferences): Promise<Preferences>;
         export function replaceUserPreferences(preferences: Preferences): Promise<Preferences>;
         export function deleteUserPreferences(): Promise<void>;
         export function deleteUserPreferences(list: string[] | undefined): Promise<void>;
+    }
+
+    export interface User {
+        id: string;
+        name: string
     }
 
     export interface Preferences {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add `getCurrentUser()` function for Plugin API. It is needed to get OpenShift cluster URL in hosted Che, see: https://www.eclipse.org/che/docs/che-7/hosted-che/#finding-the-cluster-where-the-hosted-che-workspace-is-running_hosted-che

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16890

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
