### PR TITLE
Stop workspace from Che Theia

### DIFF
--- a/dockerfiles/theia/e2e/cypress/integration/theia/typescript.spec.ts
+++ b/dockerfiles/theia/e2e/cypress/integration/theia/typescript.spec.ts
@@ -28,7 +28,7 @@ context('TypeScript', () => {
 
 
         // close any workspace
-        cy.theiaCommandPaletteClick('Close Workspace').then(() => {
+        cy.theiaCommandPaletteClick('Close Workspace', '{downarrow}').then(() => {
             const $el = Cypress.$('button.theia-button.main');
             if ($el.length) {
                 cy.get('button.theia-button.main').should('exist').then(() => {

--- a/extensions/eclipse-che-theia-workspace/src/browser/che-quick-open-workspace.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-quick-open-workspace.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2019 Red Hat, Inc.
+ * Copyright (c) 2020 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,18 +16,16 @@ import {
 } from '@theia/core/lib/common/quick-open-model';
 import { LabelProvider, QuickOpenService } from '@theia/core/lib/browser';
 import { CheApiService } from '@eclipse-che/theia-plugin-ext/lib/common/che-protocol';
-import { che as cheApi } from '@eclipse-che/api';
+import { che } from '@eclipse-che/api';
 import { OauthUtils } from '@eclipse-che/theia-plugin-ext/lib/browser/oauth-utils';
-import { AbstractDialog } from '@theia/core/lib/browser/dialogs';
 import { MessageService } from '@theia/core/lib/common/message-service';
 import * as moment from 'moment';
-import { Message } from '@theia/core/lib/browser/widgets/index';
-import { Key } from '@theia/core/lib/browser/keyboard/keys';
+import { CheWorkspaceUtils } from './che-workspace-utils';
 
 @injectable()
 export class QuickOpenCheWorkspace implements QuickOpenModel {
     protected items: QuickOpenGroupItem[];
-    protected currentWorkspace: cheApi.workspace.Workspace;
+    protected currentWorkspace: che.workspace.Workspace;
 
     @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService;
     @inject(CheApiService) protected readonly cheApi: CheApiService;
@@ -35,7 +33,7 @@ export class QuickOpenCheWorkspace implements QuickOpenModel {
     @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
     @inject(MessageService) protected readonly messageService: MessageService;
 
-    private async open(workspaces: cheApi.workspace.Workspace[]): Promise<void> {
+    private async open(workspaces: che.workspace.Workspace[], acceptor: (workspace: che.workspace.Workspace) => void): Promise<void> {
         this.items = [];
 
         if (!workspaces.length) {
@@ -50,9 +48,9 @@ export class QuickOpenCheWorkspace implements QuickOpenModel {
             const icon = this.labelProvider.folderIcon;
             const iconClass = icon + ' file-icon';
             this.items.push(new QuickOpenGroupItem({
-                label: this.getWorkspaceName(workspace) + (this.isCurrentWorkspace(workspace) ? ' (Current)' : ''),
-                detail: `Stack: ${this.getWorkspaceStack(workspace)}`,
-                groupLabel: `last modified ${moment(this.getWorkspaceModificationTime(workspace)).fromNow()}`,
+                label: CheWorkspaceUtils.getWorkspaceName(workspace) + (this.isCurrentWorkspace(workspace) ? ' (Current)' : ''),
+                detail: `Stack: ${CheWorkspaceUtils.getWorkspaceStack(workspace)}`,
+                groupLabel: `last modified ${moment(CheWorkspaceUtils.getWorkspaceModificationTime(workspace)).fromNow()}`,
                 iconClass,
                 run: (mode: QuickOpenMode): boolean => {
                     if (mode !== QuickOpenMode.OPEN) {
@@ -63,7 +61,7 @@ export class QuickOpenCheWorkspace implements QuickOpenModel {
                         return true;
                     }
 
-                    this.openWorkspace(workspace);
+                    acceptor(workspace);
 
                     return true;
                 },
@@ -81,7 +79,7 @@ export class QuickOpenCheWorkspace implements QuickOpenModel {
         acceptor(this.items);
     }
 
-    async select(): Promise<void> {
+    async select(acceptor: (workspace: che.workspace.Workspace) => void): Promise<void> {
         this.items = [];
 
         const token = await this.oAuthUtils.getUserToken();
@@ -96,108 +94,12 @@ export class QuickOpenCheWorkspace implements QuickOpenModel {
 
         const workspaces = await this.cheApi.getAllByNamespace(this.currentWorkspace.namespace, token);
 
-        workspaces.sort((a: cheApi.workspace.Workspace, b: cheApi.workspace.Workspace) => {
-            const updatedA: number = this.getWorkspaceModificationTime(a);
-            const updatedB: number = this.getWorkspaceModificationTime(b);
+        workspaces.sort(CheWorkspaceUtils.modificationTimeComparator);
 
-            if (isNaN(updatedA) || isNaN(updatedB)) {
-                return 0;
-            } else {
-                return updatedB - updatedA;
-            }
-        });
-
-        await this.open(workspaces);
+        await this.open(workspaces, acceptor);
     }
 
-    private getWorkspaceName(workspace: cheApi.workspace.Workspace): string | undefined {
-        if (workspace.devfile && workspace.devfile.metadata) {
-            return workspace.devfile.metadata.name;
-        }
-    }
-
-    private getWorkspaceStack(workspace: cheApi.workspace.Workspace): string | undefined {
-        return workspace.attributes && workspace.attributes.stackName ? workspace.attributes.stackName : 'Custom';
-    }
-
-    private getWorkspaceModificationTime(workspace: cheApi.workspace.Workspace): number {
-        if (workspace.attributes) {
-            if (workspace.attributes.updated) {
-                return parseInt(workspace.attributes.updated);
-            } else if (workspace.attributes.created) {
-                return parseInt(workspace.attributes.created);
-            }
-        }
-
-        return NaN;
-    }
-
-    private stopCurrentWorkspace(): Promise<boolean | undefined> {
-        class StopWorkspaceDialog extends AbstractDialog<boolean | undefined> {
-            protected confirmed: boolean | undefined = true;
-            protected readonly dontStopButton: HTMLButtonElement;
-
-            constructor() {
-                super({
-                    title: 'Open Workspace'
-                });
-
-                this.contentNode.appendChild(this.createMessageNode('Do you want to stop current workspace?'));
-                this.appendCloseButton('Cancel');
-                this.dontStopButton = this.appendDontStopButton();
-                this.appendAcceptButton('Yes');
-            }
-
-            get value(): boolean | undefined {
-                return this.confirmed;
-            }
-
-            protected appendDontStopButton(): HTMLButtonElement {
-                const button = this.createButton('No');
-                this.controlPanel.appendChild(button);
-                button.classList.add('secondary');
-                return button;
-            }
-
-            protected onAfterAttach(msg: Message): void {
-                super.onAfterAttach(msg);
-                this.addKeyListener(this.dontStopButton, Key.ENTER, () => {
-                    this.confirmed = false;
-                    this.accept();
-                }, 'click');
-            }
-
-            protected onCloseRequest(msg: Message): void {
-                super.onCloseRequest(msg);
-                this.confirmed = undefined;
-                this.accept();
-            }
-
-            protected createMessageNode(msg: string | HTMLElement): HTMLElement {
-                if (typeof msg === 'string') {
-                    const messageNode = document.createElement('div');
-                    messageNode.textContent = msg;
-                    return messageNode;
-                }
-                return msg;
-            }
-
-        }
-
-        return new StopWorkspaceDialog().open();
-    }
-
-    private async openWorkspace(workspace: cheApi.workspace.Workspace): Promise<void> {
-        const result = await this.stopCurrentWorkspace();
-        if (typeof result === 'boolean') {
-            if (result) {
-                await this.cheApi.stop();
-            }
-            window.parent.postMessage(`open-workspace:${workspace.id}`, '*');
-        }
-    }
-
-    private isCurrentWorkspace(workspace: cheApi.workspace.Workspace): boolean {
+    private isCurrentWorkspace(workspace: che.workspace.Workspace): boolean {
         return this.currentWorkspace.id === workspace.id;
     }
 }

--- a/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-contribution.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-contribution.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2019 Red Hat, Inc.
+ * Copyright (c) 2020 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,11 +11,12 @@ import { inject, injectable } from 'inversify';
 import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core/lib/common';
 import { CommonMenus } from '@theia/core/lib/browser';
 import { WorkspaceCommands } from '@theia/workspace/lib/browser/workspace-commands';
-import { QuickOpenCheWorkspace } from './che-quick-open-workspace';
 import { Command } from '@theia/core/lib/common/command';
+import { CheWorkspaceController } from './che-workspace-controller';
 
 export namespace CheWorkspaceCommands {
 
+    const WORKSPACE_CATEGORY = 'Workspace';
     const FILE_CATEGORY = 'File';
 
     export const OPEN_RECENT_WORKSPACE: Command = {
@@ -23,16 +24,24 @@ export namespace CheWorkspaceCommands {
         category: FILE_CATEGORY,
         label: 'Open Recent Workspace...'
     };
+    export const CLOSE_CURRENT_WORKSPACE: Command = {
+        id: 'che.closeCurrentWorkspace',
+        category: WORKSPACE_CATEGORY,
+        label: 'Close Workspace'
+    };
 }
 
 @injectable()
 export class CheWorkspaceContribution implements CommandContribution, MenuContribution {
 
-    @inject(QuickOpenCheWorkspace) protected readonly quickOpenWorkspace: QuickOpenCheWorkspace;
+    @inject(CheWorkspaceController) protected readonly workspaceController: CheWorkspaceController;
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(CheWorkspaceCommands.OPEN_RECENT_WORKSPACE, {
-            execute: () => this.quickOpenWorkspace.select()
+            execute: () => this.workspaceController.openRecentWorkspace()
+        });
+        commands.registerCommand(CheWorkspaceCommands.CLOSE_CURRENT_WORKSPACE, {
+            execute: () => this.workspaceController.closeCurrentWorkspace()
         });
     }
 
@@ -40,11 +49,18 @@ export class CheWorkspaceContribution implements CommandContribution, MenuContri
         menus.unregisterMenuAction({
             commandId: WorkspaceCommands.OPEN_RECENT_WORKSPACE.id
         }, CommonMenus.FILE_OPEN);
+        menus.unregisterMenuAction({
+            commandId: WorkspaceCommands.CLOSE.id
+        }, CommonMenus.FILE_CLOSE);
 
         menus.registerMenuAction(CommonMenus.FILE_OPEN, {
             commandId: CheWorkspaceCommands.OPEN_RECENT_WORKSPACE.id,
             label: CheWorkspaceCommands.OPEN_RECENT_WORKSPACE.label,
             order: 'a20'
+        });
+        menus.registerMenuAction(CommonMenus.FILE_CLOSE, {
+            commandId: CheWorkspaceCommands.CLOSE_CURRENT_WORKSPACE.id,
+            label: CheWorkspaceCommands.CLOSE_CURRENT_WORKSPACE.label
         });
     }
 }

--- a/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-controller.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-controller.ts
@@ -1,0 +1,99 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import { inject, injectable } from 'inversify';
+import { CheApiService } from '@eclipse-che/theia-plugin-ext/lib/common/che-protocol';
+import { che } from '@eclipse-che/api';
+import { AbstractDialog, ConfirmDialog } from '@theia/core/lib/browser';
+import { Message } from '@theia/core/lib/browser/widgets';
+import { Key } from '@theia/core/lib/browser/keyboard/keys';
+import { CheWorkspaceCommands } from './che-workspace-contribution';
+import { QuickOpenCheWorkspace } from './che-quick-open-workspace';
+
+export class StopWorkspaceDialog extends AbstractDialog<boolean | undefined> {
+    protected confirmed: boolean | undefined = true;
+    protected readonly dontStopButton: HTMLButtonElement;
+
+    constructor() {
+        super({
+            title: 'Open Workspace'
+        });
+
+        this.contentNode.appendChild(this.createMessageNode('Do you want to stop current workspace?'));
+        this.appendCloseButton('Cancel');
+        this.dontStopButton = this.appendDontStopButton();
+        this.appendAcceptButton('Yes');
+    }
+
+    get value(): boolean | undefined {
+        return this.confirmed;
+    }
+
+    protected appendDontStopButton(): HTMLButtonElement {
+        const button = this.createButton('No');
+        this.controlPanel.appendChild(button);
+        button.classList.add('secondary');
+        return button;
+    }
+
+    protected onAfterAttach(msg: Message): void {
+        super.onAfterAttach(msg);
+        this.addKeyListener(this.dontStopButton, Key.ENTER, () => {
+            this.confirmed = false;
+            this.accept();
+        }, 'click');
+    }
+
+    protected onCloseRequest(msg: Message): void {
+        super.onCloseRequest(msg);
+        this.confirmed = undefined;
+        this.accept();
+    }
+
+    protected createMessageNode(msg: string | HTMLElement): HTMLElement {
+        if (typeof msg === 'string') {
+            const messageNode = document.createElement('div');
+            messageNode.textContent = msg;
+            return messageNode;
+        }
+        return msg;
+    }
+}
+
+@injectable()
+export class CheWorkspaceController {
+
+    @inject(CheApiService) protected readonly cheApi: CheApiService;
+    @inject(QuickOpenCheWorkspace) protected readonly quickOpenWorkspace: QuickOpenCheWorkspace;
+
+    async openRecentWorkspace(): Promise<void> {
+        await this.quickOpenWorkspace.select(async (workspace: che.workspace.Workspace) => {
+            const dialog = new StopWorkspaceDialog();
+            const result = await dialog.open();
+            if (typeof result === 'boolean') {
+                if (result) {
+                    await this.cheApi.stop();
+                }
+                window.parent.postMessage(`open-workspace:${workspace.id}`, '*');
+            }
+        });
+    }
+
+    async closeCurrentWorkspace(): Promise<void> {
+        const dialog = new ConfirmDialog({
+            title: CheWorkspaceCommands.CLOSE_CURRENT_WORKSPACE.label!,
+            msg: 'Do you really want to close the workspace?'
+        });
+        if (await dialog.open()) {
+            await this.cheApi.stop();
+
+            window.parent.postMessage('show-workspaces', '*');
+        }
+    }
+}

--- a/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-module.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-module.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2019 Red Hat, Inc.
+ * Copyright (c) 2020 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,9 +11,11 @@ import { ContainerModule } from 'inversify';
 import { QuickOpenCheWorkspace } from './che-quick-open-workspace';
 import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
 import { CheWorkspaceContribution } from './che-workspace-contribution';
+import { CheWorkspaceController } from './che-workspace-controller';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(QuickOpenCheWorkspace).toSelf().inSingletonScope();
+    bind(CheWorkspaceController).toSelf().inSingletonScope();
     bind(CheWorkspaceContribution).toSelf().inSingletonScope();
     for (const identifier of [CommandContribution, MenuContribution]) {
         bind(identifier).toService(CheWorkspaceContribution);

--- a/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-utils.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-utils.ts
@@ -1,0 +1,45 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import { che } from '@eclipse-che/api';
+
+export class CheWorkspaceUtils {
+    static getWorkspaceModificationTime(workspace: che.workspace.Workspace): number {
+        if (workspace.attributes) {
+            if (workspace.attributes.updated) {
+                return parseInt(workspace.attributes.updated);
+            } else if (workspace.attributes.created) {
+                return parseInt(workspace.attributes.created);
+            }
+        }
+
+        return NaN;
+    }
+
+    static getWorkspaceStack(workspace: che.workspace.Workspace): string | undefined {
+        return workspace.attributes && workspace.attributes.stackName ? workspace.attributes.stackName : 'Custom';
+    }
+
+    static getWorkspaceName(workspace: che.workspace.Workspace): string | undefined {
+        if (workspace.devfile && workspace.devfile.metadata) {
+            return workspace.devfile.metadata.name;
+        }
+    }
+
+    static modificationTimeComparator(a: che.workspace.Workspace, b: che.workspace.Workspace): number {
+        const updatedA: number = CheWorkspaceUtils.getWorkspaceModificationTime(a);
+        const updatedB: number = CheWorkspaceUtils.getWorkspaceModificationTime(b);
+
+        if (isNaN(updatedA) || isNaN(updatedB)) {
+            return 0;
+        } else {
+            return updatedB - updatedA;
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?
This changes proposal adds an ability to stop current workspace directly from Che Theia.

_Existed command is going to be renamed in featured PR for the following issue: https://github.com/eclipse/che/issues/17106_

#### How to test
Use the following devfile:
```
apiVersion: 1.0.0
metadata:
 name: workspace
components:
  - 
    alias: theia-editor
    reference: >-
      https://raw.githubusercontent.com/vzhukovskii/devfiles/master/meta.yaml
    type: cheEditor
```

1. Go to File - Close Workspace:
<img width="428" alt="Снимок экрана 2020-07-17 в 14 30 58" src="https://user-images.githubusercontent.com/1968177/87782034-72ecc780-c83a-11ea-9105-92ae167cfe00.png">

2. Click Ok on popup dialog:
<img width="548" alt="Снимок экрана 2020-07-17 в 14 31 25" src="https://user-images.githubusercontent.com/1968177/87782077-85ff9780-c83a-11ea-9969-4c3ba907a5d8.png">

3. Workspace will be stopped and user will be redirected to Dashboard

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17238
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
Stop workspace from Che Theia
<!-- markdown to be included in marketing announcement - N/A for bugs -->
