### PR TITLE
Use internal network url for plugin registry.

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -81,8 +81,9 @@ export class ChePluginServiceImpl implements ChePluginService {
 
     try {
       const workspaceSettings: WorkspaceSettings = await this.workspaceService.getWorkspaceSettings();
-      if (workspaceSettings && workspaceSettings['cheWorkspacePluginRegistryUrl']) {
-        let uri = workspaceSettings['cheWorkspacePluginRegistryUrl'];
+      if (workspaceSettings && workspaceSettings['cheWorkspacePluginRegistryInternalUrl']) {
+        let uri = workspaceSettings['cheWorkspacePluginRegistryInternalUrl'];
+        console.log('[INFO] Plugin registry url is: ' + uri);
 
         if (!uri.endsWith('/plugins/')) {
           if (uri.endsWith('/')) {


### PR DESCRIPTION
Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>

### What does this PR do?
Use internal network url for plugin registry.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17644

### Depends on other pr's:
Yes:
https://github.com/eclipse/che-operator/pull/468 and also: https://github.com/eclipse/che/pull/17945


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->

#### Docs PR
none yet...

### Happy Path Channel
HAPPY_PATH_CHANNEL=next
