### PR TITLE
Handle more exported properties from remote plugins

### DIFF
--- a/extensions/eclipse-che-theia-plugin-remote/src/common/plugin-remote-rpc.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/common/plugin-remote-rpc.ts
@@ -11,6 +11,12 @@
 import { createProxyIdentifier } from '@theia/plugin-ext/lib/common/rpc-protocol';
 import { DeployedPlugin, ConfigStorage, PluginPackage } from '@theia/plugin-ext/lib/common';
 
+export interface ProxyNameDefinition {
+    name: string;
+    value?: string;
+    type: string;
+}
+
 export interface PluginRemoteNode {
     $initExternalPlugins(externalPlugins: DeployedPlugin[]): Promise<void>;
     $loadPlugin(pluginId: string, configStorage: ConfigStorage): Promise<void>;
@@ -19,7 +25,7 @@ export interface PluginRemoteNode {
     $callLocalMethod(callId: number, index: number, ...args: any[]): Promise<any>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     $callMethod(fromHostId: string, pluginId: string, callId: number, entryName: string, ...args: any[]): Promise<any>;
-    $definePluginExports(hostId: string, pluginId: string, proxyNames: string[]): Promise<void>;
+    $definePluginExports(hostId: string, pluginId: string, proxyNames: ProxyNameDefinition[]): Promise<void>;
     $definePluginPackage(pluginId: string, rawModel: PluginPackage): Promise<void>;
 }
 
@@ -30,7 +36,7 @@ export interface PluginRemoteBrowser {
     $callMethod(fromHostId: string, pluginId: string, callId: number, entryName: string, ...args: any[]): Promise<any>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     $callLocalMethod(hostId: string, callId: number, index: number, ...args: any[]): Promise<any>;
-    $definePluginExports(pluginId: string, proxyNames: string[]): Promise<void>;
+    $definePluginExports(pluginId: string, proxyNames: ProxyNameDefinition[]): Promise<void>;
     $definePluginPackage(pluginId: string, rawModel: PluginPackage): Promise<void>;
 }
 

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-browser-impl.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-browser-impl.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import { PluginRemoteBrowser, MAIN_REMOTE_RPC_CONTEXT } from '../common/plugin-remote-rpc';
+import { PluginRemoteBrowser, MAIN_REMOTE_RPC_CONTEXT, ProxyNameDefinition } from '../common/plugin-remote-rpc';
 import { RPCProtocol } from '@theia/plugin-ext/lib/common/rpc-protocol';
 import { ConfigStorage, PluginPackage } from '@theia/plugin-ext/lib/common';
 
@@ -65,12 +65,12 @@ export class PluginRemoteBrowserImpl implements PluginRemoteBrowser {
         return localCallResult;
     }
 
-    async $definePluginExports(pluginId: string, proxyNames: string[]): Promise<void> {
+    async $definePluginExports(pluginId: string, proxyDefinitions: ProxyNameDefinition[]): Promise<void> {
 
         this.getOtherHosts(pluginId).map(async host => {
             const rpc = this.rpcs.get(host)!;
             const nodeRemote = rpc.getProxy(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_NODE);
-            await nodeRemote.$definePluginExports(host, pluginId, proxyNames);
+            await nodeRemote.$definePluginExports(host, pluginId, proxyDefinitions);
         });
     }
 


### PR DESCRIPTION
### What does this PR do?
Handle more properties from the exports
also handle constants directly (as some plugin's are checking if the returned value is a string and not a function that might return a string)

Checked with https://che.openshift.io/f?url=https://gist.githubusercontent.com/benoitf/1fcff181b08448a96ee186bec3b5222f/raw/f4bbe2febfbd89a32dcfdf6eff470f674be7010c/devfile-16589.yaml

![image](https://user-images.githubusercontent.com/436777/86583800-2379e200-bf84-11ea-92ef-cd662d4b69e9.png)


### What issues does this PR fix or reference?
Part of https://github.com/eclipse/che/issues/16589


Change-Id: Icbb026f65577422168f1acab486e598c6146c170
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
