### PR TITLE
feat(plugin-remote): Automatically send the plugin's exports remotely even if extension is not depending on it

### DIFF
--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-node-impl.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-node-impl.ts
@@ -45,7 +45,9 @@ export class PluginRemoteNodeImpl implements PluginRemoteNode {
                 await pluginRemoteBrowser.$loadPlugin(plugin.model.id, configStorage);
                 return true;
             }
-            return originalLoadPlugin.call(pluginManager, plugin, configStorage, visited);
+            const load = await originalLoadPlugin.call(pluginManager, plugin, configStorage, visited);
+            await this.exportPluginDefinition(pluginManager, plugin.model.id, plugin);
+            return load;
         };
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -74,6 +76,11 @@ export class PluginRemoteNodeImpl implements PluginRemoteNode {
             throw new Error(`Unable to load the plug-in ${pluginId}. Wait for being ready but was never loaded.`);
         }
         await pluginManagerInternal.loadPlugin(plugin, configStorage);
+        this.exportPluginDefinition(pluginManagerInternal, pluginId, plugin);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async exportPluginDefinition(pluginManagerInternal: any, pluginId: string, plugin: any): Promise<void> {
         const activatedPlugin = pluginManagerInternal.activatedPlugins.get(pluginId);
 
         // share the JSON with others


### PR DESCRIPTION
### What does this PR do?
Always send exports to all VS Code extensions/plug-ins even to those that are not depending on it.

To try
https://che.openshift.io/f/?url=https://gist.githubusercontent.com/benoitf/1fcff181b08448a96ee186bec3b5222f/raw/dab24da194d8b03b4a0491421ad6a86fd7ca7a8e/devfile-16589.yaml

In this case I used a non-modified vsix of sonarsource (https://gist.githubusercontent.com/benoitf/cd064f61e95be361cbb2274c9a30fb44/raw/33709849aa6512d02f364cc9b0e20da7d13f3866/sonarlint-1.16-meta.yaml)

![sonarlint-java](https://user-images.githubusercontent.com/436777/86929924-b195ca00-c136-11ea-8b85-319041be5584.gif)

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/17355

Change-Id: I512c81da4ff4a13d9a374415415c4b413e8c3e3c
Signed-off-by: Florent Benoit <fbenoit@redhat.com>


HAPPY_PATH_CHANNEL=stable