### PR TITLE
Reorganize workspace related commands

### DIFF
--- a/dockerfiles/theia/e2e/cypress/integration/theia/typescript.spec.ts
+++ b/dockerfiles/theia/e2e/cypress/integration/theia/typescript.spec.ts
@@ -28,7 +28,7 @@ context('TypeScript', () => {
 
 
         // close any workspace
-        cy.theiaCommandPaletteClick('Close Workspace', '{downarrow}').then(() => {
+        cy.theiaCommandPaletteClick('Close Workspace Roots').then(() => {
             const $el = Cypress.$('button.theia-button.main');
             if ($el.length) {
                 cy.get('button.theia-button.main').should('exist').then(() => {
@@ -43,7 +43,7 @@ context('TypeScript', () => {
             // open /tmp
             cy.get('#theia-top-panel').should('exist').then(() => {
 
-                cy.theiaCommandPaletteClick('Open Workspace...', '{downarrow}{downarrow}').then(() => {
+                cy.theiaCommandPaletteClick('Open Workspace Roots...', '{downarrow}').then(() => {
                     cy.get('.theia-LocationList').should('exist');
                     cy.get('.theia-LocationList').select('file:///');
                     cy.wait(2000);

--- a/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-contribution.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-contribution.ts
@@ -13,6 +13,7 @@ import { CommonMenus } from '@theia/core/lib/browser';
 import { WorkspaceCommands } from '@theia/workspace/lib/browser/workspace-commands';
 import { Command } from '@theia/core/lib/common/command';
 import { CheWorkspaceController } from './che-workspace-controller';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 
 export namespace CheWorkspaceCommands {
 
@@ -34,12 +35,29 @@ export namespace CheWorkspaceCommands {
         category: WORKSPACE_CATEGORY,
         label: 'Close Workspace'
     };
+    export const OPEN_WORKSPACE_ROOTS: Command & { dialogLabel: string } = {
+        id: 'workspace:openWorkspace',
+        category: FILE_CATEGORY,
+        label: 'Open Workspace Roots...',
+        dialogLabel: 'Open Workspace Roots'
+    };
+    export const OPEN_RECENT_WORKSPACE_ROOTS: Command = {
+        id: 'workspace:openRecent',
+        category: FILE_CATEGORY,
+        label: 'Open Recent Workspace Roots...'
+    };
+    export const CLOSE_WORKSPACE_ROOTS: Command = {
+        id: 'workspace:close',
+        category: WORKSPACE_CATEGORY,
+        label: 'Close Workspace Roots'
+    };
 }
 
 @injectable()
 export class CheWorkspaceContribution implements CommandContribution, MenuContribution {
 
     @inject(CheWorkspaceController) protected readonly workspaceController: CheWorkspaceController;
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(CheWorkspaceCommands.OPEN_WORKSPACE, {
@@ -50,6 +68,20 @@ export class CheWorkspaceContribution implements CommandContribution, MenuContri
         });
         commands.registerCommand(CheWorkspaceCommands.CLOSE_CURRENT_WORKSPACE, {
             execute: () => this.workspaceController.closeCurrentWorkspace()
+        });
+
+        commands.unregisterCommand(WorkspaceCommands.OPEN_WORKSPACE);
+        commands.registerCommand(CheWorkspaceCommands.OPEN_WORKSPACE_ROOTS, {
+            execute: () => this.workspaceController.openWorkspaceRoots()
+        });
+        commands.unregisterCommand(WorkspaceCommands.OPEN_RECENT_WORKSPACE);
+        commands.registerCommand(CheWorkspaceCommands.OPEN_RECENT_WORKSPACE_ROOTS, {
+            execute: () => this.workspaceController.openRecentWorkspaceRoots()
+        });
+        commands.unregisterCommand(WorkspaceCommands.CLOSE);
+        commands.registerCommand(CheWorkspaceCommands.CLOSE_WORKSPACE_ROOTS, {
+            isEnabled: () => this.workspaceService.opened,
+            execute: () => this.workspaceController.closeWorkspaceRoots()
         });
     }
 
@@ -70,13 +102,27 @@ export class CheWorkspaceContribution implements CommandContribution, MenuContri
             order: 'a10'
         });
         menus.registerMenuAction(CommonMenus.FILE_OPEN, {
+            commandId: CheWorkspaceCommands.OPEN_WORKSPACE_ROOTS.id,
+            label: CheWorkspaceCommands.OPEN_WORKSPACE_ROOTS.label,
+            order: 'a11'
+        });
+        menus.registerMenuAction(CommonMenus.FILE_OPEN, {
             commandId: CheWorkspaceCommands.OPEN_RECENT_WORKSPACE.id,
             label: CheWorkspaceCommands.OPEN_RECENT_WORKSPACE.label,
             order: 'a20'
         });
+        menus.registerMenuAction(CommonMenus.FILE_OPEN, {
+            commandId: CheWorkspaceCommands.OPEN_RECENT_WORKSPACE_ROOTS.id,
+            label: CheWorkspaceCommands.OPEN_RECENT_WORKSPACE_ROOTS.label,
+            order: 'a21'
+        });
         menus.registerMenuAction(CommonMenus.FILE_CLOSE, {
             commandId: CheWorkspaceCommands.CLOSE_CURRENT_WORKSPACE.id,
             label: CheWorkspaceCommands.CLOSE_CURRENT_WORKSPACE.label
+        });
+        menus.registerMenuAction(CommonMenus.FILE_CLOSE, {
+            commandId: CheWorkspaceCommands.CLOSE_WORKSPACE_ROOTS.id,
+            label: CheWorkspaceCommands.CLOSE_WORKSPACE_ROOTS.label
         });
     }
 }

--- a/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-controller.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-controller.ts
@@ -15,6 +15,15 @@ import { Message } from '@theia/core/lib/browser/widgets';
 import { Key } from '@theia/core/lib/browser/keyboard/keys';
 import { CheWorkspaceCommands } from './che-workspace-contribution';
 import { QuickOpenCheWorkspace } from './che-quick-open-workspace';
+import { FileDialogService, OpenFileDialogProps } from '@theia/filesystem/lib/browser';
+import {
+    WorkspaceService,
+    WorkspacePreferences
+} from '@theia/workspace/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+import { FileSystem } from '@theia/filesystem/lib/common';
+import { THEIA_EXT, VSCODE_EXT } from '@theia/workspace/lib/common';
+import { QuickOpenWorkspace } from '@theia/workspace/lib/browser/quick-open-workspace';
 
 export class StopWorkspaceDialog extends AbstractDialog<boolean | undefined> {
     protected confirmed: boolean | undefined = true;
@@ -71,6 +80,11 @@ export class CheWorkspaceController {
 
     @inject(CheApiService) protected readonly cheApi: CheApiService;
     @inject(QuickOpenCheWorkspace) protected readonly quickOpenWorkspace: QuickOpenCheWorkspace;
+    @inject(QuickOpenWorkspace) protected readonly quickOpenRecentWorkspaceRoots: QuickOpenWorkspace;
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
+    @inject(FileDialogService) protected readonly fileDialogService: FileDialogService;
+    @inject(FileSystem) protected readonly fileSystem: FileSystem;
+    @inject(WorkspacePreferences) protected preferences: WorkspacePreferences;
 
     async openWorkspace(): Promise<void> {
         await this.doOpenWorkspace(false);
@@ -81,7 +95,7 @@ export class CheWorkspaceController {
     }
 
     private doOpenWorkspace(recent: boolean): Promise<void> {
-        return  this.quickOpenWorkspace.select(recent, async (workspace: che.workspace.Workspace) => {
+        return this.quickOpenWorkspace.select(recent, async (workspace: che.workspace.Workspace) => {
             const dialog = new StopWorkspaceDialog();
             const result = await dialog.open();
             if (typeof result === 'boolean') {
@@ -102,6 +116,69 @@ export class CheWorkspaceController {
             await this.cheApi.stop();
 
             window.parent.postMessage('show-workspaces', '*');
+        }
+    }
+
+    async closeWorkspaceRoots(): Promise<void> {
+        const dialog = new ConfirmDialog({
+            title: CheWorkspaceCommands.CLOSE_WORKSPACE_ROOTS.label!,
+            msg: 'Do you really want to close the workspace roots?'
+        });
+        if (await dialog.open()) {
+            await this.workspaceService.close();
+        }
+    }
+
+    openRecentWorkspaceRoots(): void {
+        this.quickOpenRecentWorkspaceRoots.select();
+    }
+
+    async openWorkspaceRoots(): Promise<URI | undefined> {
+        const props = await this.openWorkspaceOpenFileDialogProps();
+        const [rootStat] = await this.workspaceService.roots;
+        const workspaceFolderOrWorkspaceFileUri = await this.fileDialogService.showOpenDialog(props, rootStat);
+        if (workspaceFolderOrWorkspaceFileUri &&
+            this.getCurrentWorkspaceUri().toString() !== workspaceFolderOrWorkspaceFileUri.toString()) {
+            const destinationFolder = await this.fileSystem.getFileStat(workspaceFolderOrWorkspaceFileUri.toString());
+            if (destinationFolder) {
+                this.workspaceService.open(workspaceFolderOrWorkspaceFileUri);
+                return workspaceFolderOrWorkspaceFileUri;
+            }
+        }
+        return undefined;
+    }
+
+    private async openWorkspaceOpenFileDialogProps(): Promise<OpenFileDialogProps> {
+        await this.preferences.ready;
+        const supportMultiRootWorkspace = this.preferences['workspace.supportMultiRootWorkspace'];
+        return this.createOpenWorkspaceOpenFileDialogProps({
+            supportMultiRootWorkspace
+        });
+    }
+
+    private getCurrentWorkspaceUri(): URI {
+        return new URI(this.workspaceService.workspace && this.workspaceService.workspace.uri);
+    }
+
+    private createOpenWorkspaceOpenFileDialogProps(options: Readonly<{ supportMultiRootWorkspace: boolean }>): OpenFileDialogProps {
+        const title = CheWorkspaceCommands.OPEN_WORKSPACE_ROOTS.dialogLabel;
+        if (options.supportMultiRootWorkspace) {
+            return {
+                title,
+                canSelectFiles: true,
+                canSelectFolders: true,
+                filters: {
+                    'Theia Workspace (*.theia-workspace)': [THEIA_EXT],
+                    'VS Code Workspace (*.code-workspace)': [VSCODE_EXT]
+                }
+            };
+        } else {
+            // otherwise, it is always folders. No files at all.
+            return {
+                title,
+                canSelectFiles: false,
+                canSelectFolders: true
+            };
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?
This changes proposal reorganizes workspace related commands according to issue: https://github.com/eclipse/che/issues/17106

<img width="465" alt="Eclipse Che hosted by Red Hat | workspace111 2020-08-19 14-01-42" src="https://user-images.githubusercontent.com/1968177/90627746-10b22880-e225-11ea-91e4-93c68d9833c9.png">

Signed-off-by: Vladyslav Zhukovskyi vzhukovs@redhat.com

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17106

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
