### PR TITLE
Pin npm libs versions when releasing

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -81,6 +81,24 @@ apply_files_edits () {
     exit 1
   fi
 
+  WS_CLIENT_VERSION=$(curl --silent http://registry.npmjs.org/-/package/@eclipse-che/workspace-client/dist-tags | sed 's/.*"latest":"\(.*\)".*/\1/')
+  if [[ ! ${WS_CLIENT_VERSION} ]] || [[ ${WS_CLIENT_VERSION} == \"Unauthorized\" ]]; then
+    echo "Failed to get @eclipse-che/workspace-client latest version from npmjs.org. Try again."; echo
+    exit 1
+  fi
+
+  WS_TELEMETRY_CLIENT_VERSION=$(curl --silent http://registry.npmjs.org/-/package/@eclipse-che/workspace-telemetry-client/dist-tags | sed 's/.*"latest":"\(.*\)".*/\1/')
+  if [[ ! ${WS_TELEMETRY_CLIENT_VERSION} ]] || [[ ${WS_TELEMETRY_CLIENT_VERSION} == \"Unauthorized\" ]]; then
+    echo "Failed to get @eclipse-che/workspace-telemetry-client latest version from npmjs.org. Try again."; echo
+    exit 1
+  fi
+
+  API_DTO_VERSION=$(curl --silent http://registry.npmjs.org/-/package/@eclipse-che/api/dist-tags | sed 's/.*"latest":"\(.*\)",.*/\1/')
+  if [[ ! ${API_DTO_VERSION} ]] || [[ ${API_DTO_VERSION} == \"Unauthorized\" ]]; then
+    echo "Failed to get @eclipse-che/api latest version from npmjs.org. Try again."; echo
+    exit 1
+  fi
+
   # update config for Che Theia generator
   sed_in_place -e "/checkoutTo:/s/master/${BRANCH}/" che-theia-init-sources.yml
   sed_in_place -e "/checkoutTo:/s/master/${BRANCH}/" che-theia-init-sources.yml
@@ -99,6 +117,12 @@ apply_files_edits () {
     sed_in_place -r -e "s/(\"version\": )(\".*\")/\1\"$VERSION\"/" ${PACKAGE_JSON}
     # shellcheck disable=SC2086
     sed_in_place -r -e "/@eclipse-che\/api|@eclipse-che\/workspace-client|@eclipse-che\/workspace-telemetry-client/!s/(\"@eclipse-che\/..*\": )(\".*\")/\1\"$VERSION\"/" ${PACKAGE_JSON}
+    # shellcheck disable=SC2086
+    sed_in_place -r -e "s/(\"@eclipse-che\/workspace-client\": )(\".*\")/\1\"$WS_CLIENT_VERSION\"/" ${PACKAGE_JSON}
+    # shellcheck disable=SC2086
+    sed_in_place -r -e "s/(\"@eclipse-che\/workspace-telemetry-client\": )(\".*\")/\1\"$WS_TELEMETRY_CLIENT_VERSION\"/" ${PACKAGE_JSON}
+    # shellcheck disable=SC2086
+    sed_in_place -r -e "s/(\"@eclipse-che\/api\": )(\".*\")/\1\"$API_DTO_VERSION\"/" ${PACKAGE_JSON}
   done
 
   if [[ ${VERSION} == *".0" ]]; then


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Pins npm libs versions when releasing.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/17612

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
