### PR TITLE
Rebind overwrite dialog by adding check for modification time bias

### DIFF
--- a/che-theia-init-sources.yml
+++ b/che-theia-init-sources.yml
@@ -17,6 +17,7 @@ sources:
     - extensions/eclipse-che-theia-file-sync-tracker
     - extensions/eclipse-che-theia-cli-endpoint
     - extensions/eclipse-che-theia-workspace
+    - extensions/eclipse-che-theia-filesystem
   plugins:
     - plugins/containers-plugin
     - plugins/workspace-plugin

--- a/extensions/eclipse-che-theia-filesystem/.gitignore
+++ b/extensions/eclipse-che-theia-filesystem/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.browser_modules
+lib
+*.log
+*-app/*
+!*-app/package.json
+.idea

--- a/extensions/eclipse-che-theia-filesystem/package.json
+++ b/extensions/eclipse-che-theia-filesystem/package.json
@@ -9,7 +9,7 @@
     "src"
   ],
   "dependencies": {
-    "@theia/filesystem": "1.4.0-next.89694867"
+    "@theia/filesystem": "next"
   },
   "scripts": {
     "prepare": "yarn clean && yarn build",

--- a/extensions/eclipse-che-theia-filesystem/package.json
+++ b/extensions/eclipse-che-theia-filesystem/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@eclipse-che/theia-filesystem-extension",
+  "keywords": [
+    "theia-extension"
+  ],
+  "version": "0.0.1",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "dependencies": {
+    "@theia/filesystem": "1.4.0-next.89694867"
+  },
+  "scripts": {
+    "prepare": "yarn clean && yarn build",
+    "clean": "rimraf lib",
+    "format": "tsfmt -r --useTsfmt ../../configs/tsfmt.json",
+    "lint": "eslint --cache=true --no-error-on-unmatched-pattern=true \"{src,test}/**/*.{ts,tsx}\"",
+    "compile": "tsc",
+    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\"",
+    "watch": "tsc -w"
+  },
+  "license": "EPL-2.0",
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/che-filesystem-module"
+    }
+  ]
+}

--- a/extensions/eclipse-che-theia-filesystem/src/browser/che-filesystem-module.ts
+++ b/extensions/eclipse-che-theia-filesystem/src/browser/che-filesystem-module.ts
@@ -1,0 +1,30 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import { ContainerModule } from 'inversify';
+import { LabelProvider, ConfirmDialog } from '@theia/core/lib/browser';
+import { FileShouldOverwrite, FileStat } from '@theia/filesystem/lib/common/filesystem';
+import URI from '@theia/core/lib/common/uri';
+
+export default new ContainerModule((bind, unbind, isBound, rebind) => {
+    rebind(FileShouldOverwrite).toDynamicValue(context => async (file: FileStat, stat: FileStat): Promise<boolean> => {
+        if (Math.abs(file.lastModification - stat.lastModification) <= 1) {
+            return true;
+        }
+
+        const labelProvider = context.container.get(LabelProvider);
+        const dialog = new ConfirmDialog({
+            title: `The file '${labelProvider.getName(new URI(file.uri))}' has been changed on the file system.`,
+            msg: `Do you want to overwrite the changes made to '${labelProvider.getLongName(new URI(file.uri))}' on the file system?`,
+            ok: 'Yes',
+            cancel: 'No'
+        });
+        return !!await dialog.open();
+    }).inSingletonScope();
+});

--- a/extensions/eclipse-che-theia-filesystem/tsconfig.json
+++ b/extensions/eclipse-che-theia-filesystem/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../configs/base.tsconfig.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "lib": [
+      "es6",
+      "dom"
+    ],
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2252,7 +2252,7 @@
     fuzzy "^0.1.3"
     vscode-ripgrep "^1.2.4"
 
-"@theia/filesystem@1.4.0-next.89694867":
+"@theia/filesystem@1.4.0-next.89694867", "@theia/filesystem@next":
   version "1.4.0-next.89694867"
   resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-1.4.0-next.89694867.tgz#5c21e9515f82667f99f78e7c906c05ad0e22daae"
   integrity sha512-DW8e+k66zQlODh1y1/wv7qUpe6ZfgdmPtDVsfEtQnxgSgKrYHkKRchxFSwjwSYbGtCjobO/f2LRMHqsBo2tYrA==


### PR DESCRIPTION
### What does this PR do?
This changes proposal rebinds default file overwrite dialog by adding an additional check for modification time bias.

The problem which this changes proposal fixes described in [followed comment](https://github.com/eclipse/che/issues/16751#issuecomment-692768138).

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16751

#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
