### PR TITLE
Keep npmjs deps versions untouched when doing z-stream releases with z>0

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -108,30 +108,25 @@ apply_files_edits () {
   sed_in_place -e "s/^THEIA_COMMIT_SHA=$/THEIA_COMMIT_SHA=\"${THEIA_VERSION##*.}\"/" build.include
   sed_in_place -e "s/THEIA_DOCKER_IMAGE_VERSION=.*/THEIA_DOCKER_IMAGE_VERSION=\"${VERSION}\"/" build.include
 
-  # Update extensions/plugins package.json files:
-  # - set packages' version
-  # - update versions of Che dependencies
   for m in "extensions/*" "plugins/*"; do
     PACKAGE_JSON="${m}"/package.json
     # shellcheck disable=SC2086
     sed_in_place -r -e "s/(\"version\": )(\".*\")/\1\"$VERSION\"/" ${PACKAGE_JSON}
     # shellcheck disable=SC2086
     sed_in_place -r -e "/@eclipse-che\/api|@eclipse-che\/workspace-client|@eclipse-che\/workspace-telemetry-client/!s/(\"@eclipse-che\/..*\": )(\".*\")/\1\"$VERSION\"/" ${PACKAGE_JSON}
-    # shellcheck disable=SC2086
-    sed_in_place -r -e "s/(\"@eclipse-che\/workspace-client\": )(\".*\")/\1\"$WS_CLIENT_VERSION\"/" ${PACKAGE_JSON}
-    # shellcheck disable=SC2086
-    sed_in_place -r -e "s/(\"@eclipse-che\/workspace-telemetry-client\": )(\".*\")/\1\"$WS_TELEMETRY_CLIENT_VERSION\"/" ${PACKAGE_JSON}
-    # shellcheck disable=SC2086
-    sed_in_place -r -e "s/(\"@eclipse-che\/api\": )(\".*\")/\1\"$API_DTO_VERSION\"/" ${PACKAGE_JSON}
   done
 
   if [[ ${VERSION} == *".0" ]]; then
-    # Update extensions/plugins package.json files:
-    # - update versions of Theia dependencies
     for m in "extensions/*" "plugins/*"; do
       PACKAGE_JSON="${m}"/package.json
       # shellcheck disable=SC2086
-      sed_in_place -r -e "/plugin-packager/!s/(\"@theia\/..*\": )(\".*\")/\1\"${THEIA_VERSION}\"/" ${PACKAGE_JSON}
+      sed_in_place -r -e "/plugin-packager/!s/(\"@theia\/..*\": )(\"next\")/\1\"${THEIA_VERSION}\"/" ${PACKAGE_JSON}
+      # shellcheck disable=SC2086
+      sed_in_place -r -e "s/(\"@eclipse-che\/workspace-client\": )(\"latest\")/\1\"$WS_CLIENT_VERSION\"/" ${PACKAGE_JSON}
+      # shellcheck disable=SC2086
+      sed_in_place -r -e "s/(\"@eclipse-che\/workspace-telemetry-client\": )(\"latest\")/\1\"$WS_TELEMETRY_CLIENT_VERSION\"/" ${PACKAGE_JSON}
+      # shellcheck disable=SC2086
+      sed_in_place -r -e "s/(\"@eclipse-che\/api\": )(\"latest\")/\1\"$API_DTO_VERSION\"/" ${PACKAGE_JSON}
     done
 
     sed_in_place -e '$ a RUN cd ${HOME} \&\& tar zcf ${HOME}/theia-source-code.tgz theia-source-code' dockerfiles/theia/docker/ubi8/builder-clone-theia.dockerfile


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
- updates release script to avoid upgrading npmjs dependencies' version when doing z-stream releases other than x.y.0.
- updates dependencies versions only when it's next/latest in master branch

### What issues does this PR fix or reference?
closes https://github.com/eclipse/che/issues/17635

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
