### PR TITLE
Add "Reload" button to the message panel from "GitHub authenticate".

### DIFF
--- a/plugins/github-auth-plugin/src/github-auth-plugin.ts
+++ b/plugins/github-auth-plugin/src/github-auth-plugin.ts
@@ -25,7 +25,8 @@ export function start(context: theia.PluginContext): void {
                 token
             }], theia.ConfigurationTarget.Global);
             theia.window.showWarningMessage('GitHub token has been set to preferences. ' +
-                'Refresh the page to reinitialise the vscode GitHub pull-request plugin with the token');
+                'Refresh the page to reinitialize the vscode GitHub pull-request plugin with the token',
+                'Reload').then(() => theia.commands.executeCommand('workbench.action.reloadWindow'));
         }));
     }
 }


### PR DESCRIPTION
# What does this PR do?

* Enables to reload by pressing the button on the message panel provided by "GitHub authenticate".
* Adds new theia extension named "@eclipse-che/theia-ide-page-loader" that provides "ide-page-loader:reload" command.

### What issues does this PR fix or reference?

Fixes eclipse/che#17889   There is some screenshots available.

#### Docs PR

None.

I read [the document related this improvement](https://github.com/eclipse/che-docs/blob/06fe0007bb8d52502d961d934280c1e9bc54f04c/modules/end-user-guide/partials/proc_managing-pull-requests-using-the-github-pr-plug-in.adoc) and I suppose there is no need to change.

### Happy Path Channel

HAPPY_PATH_CHANNEL=stable
