### PR TITLE
Keep machine exec connection

### DIFF
--- a/extensions/che-theia-hosted-plugin-manager-extension/package.json
+++ b/extensions/che-theia-hosted-plugin-manager-extension/package.json
@@ -12,7 +12,7 @@
     "@theia/core": "1.3.0-next.dc5b9e1c",
     "@theia/plugin-dev": "1.3.0-next.dc5b9e1c",
     "@theia/plugin-ext": "1.3.0-next.dc5b9e1c",
-    "@eclipse-che/workspace-client": "latest",
+    "@eclipse-che/workspace-client": "0.0.1-1585913592",
     "@eclipse-che/api": "latest"
   },
   "scripts": {

--- a/extensions/eclipse-che-theia-plugin-ext/package.json
+++ b/extensions/eclipse-che-theia-plugin-ext/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@eclipse-che/plugin": "7.14.3",
-    "@eclipse-che/workspace-client": "latest",
+    "@eclipse-che/workspace-client": "0.0.1-1585913592",
     "@theia/core": "1.3.0-next.dc5b9e1c",
     "@theia/task": "1.3.0-next.dc5b9e1c",
     "@theia/mini-browser": "1.3.0-next.dc5b9e1c",

--- a/extensions/eclipse-che-theia-terminal/package.json
+++ b/extensions/eclipse-che-theia-terminal/package.json
@@ -22,7 +22,7 @@
     "@theia/core": "1.3.0-next.dc5b9e1c",
     "@theia/terminal": "1.3.0-next.dc5b9e1c",
     "reconnecting-websocket": "^4.2.0",
-    "@eclipse-che/workspace-client": "latest",
+    "@eclipse-che/workspace-client": "0.0.1-1585913592",
     "@eclipse-che/api": "latest",
     "vscode-ws-jsonrpc": "0.2.0"
   },

--- a/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
@@ -158,7 +158,13 @@ export class RemoteTerminalWidget extends TerminalWidgetImpl {
 
     protected async reconnectTerminalProcess(): Promise<void> {
         if (typeof this.terminalId === 'number') {
-            const termId = await this.termServer!.check({ id: this.terminalId });
+            let termId;
+            try {
+                termId = await this.termServer!.check({ id: this.terminalId });
+            } catch (error) {
+                termId = -1;
+            }
+
             if (!IBaseTerminalServer.validateId(termId)) {
                 return;
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,7 +289,7 @@
   dependencies:
     "@eclipse-che/api" latest
 
-"@eclipse-che/workspace-client@latest":
+"@eclipse-che/workspace-client@0.0.1-1585913592":
   version "0.0.1-1585913592"
   resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1585913592.tgz#509c0a12e96adfec3a8c619124c396ecdb755806"
   integrity sha512-BxR1pydD3Qn6uS5Yp3TCWDEvgAmwWo254XC6KVJxdeofDeMNRpSx3KWuSrPWdC4jd5+urGKk/nG7vZyCST+85A==


### PR DESCRIPTION
### What does this PR do?
Back port of https://github.com/eclipse/che-theia/pull/790

Fix issues related to losing connection to `machine exec`, for example, at running `che` tasks
(can be recognized by error message: `Request runTask failed with message: Failed to execute Che command: Connection is disposed.`)


Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>