### PR TITLE
Freeze version of workspace-client library

### DIFF
--- a/extensions/che-theia-hosted-plugin-manager-extension/package.json
+++ b/extensions/che-theia-hosted-plugin-manager-extension/package.json
@@ -12,7 +12,7 @@
     "@theia/core": "next",
     "@theia/plugin-dev": "next",
     "@theia/plugin-ext": "next",
-    "@eclipse-che/workspace-client": "latest",
+    "@eclipse-che/workspace-client": "0.0.1-1585913592",
     "@eclipse-che/api": "latest"
   },
   "scripts": {

--- a/extensions/eclipse-che-theia-plugin-ext/package.json
+++ b/extensions/eclipse-che-theia-plugin-ext/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@eclipse-che/plugin": "0.0.1",
-    "@eclipse-che/workspace-client": "latest",
+    "@eclipse-che/workspace-client": "0.0.1-1585913592",
     "@theia/core": "next",
     "@theia/task": "next",
     "@theia/mini-browser": "next",

--- a/extensions/eclipse-che-theia-terminal/package.json
+++ b/extensions/eclipse-che-theia-terminal/package.json
@@ -22,7 +22,7 @@
     "@theia/core": "next",
     "@theia/terminal": "next",
     "reconnecting-websocket": "^4.2.0",
-    "@eclipse-che/workspace-client": "latest",
+    "@eclipse-che/workspace-client": "0.0.1-1585913592",
     "@eclipse-che/api": "latest",
     "vscode-ws-jsonrpc": "0.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,7 +289,7 @@
   dependencies:
     "@eclipse-che/api" latest
 
-"@eclipse-che/workspace-client@latest":
+"@eclipse-che/workspace-client@0.0.1-1585913592":
   version "0.0.1-1585913592"
   resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1585913592.tgz#509c0a12e96adfec3a8c619124c396ecdb755806"
   integrity sha512-BxR1pydD3Qn6uS5Yp3TCWDEvgAmwWo254XC6KVJxdeofDeMNRpSx3KWuSrPWdC4jd5+urGKk/nG7vZyCST+85A==


### PR DESCRIPTION
### What does this PR do?
This changes proposal freezes version for workspace-client from `latest` to latest tagged `0.0.1-1585913592`. To have smooth incoming changes that won't try to break anything after merge https://github.com/eclipse/che-workspace-client/pull/31, because https://github.com/eclipse/che-workspace-client/pull/31 is going to be merged among with upcoming changes in che-theia.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
Needed for https://github.com/eclipse/che/issues/17246
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
