### PR TITLE
Disable using trash directory by default

### DIFF
--- a/generator/src/templates/assembly-package.mst
+++ b/generator/src/templates/assembly-package.mst
@@ -9,7 +9,8 @@
         "preferences": {
           "editor.autoSave": "on",
           "git.defaultCloneDirectory": "/projects",
-          "application.confirmExit": "always"
+          "application.confirmExit": "always",
+          "files.enableTrash": false
         }
       }
     }


### PR DESCRIPTION
### What does this PR do?
Back port of https://github.com/eclipse/che-theia/pull/845 into 7.18.1 for CRW 2.4

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1129


#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
