### PR TITLE
Provide ability to call filtered workspace service methods using user token

### DIFF
--- a/dockerfiles/theia/e2e/test.sh
+++ b/dockerfiles/theia/e2e/test.sh
@@ -23,6 +23,10 @@ run_test_in_docker_container() {
        -v "${base_dir}/videos":/root/cypress/videos \
        -v "${base_dir}/logs":/root/logs \
        -v /var/run/docker.sock:/var/run/docker.sock \
+       -e CHE_API_INTERNAL=http://127.0.0.1/api \
+       -e CHE_MACHINE_TOKEN=foobar \
+       -e CHE_WORKSPACE_ID=workspaceId \
+       -e CHE_WORKSPACE_TELEMETRY_BACKEND_PORT=4167 \
            $IMAGE_NAME
 }
 

--- a/extensions/che-theia-hosted-plugin-manager-extension/package.json
+++ b/extensions/che-theia-hosted-plugin-manager-extension/package.json
@@ -12,7 +12,7 @@
     "@theia/core": "next",
     "@theia/plugin-dev": "next",
     "@theia/plugin-ext": "next",
-    "@eclipse-che/workspace-client": "0.0.1-1585913592",
+    "@eclipse-che/workspace-client": "latest",
     "@eclipse-che/api": "latest"
   },
   "scripts": {

--- a/extensions/eclipse-che-theia-plugin-ext/package.json
+++ b/extensions/eclipse-che-theia-plugin-ext/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@eclipse-che/plugin": "0.0.1",
-    "@eclipse-che/workspace-client": "0.0.1-1585913592",
+    "@eclipse-che/workspace-client": "latest",
     "@theia/core": "next",
     "@theia/task": "next",
     "@theia/mini-browser": "next",

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-devfile-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-devfile-main.ts
@@ -34,7 +34,7 @@ export class CheDevfileMainImpl implements CheDevfileMain {
 
     async $createWorkspace(devfilePath: string): Promise<void> {
         return new Promise<void>(async (resolve, reject) => {
-            let baseURI = await this.cheApiService.getCheApiURI();
+            let baseURI = this.cheApiService.getCheApiURI();
 
             if (!baseURI) {
                 const error = 'Che API URI is not set!';

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-task-resolver.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-task-resolver.ts
@@ -113,7 +113,7 @@ export class CheTaskResolver implements TaskResolver {
             return this.workspaceId;
         }
 
-        this.workspaceId = await this.cheApi.getCurrentWorkspaceId();
+        this.workspaceId = this.cheApi.getCurrentWorkspaceId();
         return this.workspaceId;
     }
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -454,11 +454,13 @@ export const CHE_API_SERVICE_PATH = '/che-api-service';
 export const CheApiService = Symbol('CheApiService');
 
 export interface CheApiService {
-    getCurrentWorkspaceId(): Promise<string>;
-    getCheApiURI(): Promise<string | undefined>;
+    getCurrentWorkspaceId(): string;
+    getCheApiURI(): string;
 
     currentWorkspace(): Promise<cheApi.workspace.Workspace>;
     getWorkspaceById(workspaceId: string): Promise<cheApi.workspace.Workspace>;
+    getAll(userToken?: string): Promise<cheApi.workspace.Workspace[]>;
+    getAllByNamespace(namespace: string, userToken?: string): Promise<cheApi.workspace.Workspace[]>;
     getCurrentWorkspacesContainers(): Promise<{ [key: string]: cheApi.workspace.Machine }>;
     findUniqueServerByAttribute(attributeName: string, attributeValue: string): Promise<cheApi.workspace.Server>;
 
@@ -469,8 +471,8 @@ export interface CheApiService {
     getFactoryById(factoryId: string): Promise<cheApi.factory.Factory>;
 
     /** @deprecated use {@link getCurrentUser} instead. */
-    getUserId(token?: string): Promise<string>;
-    getCurrentUser(token?: string): Promise<User>;
+    getUserId(userToken?: string): Promise<string>;
+    getCurrentUser(userToken?: string): Promise<User>;
     getUserPreferences(): Promise<Preferences>;
     getUserPreferences(filter: string | undefined): Promise<Preferences>;
     updateUserPreferences(update: Preferences): Promise<Preferences>;
@@ -486,8 +488,8 @@ export interface CheApiService {
     getAllSshKey(service: string): Promise<cheApi.ssh.SshPair[]>;
     submitTelemetryEvent(id: string, ownerId: string, ip: string, agent: string, resolution: string, properties: [string, string][]): Promise<void>;
     submitTelemetryActivity(): Promise<void>;
-    getOAuthToken(oAuthProvider: string, token?: string): Promise<string | undefined>;
-    getOAuthProviders(token?: string): Promise<string[]>;
+    getOAuthToken(oAuthProvider: string, userToken?: string): Promise<string | undefined>;
+    getOAuthProviders(userToken?: string): Promise<string[]>;
 }
 
 export const CHE_TASK_SERVICE_PATH = '/che-task-service';

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-api-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-api-service.ts
@@ -9,138 +9,116 @@
  **********************************************************************/
 import { CheApiService, Preferences, User, WorkspaceSettings } from '../common/che-protocol';
 import { che as cheApi } from '@eclipse-che/api';
-import WorkspaceClient, { IRestAPIConfig, IRemoteAPI } from '@eclipse-che/workspace-client';
+import WorkspaceClient, { IRemoteAPI } from '@eclipse-che/workspace-client';
 import { injectable } from 'inversify';
-
 import { SS_CRT_PATH } from './che-https';
-
-import { TelemetryClient, Event, EventProperty } from '@eclipse-che/workspace-telemetry-client';
-
-const ENV_WORKSPACE_ID_IS_NOT_SET = 'Environment variable CHE_WORKSPACE_ID is not set';
+import { TelemetryClient, EventProperty } from '@eclipse-che/workspace-telemetry-client';
 
 @injectable()
 export class CheApiServiceImpl implements CheApiService {
 
-    private workspaceRestAPI: IRemoteAPI | undefined;
-    private telemetryClient: TelemetryClient | undefined = this.getWorkspaceTelemetryClient();
+    private readonly telemetryClient: TelemetryClient | undefined;
 
-    async getCurrentWorkspaceId(): Promise<string> {
-        return this.getWorkspaceIdFromEnv();
+    /**
+     * Workspace client based variables.
+     *
+     * baseAPIUrl - responsible for storing base url to API service, taken from environment variable
+     * machineToken - machine token taken from environment variable, always the same at workspace lifecycle
+     * workspaceId - workspace ID taken from environment variable, always the same at workspace lifecycle
+     */
+    private readonly baseAPIUrl: string;
+    private readonly machineToken: string;
+    private readonly workspaceId: string;
+
+    constructor() {
+        if (process.env.CHE_API_INTERNAL === undefined) {
+            throw new Error('Unable to create Che API REST Client: "CHE_API_INTERNAL" is not set.');
+        } else {
+            this.baseAPIUrl = process.env.CHE_API_INTERNAL;
+        }
+
+        if (process.env.CHE_MACHINE_TOKEN === undefined) {
+            throw new Error('Machine token is not set.');
+        } else {
+            this.machineToken = process.env.CHE_MACHINE_TOKEN;
+        }
+
+        if (process.env.CHE_WORKSPACE_ID === undefined) {
+            throw new Error('Environment variable CHE_WORKSPACE_ID is not set');
+        } else {
+            this.workspaceId = process.env.CHE_WORKSPACE_ID;
+        }
+
+        if (process.env.CHE_WORKSPACE_TELEMETRY_BACKEND_PORT === undefined) {
+            console.error('Unable to create Che API REST Client: "CHE_WORKSPACE_TELEMETRY_BACKEND_PORT" is not set.');
+        } else {
+            this.telemetryClient = new TelemetryClient(undefined, 'http://localhost:' + process.env.CHE_WORKSPACE_TELEMETRY_BACKEND_PORT);
+        }
     }
 
-    async getCheApiURI(): Promise<string | undefined> {
-        return process.env.CHE_API_INTERNAL;
+    getCurrentWorkspaceId(): string {
+        return this.workspaceId;
     }
 
-    async getUserId(token?: string): Promise<string> {
-        const cheApiClient = await this.getCheApiClient();
-        const user = await cheApiClient.getCurrentUser(token);
+    getCheApiURI(): string {
+        return this.baseAPIUrl;
+    }
+
+    async getUserId(userToken?: string): Promise<string> {
+        const user = await this.updateAndGetRemoteAPI(userToken).getCurrentUser();
         return user.id;
     }
 
-    async getCurrentUser(token?: string): Promise<User> {
-        const cheApiClient = await this.getCheApiClient();
-        return cheApiClient.getCurrentUser(token);
+    getCurrentUser(userToken?: string): Promise<User> {
+        return this.updateAndGetRemoteAPI(userToken).getCurrentUser();
     }
 
-    async getUserPreferences(filter?: string): Promise<Preferences> {
-        const cheApiClient = await this.getCheApiClient();
-        return cheApiClient.getUserPreferences(filter);
+    getUserPreferences(filter?: string): Promise<Preferences> {
+        return this.updateAndGetRemoteAPI().getUserPreferences(filter);
     }
 
-    async updateUserPreferences(update: Preferences): Promise<Preferences> {
-        const cheApiClient = await this.getCheApiClient();
-        return cheApiClient.updateUserPreferences(update);
+    updateUserPreferences(update: Preferences): Promise<Preferences> {
+        return this.updateAndGetRemoteAPI().updateUserPreferences(update);
     }
 
-    async replaceUserPreferences(preferences: Preferences): Promise<Preferences> {
-        const cheApiClient = await this.getCheApiClient();
-        return cheApiClient.replaceUserPreferences(preferences);
+    replaceUserPreferences(preferences: Preferences): Promise<Preferences> {
+        return this.updateAndGetRemoteAPI().replaceUserPreferences(preferences);
     }
 
-    async deleteUserPreferences(list?: string[]): Promise<void> {
-        const cheApiClient = await this.getCheApiClient();
-        return cheApiClient.deleteUserPreferences(list);
+    deleteUserPreferences(list?: string[]): Promise<void> {
+        return this.updateAndGetRemoteAPI().deleteUserPreferences(list);
     }
 
-    async getWorkspaceSettings(): Promise<WorkspaceSettings> {
-        const cheApiClient = await this.getCheApiClient();
-        return cheApiClient.getSettings();
+    getWorkspaceSettings(): Promise<WorkspaceSettings> {
+        return this.updateAndGetRemoteAPI().getSettings();
     }
 
-    async currentWorkspace(): Promise<cheApi.workspace.Workspace> {
-        try {
-            const workspaceId = process.env.CHE_WORKSPACE_ID;
-            if (!workspaceId) {
-                return Promise.reject(ENV_WORKSPACE_ID_IS_NOT_SET);
-            }
-
-            const cheApiClient = await this.getCheApiClient();
-            if (cheApiClient) {
-                return await cheApiClient.getById<cheApi.workspace.Workspace>(workspaceId);
-            }
-
-            return Promise.reject('Cannot create Che API REST Client');
-        } catch (e) {
-            console.log(e);
-            return Promise.reject('Cannot create Che API REST Client');
-        }
+    currentWorkspace(): Promise<cheApi.workspace.Workspace> {
+        return this.updateAndGetRemoteAPI().getById<cheApi.workspace.Workspace>(this.workspaceId);
     }
 
-    async getWorkspaceById(workspaceId: string): Promise<cheApi.workspace.Workspace> {
-        try {
-            if (!workspaceId) {
-                return Promise.reject('Che Workspace id is not set');
-            }
-
-            const cheApiClient = await this.getCheApiClient();
-            if (cheApiClient) {
-                return await cheApiClient.getById<cheApi.workspace.Workspace>(workspaceId);
-            }
-
-            return Promise.reject('Cannot create Che API REST Client');
-        } catch (e) {
-            console.log(e);
-            return Promise.reject('Cannot create Che API REST Client');
-        }
+    getWorkspaceById(workspaceId: string): Promise<cheApi.workspace.Workspace> {
+        return this.updateAndGetRemoteAPI().getById(this.workspaceId);
     }
 
-    async updateWorkspace(workspaceId: string, workspace: cheApi.workspace.Workspace): Promise<cheApi.workspace.Workspace> {
-        try {
-            if (!workspaceId) {
-                return Promise.reject('Che Workspace id is not set');
-            }
-
-            const cheApiClient = await this.getCheApiClient();
-            if (cheApiClient) {
-                return await cheApiClient.update(workspaceId, workspace);
-            }
-
-            return Promise.reject('Cannot create Che API REST Client');
-        } catch (e) {
-            console.log(e);
-            return Promise.reject('Cannot create Che API REST Client');
-        }
+    getAll(userToken?: string): Promise<cheApi.workspace.Workspace[]> {
+        return this.updateAndGetRemoteAPI(userToken).getAll();
     }
 
-    async updateWorkspaceActivity(): Promise<void> {
-        try {
-            const cheApiClient = await this.getCheApiClient();
-            return cheApiClient.updateActivity(this.getWorkspaceIdFromEnv());
-        } catch (e) {
-            console.error(e);
-            throw new Error(e);
-        }
+    getAllByNamespace(namespace: string, userToken?: string): Promise<cheApi.workspace.Workspace[]> {
+        return this.updateAndGetRemoteAPI(userToken).getAllByNamespace(namespace);
     }
 
-    async stop(): Promise<void> {
-        const workspaceId = process.env.CHE_WORKSPACE_ID;
-        if (!workspaceId) {
-            return Promise.reject(ENV_WORKSPACE_ID_IS_NOT_SET);
-        }
+    updateWorkspace(workspaceId: string, workspace: cheApi.workspace.Workspace): Promise<cheApi.workspace.Workspace> {
+        return this.updateAndGetRemoteAPI().update(workspaceId, workspace);
+    }
 
-        const cheApiClient = await this.getCheApiClient();
-        return await cheApiClient.stop(workspaceId);
+    updateWorkspaceActivity(): Promise<void> {
+        return this.updateAndGetRemoteAPI().updateActivity(this.workspaceId);
+    }
+
+    stop(): Promise<void> {
+        return this.updateAndGetRemoteAPI().stop(this.workspaceId);
     }
 
     async getCurrentWorkspacesContainers(): Promise<{ [key: string]: cheApi.workspace.Machine }> {
@@ -184,184 +162,72 @@ export class CheApiServiceImpl implements CheApiService {
         }
     }
 
-    async getFactoryById(factoryId: string): Promise<cheApi.factory.Factory> {
-        try {
-            const client = await this.getCheApiClient();
-            if (client) {
-                return await client.getFactory<cheApi.factory.Factory>(factoryId);
-            }
-
-            return Promise.reject(`Unable to get factory with ID ${factoryId}`);
-        } catch (e) {
-            return Promise.reject('Unable to create Che API REST Client');
-        }
+    getFactoryById(factoryId: string): Promise<cheApi.factory.Factory> {
+        return this.updateAndGetRemoteAPI().getFactory(factoryId);
     }
 
-    async generateSshKey(service: string, name: string): Promise<cheApi.ssh.SshPair> {
-        try {
-            const client = await this.getCheApiClient();
-            if (client) {
-                return client.generateSshKey(service, name);
-            }
-
-            throw new Error(`Unable to generate SSH Key for ${service}:${name}`);
-        } catch (e) {
-            console.error(e);
-            throw new Error(e);
-        }
+    generateSshKey(service: string, name: string): Promise<cheApi.ssh.SshPair> {
+        return this.updateAndGetRemoteAPI().generateSshKey(service, name);
     }
 
-    async createSshKey(sshKeyPair: cheApi.ssh.SshPair): Promise<void> {
-        try {
-            const client = await this.getCheApiClient();
-            if (client) {
-                return client.createSshKey(sshKeyPair);
-            }
-
-            throw new Error('Unable to create SSH Key');
-        } catch (e) {
-            console.error(e);
-            throw new Error(e);
-        }
+    createSshKey(sshKeyPair: cheApi.ssh.SshPair): Promise<void> {
+        return this.updateAndGetRemoteAPI().createSshKey(sshKeyPair);
     }
 
-    async getSshKey(service: string, name: string): Promise<cheApi.ssh.SshPair> {
-        try {
-            const client = await this.getCheApiClient();
-            if (client) {
-                return await client.getSshKey(service, name);
-            }
-
-            throw new Error(`Unable to get SSH Key for ${service}:${name}`);
-        } catch (e) {
-            console.error(e);
-            throw new Error(e);
-        }
+    getSshKey(service: string, name: string): Promise<cheApi.ssh.SshPair> {
+        return this.updateAndGetRemoteAPI().getSshKey(service, name);
     }
 
-    async getAllSshKey(service: string): Promise<cheApi.ssh.SshPair[]> {
-        try {
-            const client = await this.getCheApiClient();
-            if (client) {
-                return client.getAllSshKey(service);
-            }
-            throw new Error(`Unable to get SSH Keys for ${service}`);
-        } catch (e) {
-            console.error(e);
-            throw new Error(e);
-        }
+    getAllSshKey(service: string): Promise<cheApi.ssh.SshPair[]> {
+        return this.updateAndGetRemoteAPI().getAllSshKey(service);
     }
 
-    async deleteSshKey(service: string, name: string): Promise<void> {
-        try {
-            const client = await this.getCheApiClient();
-            if (client) {
-                return client.deleteSshKey(service, name);
-            }
-            throw new Error(`Unable to delete SSH Key for ${service}:${name}`);
-        } catch (e) {
-            console.error(e);
-            throw new Error(e);
-        }
+    deleteSshKey(service: string, name: string): Promise<void> {
+        return this.updateAndGetRemoteAPI().deleteSshKey(service, name);
     }
 
     async submitTelemetryEvent(id: string, ownerId: string, ip: string, agent: string, resolution: string, properties: [string, string][]): Promise<void> {
-        try {
-            const event: Event = {
-                id: id,
-                ip: ip,
-                ownerId: ownerId,
-                agent: agent,
-                resolution: resolution,
-                properties: properties.map((prop: [string, string]) => {
-                    const eventProp: EventProperty = {
-                        id: prop[0],
-                        value: prop[1]
-                    };
-                    return eventProp;
-                })
-            };
-            if (this.telemetryClient) {
-                await this.telemetryClient.event(event);
-            }
-        } catch (e) {
-            console.error(e);
-            throw new Error(e);
+        if (this.telemetryClient === undefined) {
+            return;
         }
+
+        await this.telemetryClient.event({
+            id: id,
+            ip: ip,
+            ownerId: ownerId,
+            agent: agent,
+            resolution: resolution,
+            properties: properties.map((prop: [string, string]) => {
+                const eventProp: EventProperty = {
+                    id: prop[0],
+                    value: prop[1]
+                };
+                return eventProp;
+            })
+        });
     }
 
     async submitTelemetryActivity(): Promise<void> {
-        try {
-            if (this.telemetryClient) {
-                await this.telemetryClient.activity();
-            }
-        } catch (e) {
-            console.error(e);
-            throw new Error(e);
+        if (this.telemetryClient === undefined) {
+            return;
         }
+        await this.telemetryClient.activity();
     }
 
-    async getOAuthToken(oAuthProvider: string, token?: string): Promise<string | undefined> {
-        const cheApiClient = await this.getCheApiClient();
-        return cheApiClient.getOAuthToken(oAuthProvider, token);
+    getOAuthToken(oAuthProvider: string, userToken?: string): Promise<string | undefined> {
+        return this.updateAndGetRemoteAPI(userToken).getOAuthToken(oAuthProvider);
     }
 
-    async getOAuthProviders(token?: string): Promise<string[]> {
-        const cheApiClient = await this.getCheApiClient();
-        try {
-            return await cheApiClient.getOAuthProviders(token);
-        } catch (e) {
-            return [];
-        }
+    getOAuthProviders(userToken?: string): Promise<string[]> {
+        return this.updateAndGetRemoteAPI(userToken).getOAuthProviders();
     }
 
-    private getWorkspaceTelemetryClient(): TelemetryClient | undefined {
-
-        if (!this.telemetryClient) {
-            const cheWorkspaceTelemetryBackendPortVar = process.env.CHE_WORKSPACE_TELEMETRY_BACKEND_PORT;
-
-            if (!cheWorkspaceTelemetryBackendPortVar) {
-                console.error('Unable to create Che API REST Client: "CHE_WORKSPACE_TELEMETRY_BACKEND_PORT" is not set.');
-                return undefined;
-            }
-
-            this.telemetryClient = new TelemetryClient(undefined, 'http://localhost:' + cheWorkspaceTelemetryBackendPortVar);
-        }
-
-        return this.telemetryClient;
+    private updateAndGetRemoteAPI(userToken?: string): IRemoteAPI {
+        return WorkspaceClient.getRestApi({
+            baseUrl: this.baseAPIUrl,
+            ssCrtPath: SS_CRT_PATH,
+            machineToken: userToken && userToken.length > 0 ? undefined : this.machineToken,
+            userToken: userToken && userToken.length > 0 ? userToken : undefined
+        });
     }
-
-    private async getCheApiClient(): Promise<IRemoteAPI> {
-        const cheApiInternalVar = process.env.CHE_API_INTERNAL;
-        const cheMachineToken = process.env.CHE_MACHINE_TOKEN;
-
-        if (!cheApiInternalVar) {
-            return Promise.reject('Unable to create Che API REST Client: "CHE_API_INTERNAL" is not set.');
-        }
-
-        if (!this.workspaceRestAPI) {
-            const restAPIConfig: IRestAPIConfig = {
-                baseUrl: cheApiInternalVar,
-                headers: {}
-            };
-            if (cheMachineToken) {
-                restAPIConfig.headers['Authorization'] = 'Bearer ' + cheMachineToken;
-            }
-            restAPIConfig.ssCrtPath = SS_CRT_PATH;
-
-            this.workspaceRestAPI = WorkspaceClient.getRestApi(restAPIConfig);
-        }
-
-        return this.workspaceRestAPI;
-    }
-
-    private getWorkspaceIdFromEnv(): string {
-        const workspaceId = process.env.CHE_WORKSPACE_ID;
-        if (!workspaceId) {
-            throw new Error(ENV_WORKSPACE_ID_IS_NOT_SET);
-        }
-
-        return workspaceId;
-    }
-
 }

--- a/extensions/eclipse-che-theia-terminal/package.json
+++ b/extensions/eclipse-che-theia-terminal/package.json
@@ -22,7 +22,7 @@
     "@theia/core": "next",
     "@theia/terminal": "next",
     "reconnecting-websocket": "^4.2.0",
-    "@eclipse-che/workspace-client": "0.0.1-1585913592",
+    "@eclipse-che/workspace-client": "latest",
     "@eclipse-che/api": "latest",
     "vscode-ws-jsonrpc": "0.2.0"
   },

--- a/extensions/eclipse-che-theia-terminal/src/node/workspace-service-impl.ts
+++ b/extensions/eclipse-che-theia-terminal/src/node/workspace-service-impl.ts
@@ -9,7 +9,7 @@
  **********************************************************************/
 
 import { injectable, inject } from 'inversify';
-import WorkspaceClient, { IRemoteAPI, IRestAPIConfig } from '@eclipse-che/workspace-client';
+import WorkspaceClient, { IRemoteAPI } from '@eclipse-che/workspace-client';
 import { che } from '@eclipse-che/api';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { CHEWorkspaceService, WorkspaceContainer } from '../common/workspace-service';
@@ -113,16 +113,11 @@ export class CHEWorkspaceServiceImpl implements CHEWorkspaceService {
 
     private getRemoteApi(): IRemoteAPI {
         if (!this.api) {
-            const machineToken = this.getMachineToken();
-            const baseUrl = this.getWsMasterApiEndPoint();
-            const restConfig: IRestAPIConfig = { baseUrl: baseUrl, headers: {} };
-
-            if (machineToken) {
-                restConfig.headers['Authorization'] = 'Bearer ' + machineToken;
-            }
-            restConfig.ssCrtPath = SS_CRT_PATH;
-
-            this.api = WorkspaceClient.getRestApi(restConfig);
+            this.api = WorkspaceClient.getRestApi({
+                baseUrl: this.getWsMasterApiEndPoint(),
+                machineToken: this.getMachineToken(),
+                ssCrtPath: SS_CRT_PATH
+            });
         }
         return this.api;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,10 +304,10 @@
   dependencies:
     "@eclipse-che/api" latest
 
-"@eclipse-che/workspace-client@0.0.1-1585913592":
-  version "0.0.1-1585913592"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1585913592.tgz#509c0a12e96adfec3a8c619124c396ecdb755806"
-  integrity sha512-BxR1pydD3Qn6uS5Yp3TCWDEvgAmwWo254XC6KVJxdeofDeMNRpSx3KWuSrPWdC4jd5+urGKk/nG7vZyCST+85A==
+"@eclipse-che/workspace-client@latest":
+  version "0.0.1-1593692693"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1593692693.tgz#0606ef98a84b7e7c8a5305f31cf07696c1e29bed"
+  integrity sha512-DCD/oL3Hs0EKzypyn05c5cMiVOHrYds8cQ102Sti2/W70KTyTtQJNVUsuew1qnUHUlb/VCLdkwq2ck/DV6TqgQ==
   dependencies:
     "@eclipse-che/api" "^7.0.0-beta-4.0"
     axios "0.19.0"


### PR DESCRIPTION
### What does this PR do?
This changes proposal adds an ability to call workspace service methods using user access token. Some of methods due to restriction, requires keycloak token, not machine's one.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17246
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
