### PR TITLE
Switch to the previous version of @eclipse-che/api npm package

### DIFF
--- a/extensions/che-theia-hosted-plugin-manager-extension/package.json
+++ b/extensions/che-theia-hosted-plugin-manager-extension/package.json
@@ -13,7 +13,7 @@
     "@theia/plugin-dev": "next",
     "@theia/plugin-ext": "next",
     "@eclipse-che/workspace-client": "latest",
-    "@eclipse-che/api": "latest"
+    "@eclipse-che/api": "7.5.0-SNAPSHOT"
   },
   "scripts": {
     "prepare": "yarn clean && yarn build",

--- a/extensions/eclipse-che-theia-dashboard/package.json
+++ b/extensions/eclipse-che-theia-dashboard/package.json
@@ -9,7 +9,7 @@
     "src"
   ],
   "dependencies": {
-    "@eclipse-che/api": "latest",
+    "@eclipse-che/api": "7.5.0-SNAPSHOT",
     "@theia/core": "next",
     "@eclipse-che/theia-plugin-ext": "^0.0.1"
   },

--- a/extensions/eclipse-che-theia-plugin/package.json
+++ b/extensions/eclipse-che-theia-plugin/package.json
@@ -11,7 +11,7 @@
         "src"
     ],
     "dependencies": {
-        "@eclipse-che/api": "latest"
+        "@eclipse-che/api": "7.5.0-SNAPSHOT"
     },
     "scripts": {
         "prepare": "",

--- a/extensions/eclipse-che-theia-preferences-provider-extension/package.json
+++ b/extensions/eclipse-che-theia-preferences-provider-extension/package.json
@@ -10,7 +10,7 @@
     "src"
   ],
   "dependencies": {
-    "@eclipse-che/api": "latest",
+    "@eclipse-che/api": "7.5.0-SNAPSHOT",
     "@eclipse-che/theia-plugin-ext": "^0.0.1",
     "@theia/core": "next",
     "@theia/preferences": "next",

--- a/extensions/eclipse-che-theia-terminal/package.json
+++ b/extensions/eclipse-che-theia-terminal/package.json
@@ -23,7 +23,7 @@
     "@theia/terminal": "next",
     "reconnecting-websocket": "^4.2.0",
     "@eclipse-che/workspace-client": "latest",
-    "@eclipse-che/api": "latest",
+    "@eclipse-che/api": "7.5.0-SNAPSHOT",
     "vscode-ws-jsonrpc": "0.2.0"
   },
   "license": "EPL-2.0",

--- a/extensions/eclipse-che-theia-workspace/package.json
+++ b/extensions/eclipse-che-theia-workspace/package.json
@@ -9,7 +9,7 @@
     "src"
   ],
   "dependencies": {
-    "@eclipse-che/api": "latest",
+    "@eclipse-che/api": "7.5.0-SNAPSHOT",
     "@theia/workspace": "next",
     "@eclipse-che/theia-plugin-ext": "^0.0.1",
     "js-yaml": "3.13.1"

--- a/plugins/ssh-plugin/package.json
+++ b/plugins/ssh-plugin/package.json
@@ -33,7 +33,7 @@
       },
       "devDependencies": {
         "@types/node": "^12.0.0",
-        "@eclipse-che/api": "latest",
+        "@eclipse-che/api": "7.5.0-SNAPSHOT",
         "@eclipse-che/plugin": "0.0.1",
         "@theia/plugin": "next",
         "@theia/plugin-packager": "latest"

--- a/plugins/workspace-plugin/package.json
+++ b/plugins/workspace-plugin/package.json
@@ -14,7 +14,7 @@
     },
     "devDependencies": {
         "@types/node": "^12.0.0",
-        "@eclipse-che/api": "latest",
+        "@eclipse-che/api": "7.5.0-SNAPSHOT",
         "@eclipse-che/plugin": "0.0.1",
         "@theia/plugin": "next",
         "@theia/plugin-packager": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -854,15 +854,15 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@eclipse-che/api@7.5.0-SNAPSHOT", "@eclipse-che/api@latest":
+  version "7.5.0-SNAPSHOT"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.5.0-SNAPSHOT.tgz#bf0c5be60354e34c73bc52b2e18be8680ce8d900"
+  integrity sha512-4CgKEGCBOIOBGBNoH0dhN8TkP1Sj39fG4LGCXYw3JB7nQucVooJyq7AhIV+w7L4iZ+ln+y2KEfZugCmOIuzIeQ==
+
 "@eclipse-che/api@^7.0.0-beta-4.0", "@eclipse-che/api@^7.3.2":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.4.0.tgz#74be0ca037ea2e9702d74971ac2ed8befdcb8a46"
   integrity sha512-/WDMO6F2lKNuNMAIBmPDYQ22TqGIhrSpK6OaU0aie3qeQa7yxXHtK5nuxyyQGFOZWVdKD9cWisjDyaro7+OM0Q==
-
-"@eclipse-che/api@latest":
-  version "7.5.0-SNAPSHOT"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.5.0-SNAPSHOT.tgz#bf0c5be60354e34c73bc52b2e18be8680ce8d900"
-  integrity sha512-4CgKEGCBOIOBGBNoH0dhN8TkP1Sj39fG4LGCXYw3JB7nQucVooJyq7AhIV+w7L4iZ+ln+y2KEfZugCmOIuzIeQ==
 
 "@eclipse-che/plugin@latest":
   version "0.0.1-1595942817"


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Switches to the previous version of [`@eclipse-che/api`](https://www.npmjs.com/package/@eclipse-che/api) npm package - 7.5.0-SNAPSHOT. As the latest one (7.18.2) brings breaking changes.

Follow-up issue for adapting Che Theia to `@eclipse-che/api:7.18.2` - https://github.com/eclipse/che/issues/17860

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
