### PR TITLE
Add an ability to use custom public certificates

### DIFF
--- a/extensions/che-theia-hosted-plugin-manager-extension/package.json
+++ b/extensions/che-theia-hosted-plugin-manager-extension/package.json
@@ -12,7 +12,7 @@
     "@theia/core": "1.5.0-next.4390a7d6",
     "@theia/plugin-dev": "1.5.0-next.4390a7d6",
     "@theia/plugin-ext": "1.5.0-next.4390a7d6",
-    "@eclipse-che/workspace-client": "0.0.1-1597050739",
+    "@eclipse-che/workspace-client": "0.0.1-1598950097",
     "@eclipse-che/api": "7.5.0-SNAPSHOT"
   },
   "scripts": {

--- a/extensions/eclipse-che-theia-plugin-ext/package.json
+++ b/extensions/eclipse-che-theia-plugin-ext/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@eclipse-che/plugin": "7.18.0",
-    "@eclipse-che/workspace-client": "0.0.1-1597050739",
+    "@eclipse-che/workspace-client": "0.0.1-1598950097",
     "@theia/core": "1.5.0-next.4390a7d6",
     "@theia/task": "1.5.0-next.4390a7d6",
     "@theia/mini-browser": "1.5.0-next.4390a7d6",

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-api-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-api-service.ts
@@ -11,7 +11,7 @@ import { CheApiService, Preferences, User, WorkspaceSettings } from '../common/c
 import { che as cheApi } from '@eclipse-che/api';
 import WorkspaceClient, { IRemoteAPI } from '@eclipse-che/workspace-client';
 import { injectable } from 'inversify';
-import { SS_CRT_PATH } from './che-https';
+import { PUBLIC_CRT_PATH, SS_CRT_PATH } from './che-https';
 import { TelemetryClient, EventProperty } from '@eclipse-che/workspace-telemetry-client';
 
 @injectable()
@@ -226,6 +226,7 @@ export class CheApiServiceImpl implements CheApiService {
         return WorkspaceClient.getRestApi({
             baseUrl: this.baseAPIUrl,
             ssCrtPath: SS_CRT_PATH,
+            publicCrtPath: PUBLIC_CRT_PATH,
             machineToken: userToken && userToken.length > 0 ? undefined : this.machineToken,
             userToken: userToken && userToken.length > 0 ? userToken : undefined
         });

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-https.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-https.ts
@@ -9,3 +9,4 @@
  **********************************************************************/
 
 export const SS_CRT_PATH = '/tmp/che/secret/ca.crt';
+export const PUBLIC_CRT_PATH = '/public-certs';

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -24,7 +24,8 @@ import URI from '@theia/core/lib/common/uri';
 import { PluginFilter } from '../common/plugin/plugin-filter';
 import * as fs from 'fs-extra';
 import * as https from 'https';
-import { SS_CRT_PATH } from './che-https';
+import { PUBLIC_CRT_PATH, SS_CRT_PATH } from './che-https';
+import * as path from 'path';
 
 const yaml = require('js-yaml');
 
@@ -127,11 +128,11 @@ export class ChePluginServiceImpl implements ChePluginService {
                 const httpOverHttpsAgent = tunnel.httpOverHttps({ proxy: httpsProxyOptions });
                 const httpsOverHttpAgent = tunnel.httpsOverHttp({
                     proxy: mainProxyOptions,
-                    ca: certificateAuthority ? [certificateAuthority] : undefined
+                    ca: certificateAuthority ? certificateAuthority : undefined
                 });
                 const httpsOverHttpsAgent = tunnel.httpsOverHttps({
                     proxy: httpsProxyOptions,
-                    ca: certificateAuthority ? [certificateAuthority] : undefined
+                    ca: certificateAuthority ? certificateAuthority : undefined
                 });
                 const urlIsHttps = (parsedBaseUrl.protocol || 'http:').startsWith('https:');
                 const proxyIsHttps = (parsedProxyUrl.protocol || 'http:').startsWith('https:');
@@ -155,13 +156,13 @@ export class ChePluginServiceImpl implements ChePluginService {
         return axios;
     }
 
-    private getHttpsProxyOptions(mainProxyOptions: tunnel.ProxyOptions, servername: string | undefined, certificateAuthority: Buffer | undefined): tunnel.HttpsProxyOptions {
+    private getHttpsProxyOptions(mainProxyOptions: tunnel.ProxyOptions, servername: string | undefined, certificateAuthority: Buffer[] | undefined): tunnel.HttpsProxyOptions {
         return {
             host: mainProxyOptions.host,
             port: mainProxyOptions.port,
             proxyAuth: mainProxyOptions.proxyAuth,
             servername,
-            ca: certificateAuthority ? [certificateAuthority] : undefined
+            ca: certificateAuthority ? certificateAuthority : undefined
         };
     }
 
@@ -196,12 +197,23 @@ export class ChePluginServiceImpl implements ChePluginService {
         return (typeof process !== 'undefined') && (typeof process.versions.node !== 'undefined');
     }
 
-    private getCertificateAuthority(): Buffer | undefined {
-        let certificateAuthority: Buffer | undefined;
+    private getCertificateAuthority(): Array<Buffer> | undefined {
+        const certificateAuthority: Buffer[] = [];
         if (fs.existsSync(SS_CRT_PATH)) {
-            certificateAuthority = fs.readFileSync(SS_CRT_PATH);
+            certificateAuthority.push(fs.readFileSync(SS_CRT_PATH));
         }
-        return certificateAuthority;
+
+        if (fs.existsSync(PUBLIC_CRT_PATH)) {
+            const publicCertificates = fs.readdirSync(PUBLIC_CRT_PATH);
+            for (const publicCertificate of publicCertificates) {
+                if (publicCertificate.endsWith('.crt')) {
+                    const certPath = path.join(PUBLIC_CRT_PATH, publicCertificate);
+                    certificateAuthority.push(fs.readFileSync(certPath));
+                }
+            }
+        }
+
+        return certificateAuthority.length > 0 ? certificateAuthority : undefined;
     }
 
     /**

--- a/extensions/eclipse-che-theia-terminal/package.json
+++ b/extensions/eclipse-che-theia-terminal/package.json
@@ -22,7 +22,7 @@
     "@theia/core": "1.5.0-next.4390a7d6",
     "@theia/terminal": "1.5.0-next.4390a7d6",
     "reconnecting-websocket": "^4.2.0",
-    "@eclipse-che/workspace-client": "0.0.1-1597050739",
+    "@eclipse-che/workspace-client": "0.0.1-1598950097",
     "@eclipse-che/api": "7.5.0-SNAPSHOT",
     "vscode-ws-jsonrpc": "0.2.0"
   },

--- a/extensions/eclipse-che-theia-terminal/src/node/workspace-service-impl.ts
+++ b/extensions/eclipse-che-theia-terminal/src/node/workspace-service-impl.ts
@@ -18,6 +18,7 @@ import { TERMINAL_SERVER_TYPE } from '../browser/server-definition/remote-termin
 const TYPE: string = 'type';
 const EDITOR_SERVER_TYPE: string = 'ide';
 const SS_CRT_PATH = '/tmp/che/secret/ca.crt';
+const PUBLIC_CRT_PATH = '/public-certs';
 
 @injectable()
 export class CHEWorkspaceServiceImpl implements CHEWorkspaceService {
@@ -116,7 +117,8 @@ export class CHEWorkspaceServiceImpl implements CHEWorkspaceService {
             this.api = WorkspaceClient.getRestApi({
                 baseUrl: this.getWsMasterApiEndPoint(),
                 machineToken: this.getMachineToken(),
-                ssCrtPath: SS_CRT_PATH
+                ssCrtPath: SS_CRT_PATH,
+                publicCrtPath: PUBLIC_CRT_PATH
             });
         }
         return this.api;

--- a/yarn.lock
+++ b/yarn.lock
@@ -872,9 +872,9 @@
     "@eclipse-che/api" latest
 
 "@eclipse-che/workspace-client@latest":
-  version "0.0.1-1593692693"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1593692693.tgz#0606ef98a84b7e7c8a5305f31cf07696c1e29bed"
-  integrity sha512-DCD/oL3Hs0EKzypyn05c5cMiVOHrYds8cQ102Sti2/W70KTyTtQJNVUsuew1qnUHUlb/VCLdkwq2ck/DV6TqgQ==
+  version "0.0.1-1598950097"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1598950097.tgz#4e341849b74ce9f123952ba7edc3be1005c20f68"
+  integrity sha512-z07pA8MrfSAYZzFnTXifKBAG3w6QxUl0eWVonFxU2lucMq+vFdUI6yPxNgj7dVdm0EeQ1BHZqgnkO1eNaTT1fA==
   dependencies:
     "@eclipse-che/api" "^7.0.0-beta-4.0"
     axios "0.19.0"


### PR DESCRIPTION
### What does this PR do?
Back port of https://github.com/eclipse/che-theia/pull/824 for CRW 2.4

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17440

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
