### PR TITLE
Keep machine exec connection

### DIFF
--- a/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
@@ -158,7 +158,13 @@ export class RemoteTerminalWidget extends TerminalWidgetImpl {
 
     protected async reconnectTerminalProcess(): Promise<void> {
         if (typeof this.terminalId === 'number') {
-            const termId = await this.termServer!.check({ id: this.terminalId });
+            let termId;
+            try {
+                termId = await this.termServer!.check({ id: this.terminalId });
+            } catch (error) {
+                termId = -1;
+            }
+
             if (!IBaseTerminalServer.validateId(termId)) {
                 return;
             }


### PR DESCRIPTION
### What does this PR do?
Fix issues related to losing connection to `machine exec`, for example, at running `che` tasks
(can be recognized by error message: `Request runTask failed with message: Failed to execute Che command: Connection is disposed.`)

image for testing goals: `rnikitenko/che-theia:keepExecConnectionMaster`

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>