### PR TITLE
Fix ws connection on single-host

### DIFF
--- a/extensions/eclipse-che-theia-messaging/src/node/messaging/che-messaging-contribution.ts
+++ b/extensions/eclipse-che-theia-messaging/src/node/messaging/che-messaging-contribution.ts
@@ -53,20 +53,14 @@ export class CheMessagingContribution extends MessagingContribution {
     }
 
     async isRequestAllowed(request: http.IncomingMessage): Promise<boolean> {
-        console.log(request.headers)
         const theiaEndpoints = [];
         try {
             const containers = await this.cheApiService.getCurrentWorkspacesContainers();
-            console.log(containers);
             for (const containerName of Object.keys(containers)) {
-                console.log(containerName)
                 const servers = containers[containerName].servers;
-                console.log(servers)
                 if (servers) {
                     for (const serverName of Object.keys(servers)) {
-                        console.log(serverName)
                         const server = servers[serverName];
-                        console.log(server)
                         if (serverName === 'theia' || serverName === 'theia-dev' || serverName === 'theia-dev-flow') {
                             theiaEndpoints.push(new URI(server.url));
                         }
@@ -78,17 +72,14 @@ export class CheMessagingContribution extends MessagingContribution {
             return true; // we're outside of Che Workspace, so allow a request
         }
 
-        console.log(theiaEndpoints)
 
         const requestOrigin = request.headers.origin;
-        console.log(requestOrigin)
         if (typeof requestOrigin !== 'string') {
             return false;
         }
         const requestOriginURI = new URI(requestOrigin);
 
-        console.log(requestOriginURI)
-        return theiaEndpoints.some(uri => uri.isEqualOrParent(requestOriginURI));
+        return theiaEndpoints.some(uri => requestOriginURI.isEqualOrParent(uri));
     }
 
     public getConnectionContainers(): Container[] {

--- a/extensions/eclipse-che-theia-messaging/src/node/messaging/che-messaging-contribution.ts
+++ b/extensions/eclipse-che-theia-messaging/src/node/messaging/che-messaging-contribution.ts
@@ -72,7 +72,6 @@ export class CheMessagingContribution extends MessagingContribution {
             return true; // we're outside of Che Workspace, so allow a request
         }
 
-
         const requestOrigin = request.headers.origin;
         if (typeof requestOrigin !== 'string') {
             return false;

--- a/extensions/eclipse-che-theia-messaging/src/node/messaging/che-messaging-contribution.ts
+++ b/extensions/eclipse-che-theia-messaging/src/node/messaging/che-messaging-contribution.ts
@@ -53,14 +53,20 @@ export class CheMessagingContribution extends MessagingContribution {
     }
 
     async isRequestAllowed(request: http.IncomingMessage): Promise<boolean> {
+        console.log(request.headers)
         const theiaEndpoints = [];
         try {
             const containers = await this.cheApiService.getCurrentWorkspacesContainers();
+            console.log(containers);
             for (const containerName of Object.keys(containers)) {
+                console.log(containerName)
                 const servers = containers[containerName].servers;
+                console.log(servers)
                 if (servers) {
                     for (const serverName of Object.keys(servers)) {
+                        console.log(serverName)
                         const server = servers[serverName];
+                        console.log(server)
                         if (serverName === 'theia' || serverName === 'theia-dev' || serverName === 'theia-dev-flow') {
                             theiaEndpoints.push(new URI(server.url));
                         }
@@ -72,12 +78,16 @@ export class CheMessagingContribution extends MessagingContribution {
             return true; // we're outside of Che Workspace, so allow a request
         }
 
+        console.log(theiaEndpoints)
+
         const requestOrigin = request.headers.origin;
+        console.log(requestOrigin)
         if (typeof requestOrigin !== 'string') {
             return false;
         }
         const requestOriginURI = new URI(requestOrigin);
 
+        console.log(requestOriginURI)
         return theiaEndpoints.some(uri => uri.isEqualOrParent(requestOriginURI));
     }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
fix ws connection for single-host. It was failing on checking endpoint with origin uri paths. Reverse check works ok.

I still need to test it with default/multi-host.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17396

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

### Hapy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
