### PR TITLE
Open workspace from Che Theia

### DIFF
--- a/extensions/eclipse-che-theia-workspace/src/browser/che-quick-open-workspace.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-quick-open-workspace.ts
@@ -79,7 +79,7 @@ export class QuickOpenCheWorkspace implements QuickOpenModel {
         acceptor(this.items);
     }
 
-    async select(acceptor: (workspace: che.workspace.Workspace) => void): Promise<void> {
+    async select(recent: boolean, acceptor: (workspace: che.workspace.Workspace) => void): Promise<void> {
         this.items = [];
 
         const token = await this.oAuthUtils.getUserToken();
@@ -92,9 +92,15 @@ export class QuickOpenCheWorkspace implements QuickOpenModel {
             return;
         }
 
-        const workspaces = await this.cheApi.getAllByNamespace(this.currentWorkspace.namespace, token);
+        let workspaces = await this.cheApi.getAllByNamespace(this.currentWorkspace.namespace, token);
 
-        workspaces.sort(CheWorkspaceUtils.modificationTimeComparator);
+        if (recent) {
+            workspaces.sort(CheWorkspaceUtils.modificationTimeComparator);
+
+            if (workspaces.length > 5) {
+                workspaces = workspaces.slice(0, 5);
+            }
+        }
 
         await this.open(workspaces, acceptor);
     }

--- a/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-contribution.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-contribution.ts
@@ -19,6 +19,11 @@ export namespace CheWorkspaceCommands {
     const WORKSPACE_CATEGORY = 'Workspace';
     const FILE_CATEGORY = 'File';
 
+    export const OPEN_WORKSPACE: Command = {
+        id: 'che.openWorkspace',
+        category: FILE_CATEGORY,
+        label: 'Open Workspace...'
+    };
     export const OPEN_RECENT_WORKSPACE: Command = {
         id: 'che.openRecentWorkspace',
         category: FILE_CATEGORY,
@@ -37,6 +42,9 @@ export class CheWorkspaceContribution implements CommandContribution, MenuContri
     @inject(CheWorkspaceController) protected readonly workspaceController: CheWorkspaceController;
 
     registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(CheWorkspaceCommands.OPEN_WORKSPACE, {
+            execute: () => this.workspaceController.openWorkspace()
+        });
         commands.registerCommand(CheWorkspaceCommands.OPEN_RECENT_WORKSPACE, {
             execute: () => this.workspaceController.openRecentWorkspace()
         });
@@ -47,12 +55,20 @@ export class CheWorkspaceContribution implements CommandContribution, MenuContri
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.unregisterMenuAction({
+            commandId: WorkspaceCommands.OPEN_WORKSPACE.id
+        }, CommonMenus.FILE_OPEN);
+        menus.unregisterMenuAction({
             commandId: WorkspaceCommands.OPEN_RECENT_WORKSPACE.id
         }, CommonMenus.FILE_OPEN);
         menus.unregisterMenuAction({
             commandId: WorkspaceCommands.CLOSE.id
         }, CommonMenus.FILE_CLOSE);
 
+        menus.registerMenuAction(CommonMenus.FILE_OPEN, {
+            commandId: CheWorkspaceCommands.OPEN_WORKSPACE.id,
+            label: CheWorkspaceCommands.OPEN_WORKSPACE.label,
+            order: 'a10'
+        });
         menus.registerMenuAction(CommonMenus.FILE_OPEN, {
             commandId: CheWorkspaceCommands.OPEN_RECENT_WORKSPACE.id,
             label: CheWorkspaceCommands.OPEN_RECENT_WORKSPACE.label,

--- a/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-controller.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-controller.ts
@@ -72,8 +72,16 @@ export class CheWorkspaceController {
     @inject(CheApiService) protected readonly cheApi: CheApiService;
     @inject(QuickOpenCheWorkspace) protected readonly quickOpenWorkspace: QuickOpenCheWorkspace;
 
+    async openWorkspace(): Promise<void> {
+        await this.doOpenWorkspace(false);
+    }
+
     async openRecentWorkspace(): Promise<void> {
-        await this.quickOpenWorkspace.select(async (workspace: che.workspace.Workspace) => {
+        await this.doOpenWorkspace(true);
+    }
+
+    private doOpenWorkspace(recent: boolean): Promise<void> {
+        return  this.quickOpenWorkspace.select(recent, async (workspace: che.workspace.Workspace) => {
             const dialog = new StopWorkspaceDialog();
             const result = await dialog.open();
             if (typeof result === 'boolean') {


### PR DESCRIPTION
### What does this PR do?
This changes proposal adds ability to open Che workspace directly from Che-Theia. Also it modifies behavior of Open Recent Workspace command, so the last one simply displays the last five workspaces sorted by modification time and Open Workspace command displays all workspaces in user account.

_Existed command is going to be renamed in featured PR for the following issue: eclipse/che#17106_

All workspaces:
<img width="619" alt="Снимок экрана 2020-07-28 в 17 07 54" src="https://user-images.githubusercontent.com/1968177/88685912-2d17e500-d0ff-11ea-9fb3-f53919ed8765.png">

Recent workspaces:
<img width="619" alt="Снимок экрана 2020-07-28 в 17 07 28" src="https://user-images.githubusercontent.com/1968177/88686005-4325a580-d0ff-11ea-9182-660caaa8ff30.png">

#### How to test

Simply create a workspace from the following devfile:
```
apiVersion: 1.0.0
metadata:
 name: workspace
components:
  - 
    alias: theia-editor
    reference: >-
      https://raw.githubusercontent.com/vzhukovskii/devfiles/master/meta.yaml
    type: cheEditor
```

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17237
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

### Hapy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
