### PR TITLE
feat(terminal): Use workspace root as default path in containers

### DIFF
--- a/extensions/eclipse-che-theia-terminal/src/browser/contribution/exec-terminal-contribution.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/contribution/exec-terminal-contribution.ts
@@ -186,13 +186,7 @@ export class ExecTerminalFrontendContribution extends TerminalFrontendContributi
     }
 
     async openTerminalByContainerName(containerName: string): Promise<void> {
-        const editorContainer = await this.getEditorContainerName();
-        let cwd: string | undefined;
-        // use information about volumes to cover cwd for development containers too. Depends on https://github.com/eclipse/che/issues/13290
-        if (containerName === editorContainer) {
-            cwd = await this.selectTerminalCwd();
-        }
-
+        const cwd = await this.selectTerminalCwd();
         const termWidget = await this.newTerminalPerContainer(containerName, { cwd });
         this.open(termWidget);
         termWidget.start();

--- a/extensions/eclipse-che-theia-terminal/src/browser/contribution/terminal-quick-open.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/contribution/terminal-quick-open.ts
@@ -58,7 +58,7 @@ export class TerminalQuickOpenService implements QuickOpenHandler, QuickOpenMode
                         if (mode !== QuickOpenMode.OPEN) {
                             return false;
                         }
-                        doOpen(container.name);
+                        setTimeout(() => doOpen(container.name), 0);
 
                         return true;
                     }
@@ -78,7 +78,7 @@ export class TerminalQuickOpenService implements QuickOpenHandler, QuickOpenMode
                         if (mode !== QuickOpenMode.OPEN) {
                             return false;
                         }
-                        doOpen(container.name);
+                        setTimeout(() => doOpen(container.name), 0);
 
                         return true;
                     }


### PR DESCRIPTION
### What does this PR do?
Open by default terminal in workspace root.
In case of multiple workspace roots, prompt user.

### What issues does this PR fix or reference?
Fix https://github.com/eclipse/che/issues/17548

### Happy Path Channel
HAPPY_PATH_CHANNEL=stable

Change-Id: I8ad33cd6d85c5582c347bcc5390c25daacf825ef
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
