### PR TITLE
Disable using trash directory by default

### DIFF
--- a/generator/src/templates/assembly-package.mst
+++ b/generator/src/templates/assembly-package.mst
@@ -9,7 +9,8 @@
         "preferences": {
           "editor.autoSave": "on",
           "git.defaultCloneDirectory": "/projects",
-          "application.confirmExit": "always"
+          "application.confirmExit": "always",
+          "files.enableTrash", false
         }
       }
     }

--- a/generator/src/templates/assembly-package.mst
+++ b/generator/src/templates/assembly-package.mst
@@ -10,7 +10,7 @@
           "editor.autoSave": "on",
           "git.defaultCloneDirectory": "/projects",
           "application.confirmExit": "always",
-          "files.enableTrash", false
+          "files.enableTrash": false
         }
       }
     }


### PR DESCRIPTION
### What does this PR do?
Disable `Enable Trash` property by default.

<img width="652" alt="Eclipse Che hosted by Red Hat | java-web-spring-iyg6x 2020-09-02 17-31-37" src="https://user-images.githubusercontent.com/1968177/91996953-3de0f980-ed42-11ea-8e21-bdbd22b6d4a3.png">

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1129


#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
