### PR TITLE
Add an ability to export devfile to file system

### DIFF
--- a/extensions/eclipse-che-theia-workspace/package.json
+++ b/extensions/eclipse-che-theia-workspace/package.json
@@ -11,7 +11,11 @@
   "dependencies": {
     "@eclipse-che/api": "latest",
     "@theia/workspace": "next",
-    "@eclipse-che/theia-plugin-ext": "^0.0.1"
+    "@eclipse-che/theia-plugin-ext": "^0.0.1",
+    "js-yaml": "3.13.1"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "3.11.2"
   },
   "scripts": {
     "prepare": "yarn clean && yarn build",

--- a/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-contribution.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-contribution.ts
@@ -35,6 +35,11 @@ export namespace CheWorkspaceCommands {
         category: WORKSPACE_CATEGORY,
         label: 'Close Workspace'
     };
+    export const SAVE_WORKSPACE_AS: Command = {
+        id: 'che.saveWorkspaceAs',
+        category: WORKSPACE_CATEGORY,
+        label: 'Save Workspace As...'
+    };
     export const OPEN_WORKSPACE_ROOTS: Command & { dialogLabel: string } = {
         id: 'workspace:openWorkspace',
         category: FILE_CATEGORY,
@@ -50,6 +55,11 @@ export namespace CheWorkspaceCommands {
         id: 'workspace:close',
         category: WORKSPACE_CATEGORY,
         label: 'Close Workspace Roots'
+    };
+    export const SAVE_WORKSPACE_ROOTS_AS: Command = {
+        id: 'workspace:saveAs',
+        category: WORKSPACE_CATEGORY,
+        label: 'Save Workspace Roots As...'
     };
 }
 
@@ -69,6 +79,9 @@ export class CheWorkspaceContribution implements CommandContribution, MenuContri
         commands.registerCommand(CheWorkspaceCommands.CLOSE_CURRENT_WORKSPACE, {
             execute: () => this.workspaceController.closeCurrentWorkspace()
         });
+        commands.registerCommand(CheWorkspaceCommands.SAVE_WORKSPACE_AS, {
+            execute: () => this.workspaceController.saveWorkspaceAs()
+        });
 
         commands.unregisterCommand(WorkspaceCommands.OPEN_WORKSPACE);
         commands.registerCommand(CheWorkspaceCommands.OPEN_WORKSPACE_ROOTS, {
@@ -83,6 +96,11 @@ export class CheWorkspaceContribution implements CommandContribution, MenuContri
             isEnabled: () => this.workspaceService.opened,
             execute: () => this.workspaceController.closeWorkspaceRoots()
         });
+        commands.unregisterCommand(WorkspaceCommands.SAVE_WORKSPACE_AS);
+        commands.registerCommand(CheWorkspaceCommands.SAVE_WORKSPACE_ROOTS_AS, {
+            isEnabled: () => this.workspaceService.isMultiRootWorkspaceEnabled,
+            execute: () => this.workspaceController.saveWorkspaceRootsAs()
+        });
     }
 
     registerMenus(menus: MenuModelRegistry): void {
@@ -95,6 +113,9 @@ export class CheWorkspaceContribution implements CommandContribution, MenuContri
         menus.unregisterMenuAction({
             commandId: WorkspaceCommands.CLOSE.id
         }, CommonMenus.FILE_CLOSE);
+        menus.unregisterMenuAction({
+            commandId: WorkspaceCommands.SAVE_WORKSPACE_AS.id
+        }, CommonMenus.FILE_OPEN);
 
         menus.registerMenuAction(CommonMenus.FILE_OPEN, {
             commandId: CheWorkspaceCommands.OPEN_WORKSPACE.id,
@@ -123,6 +144,16 @@ export class CheWorkspaceContribution implements CommandContribution, MenuContri
         menus.registerMenuAction(CommonMenus.FILE_CLOSE, {
             commandId: CheWorkspaceCommands.CLOSE_WORKSPACE_ROOTS.id,
             label: CheWorkspaceCommands.CLOSE_WORKSPACE_ROOTS.label
+        });
+        menus.registerMenuAction(CommonMenus.FILE_OPEN, {
+            commandId: CheWorkspaceCommands.SAVE_WORKSPACE_AS.id,
+            label: CheWorkspaceCommands.SAVE_WORKSPACE_AS.label,
+            order: 'a30'
+        });
+        menus.registerMenuAction(CommonMenus.FILE_OPEN, {
+            commandId: CheWorkspaceCommands.SAVE_WORKSPACE_ROOTS_AS.id,
+            label: CheWorkspaceCommands.SAVE_WORKSPACE_ROOTS_AS.label,
+            order: 'a31'
         });
     }
 }

--- a/extensions/eclipse-che-theia-workspace/tsconfig.json
+++ b/extensions/eclipse-che-theia-workspace/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../configs/base.tsconfig.json",
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "lib": [
       "es6",
       "dom"


### PR DESCRIPTION
### What does this PR do?
This changes proposal adds an ability to export workspace's devfile from Theia editor to file system. 
Default Theia's command has moved from `Save Workspace...` to `Save Workspace Roots As...`. And `Save Workspace As...` now exports devfile from workspace configuration.

<img width="588" alt="Eclipse Che hosted by Red Hat | workspace111 2020-08-21 20-08-54" src="https://user-images.githubusercontent.com/1968177/90916830-7bf92780-e3ea-11ea-8d2a-1b5221ec16cf.png">

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17239

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
