### PR TITLE
Do not store state of Welcome page

### DIFF
--- a/plugins/welcome-plugin/src/welcome-plugin.ts
+++ b/plugins/welcome-plugin/src/welcome-plugin.ts
@@ -113,8 +113,6 @@ export async function addPanel(context: theia.PluginContext): Promise<void> {
 export function start(context: theia.PluginContext): void {
     let showWelcomePage: boolean | undefined = true;
 
-    theia.window.registerWebviewPanelSerializer(welcomePageViewType, new WelcomePageSerializer(context));
-
     const configuration = theia.workspace.getConfiguration(Settings.CHE_CONFIGURATION);
     if (configuration) {
         showWelcomePage = configuration.get(Settings.SHOW_WELCOME_PAGE);
@@ -129,15 +127,4 @@ export function start(context: theia.PluginContext): void {
 }
 
 export function stop(): void {
-}
-
-export class WelcomePageSerializer implements theia.WebviewPanelSerializer {
-
-    constructor(readonly context: theia.PluginContext) {
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async deserializeWebviewPanel(webviewPanel: theia.WebviewPanel, state: any): Promise<void> {
-        webviewPanel.webview.html = await getHtmlForWebview(this.context);
-    }
 }


### PR DESCRIPTION
Signed-off-by: Vitaliy Guliy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Disables saving the state of Welcome page.

Why do we need to do this:
  - the plugin doesn't take into account that after reload the page, Theia restores all the views, including the previously opened Welcome page
  - after restoring the state, links in the webview become not working

Depends on https://github.com/eclipse-theia/theia/pull/8473

### What issues does this PR fix or reference?
- https://github.com/eclipse/che/issues/16352
- https://issues.redhat.com/browse/CRW-1029

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
