### PR TITLE
bump vscode-ripgrep version.  no s390x build for version 1.7.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12927,9 +12927,9 @@ vscode-languageserver-types@3.15.1, vscode-languageserver-types@^3.15.0-next:
   integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
 
 vscode-ripgrep@^1.2.4:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.7.0.tgz#ec912e04aa29f7d73bcef04b7576b792f12c9b38"
-  integrity sha512-sQY/u0ymc9YMiPaSsMmdZSFQ6PTS2UxcGuiQkF7aoIezDxZcGE1sMarqftWEl9wYWYc9hElYm00WpoFgzj1oUg==
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.8.0.tgz#dfe7c2ae2a2032df8a8108765c2feef73474888a"
+  integrity sha512-/Q5XtePkTLLi8yplr5ai24pVEymRF62xH9xXrtj35GTaDCJg3zq1s1/L1UqhVbfNDv4OcMBYjyIAt/quEi3d5w==
   dependencies:
     https-proxy-agent "^4.0.0"
     proxy-from-env "^1.1.0"


### PR DESCRIPTION
Signed-off-by: Kirk Crane <krcrane@ca.ibm.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
bump vscode-ripgrep version to 1.8.0.  no s390x build of ripgrep-prebuilt for version 1.7.0

### What issues does this PR fix or reference?
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
error /home/theia-dev/theia-source-code/che-theia/node_modules/vscode-ripgrep: Command failed.
Exit code: 1
Command: node ./lib/postinstall.js
Arguments:
Directory: /home/theia-dev/theia-source-code/che-theia/node_modules/vscode-ripgrep
Output:
Finding release for v11.0.1-6
GET https://api.github.com/repos/microsoft/ripgrep-prebuilt/releases/tags/v11.0.1-6
Deleting invalid download cache
Downloading ripgrep failed: Error: Asset not found with name: ripgrep-v11.0.1-6-s390x-unknown-linux-gnu.tar.gz
    at getAssetFromGithubApi (/home/theia-dev/theia-source-code/che-theia/node_modules/vscode-ripgrep/lib/download.js:188:15)
    at process._tickCallback (internal/process/next_tick.js:68:7)
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

### Hapy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
