### PR TITLE
Adapt to upstream changes: @theia/json has gone

### DIFF
--- a/build.include
+++ b/build.include
@@ -12,7 +12,7 @@ set -u
 
 IMAGE_TAG="next"
 THEIA_VERSION="master"
-THEIA_BRANCH="ak\\/json_vscode"
+THEIA_BRANCH="master"
 THEIA_COMMIT_SHA=
 THEIA_GIT_REFS="refs\\/heads\\/master"
 THEIA_DOCKER_IMAGE_VERSION=

--- a/build.include
+++ b/build.include
@@ -12,7 +12,7 @@ set -u
 
 IMAGE_TAG="next"
 THEIA_VERSION="master"
-THEIA_BRANCH="master"
+THEIA_BRANCH="ak/json_vscode"
 THEIA_COMMIT_SHA=
 THEIA_GIT_REFS="refs\\/heads\\/master"
 THEIA_DOCKER_IMAGE_VERSION=

--- a/build.include
+++ b/build.include
@@ -12,8 +12,8 @@ set -u
 
 IMAGE_TAG="next"
 THEIA_VERSION="master"
-THEIA_BRANCH="ak/json_vscode"
-THEIA_COMMIT_SHA=
+THEIA_BRANCH="master"
+THEIA_COMMIT_SHA="ad2f8121c2c535801ab986d98db3be593e1257c8"
 THEIA_GIT_REFS="refs\\/heads\\/master"
 THEIA_DOCKER_IMAGE_VERSION=
 

--- a/build.include
+++ b/build.include
@@ -12,8 +12,8 @@ set -u
 
 IMAGE_TAG="next"
 THEIA_VERSION="master"
-THEIA_BRANCH="master"
-THEIA_COMMIT_SHA="ad2f8121c2c535801ab986d98db3be593e1257c8"
+THEIA_BRANCH="ak\\/json_vscode"
+THEIA_COMMIT_SHA=
 THEIA_GIT_REFS="refs\\/heads\\/master"
 THEIA_DOCKER_IMAGE_VERSION=
 

--- a/generator/src/templates/assembly-package.mst
+++ b/generator/src/templates/assembly-package.mst
@@ -22,7 +22,6 @@
     "@theia/editor": "^{{ version }}",
     "@theia/file-search": "^{{ version }}",
     "@theia/filesystem": "^{{ version }}",
-    "@theia/json": "^{{ version }}",
     "@theia/keymaps": "^{{ version }}",
     "@theia/languages": "^{{ version }}",
     "@theia/markers": "^{{ version }}",

--- a/generator/src/templates/theiaPlugins.json
+++ b/generator/src/templates/theiaPlugins.json
@@ -21,6 +21,7 @@
     "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
     "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
     "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+    "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
     "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
     "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
     "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",

--- a/generator/src/templates/theiaPlugins.json
+++ b/generator/src/templates/theiaPlugins.json
@@ -20,7 +20,7 @@
     "vscode-builtin-jake": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/jake-1.39.1-prel.vsix",
     "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
     "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
-    "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+    "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.46.1/file/vscode.json-1.46.1.vsix",
     "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
     "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
     "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Switches Che Theia to using VS Code built-in JSON extensions instead of JSON Theia Extension.

### What issues does this PR fix or reference?
closes https://github.com/eclipse/che/issues/17319

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
