### PR TITLE
Do not use authority certificate for requests outside Che container

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -108,7 +108,6 @@ export class ChePluginServiceImpl implements ChePluginService {
     }
 
     /**
-     * URI for which an axios instance will be created.
      * If the URI points to default plugin registry, axios will use local authority certificates.
      */
     private getAxiosInstance(uri: string): AxiosInstance {

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -107,6 +107,10 @@ export class ChePluginServiceImpl implements ChePluginService {
         }
     }
 
+    /**
+     * URI for which an axios instance will be created.
+     * If the URI points to default plugin registry, axios will use local authority certificates.
+     */
     private getAxiosInstance(uri: string): AxiosInstance {
         const certificateAuthority = this.getCertificateAuthority();
 


### PR DESCRIPTION
Signed-off-by: admin <admin@admin.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Disables using authority certificates when getting plugin list from custom plugin registry.


How to test:
- build and launch Che-Theia with changes from this PR
- open Plugins view, add registry (it could be https://raw.githubusercontent.com/vitaliy-guliy/che-theia-plugin-registry/master/plugins/plugins.json)

![Screenshot from 2020-09-09 17-26-48](https://user-images.githubusercontent.com/1655894/92611647-ab9ca080-f2c1-11ea-8b3e-7ccc406a20e6.png)

- after refreshing the view, scroll to bottom

![Screenshot from 2020-09-09 17-32-20](https://user-images.githubusercontent.com/1655894/92612360-78a6dc80-f2c2-11ea-9da3-3753e4431a34.png)


Without this fix, new plugins will not appear in the list and Theia will trace the following
```
2020-07-30 13:01:29.028 root INFO Cannot access the registry Params: Error: unable to get local issuer certificate
    at TLSSocket.onConnectSecure (_tls_wrap.js:1501:34)
    at TLSSocket.emit (events.js:315:20)
    at TLSSocket._finishInit (_tls_wrap.js:936:8)
    at TLSWrap.ssl.onhandshakedone (_tls_wrap.js:710:12)
2020-07-30 13:01:29.148 root INFO Unable to read plugin registry Params: https://raw.githubusercontent.com/vitaliy-guliy/che-theia-plugin-registry/master/plugins/plugins.json
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16473

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
