### PR TITLE
fix(projects): Use correct default folder if set for root projects

### DIFF
--- a/dockerfiles/theia/src/entrypoint.sh
+++ b/dockerfiles/theia/src/entrypoint.sh
@@ -81,7 +81,8 @@ fi
 shopt -u nocasematch
 
 # run Che Theia
-node src-gen/backend/main.js /projects --hostname=${THEIA_HOST} --port=${THEIA_PORT} &
+PROJ_ROOT=${CHE_PROJECTS_ROOT:-/projects}
+node src-gen/backend/main.js ${PROJ_ROOT} --hostname=${THEIA_HOST} --port=${THEIA_PORT} &
 
 PID=$!
 


### PR DESCRIPTION
### What does this PR do?
Use env variable that defines the root project to open in the right folder

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/17347

need to edit config map so can't be tested against che.openshift.io

edited with
```
  CHE_WORKSPACE_PROJECTS_STORAGE: /home/florent
```

and here is the result with the devfile https://gist.githubusercontent.com/benoitf/6f2c761690646c930ea728e85054e43c/raw/620e0fca2911f62534007ca21769eee966ca9649/devfile-projects.yaml

![other-project-root](https://user-images.githubusercontent.com/436777/86786038-c6555d80-c063-11ea-8d1f-30681cfae8e7.gif)



Change-Id: I22d9567604de0cdac90df9ba5fc514ff833a2884
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

