### PR TITLE
Resolve remote connection for a terminal at reconnection

### DIFF
--- a/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts
@@ -209,6 +209,7 @@ export class RemoteTerminalWidget extends TerminalWidgetImpl {
 
     protected async connectSocket(id: number): Promise<void> {
         if (this.socket) {
+            this.resolveRemoteConnection();
             return Promise.resolve();
         }
         this.socket = this.createWebSocket(id.toString());
@@ -218,9 +219,7 @@ export class RemoteTerminalWidget extends TerminalWidgetImpl {
         let onDataDisposeHandler: IDisposable;
         this.socket.onopen = () => {
             this.term.reset();
-            if (this.waitForRemoteConnection) {
-                this.waitForRemoteConnection.resolve(this.socket);
-            }
+            this.resolveRemoteConnection();
 
             onDataDisposeHandler = this.term.onData(sendListener);
             this.socket.onmessage = ev => this.write(ev.data);
@@ -340,6 +339,12 @@ export class RemoteTerminalWidget extends TerminalWidgetImpl {
         this.interruptProcess().then(() => {
             super.dispose();
         });
+    }
+
+    private resolveRemoteConnection(): void {
+        if (this.waitForRemoteConnection) {
+            this.waitForRemoteConnection.resolve(this.socket);
+        }
     }
 
     private async interruptProcess(): Promise<void> {


### PR DESCRIPTION
### What does this PR do?
[waitForRemoteConnection](https://github.com/eclipse/che-theia/blob/2142853188913cf14bb8ee00beac767c2329c0ca/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts#L46) is `defferred` object for `ReconnectingWebSocket`.
It's resolved when `websocket` [is open](https://github.com/eclipse/che-theia/blob/2142853188913cf14bb8ee00beac767c2329c0ca/extensions/eclipse-che-theia-terminal/src/browser/terminal-widget/remote-terminal-widget.ts#L222).

But it should be resolved when `websocket` is reconnected as well.
Otherwise `websocket` can not be got from `defferred` object and leads to bugs.

### What issues does this PR fix or reference?
The changes should fix issues related to remote terminal widget, for example when we send signal to terminate a process.
We have such issue for Code Ready Workspaces (CRW-827) .

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>