### PR TITLE
Add vscode github built-in plugin as a default plugin

### DIFF
--- a/generator/src/templates/theiaPlugins.json
+++ b/generator/src/templates/theiaPlugins.json
@@ -52,6 +52,7 @@
     "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
     "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix",
     "vscode-git": "https://open-vsx.org/api/vscode/git/1.49.3/file/vscode.git-1.49.3.vsix",
+    "vscode-github": "https://open-vsx.org/api/vscode/github/1.50.0/file/vscode.github-1.50.0.vsix",
     "vscode-references-view": "https://github.com/theia-ide/vscode-references-view/releases/download/v0.0.47/references-view-0.0.47.vsix",
     "vscode-builtin-theme-abyss": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/theme-abyss-1.39.1-prel.vsix",
     "vscode-builtin-theme-defaults": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/theme-defaults-1.39.1-prel.vsix",

--- a/plugins/github-auth-plugin/src/github-auth-plugin.ts
+++ b/plugins/github-auth-plugin/src/github-auth-plugin.ts
@@ -12,40 +12,40 @@ import * as theia from '@theia/plugin';
 import * as che from '@eclipse-che/plugin';
 
 export async function start(context: theia.PluginContext): Promise<void> {
-    if (theia.plugins.getPlugin('github.vscode-pull-request-github')) {
-        let session: theia.AuthenticationSession | undefined = context.workspaceState.get('session');
-        const onDidChangeSessions = new theia.EventEmitter<theia.AuthenticationProviderAuthenticationSessionsChangeEvent>();
-        theia.authentication.registerAuthenticationProvider({
-                id: 'github',
-                label: 'GitHub',
-                supportsMultipleAccounts: false,
-                onDidChangeSessions: onDidChangeSessions.event,
-                getSessions: async () => {
-                    if (session) {
-                        return [session];
-                    } else {
-                        return [];
-                    }
-                },
-                login: async (scopes: string[]) => {
-                    const githubUser = await che.github.getUser();
-                    session = {
-                        id: 'github-session',
-                        accessToken: await che.github.getToken(),
-                        account: {label: githubUser.login, id: githubUser.id.toString()},
-                        scopes
-                    };
-                    context.workspaceState.update('session', session);
-                    onDidChangeSessions.fire({ added: [session.id], removed: [], changed: [] });
-                    return session;
-                },
-                logout: async (id: string) => {
-                    session = undefined;
-                    context.workspaceState.update('session', session);
-                    onDidChangeSessions.fire({ added: [], removed: [id], changed: [] });
+    let session: theia.AuthenticationSession | undefined = context.workspaceState.get('session');
+    const onDidChangeSessions = new theia.EventEmitter<theia.AuthenticationProviderAuthenticationSessionsChangeEvent>();
+    theia.authentication.registerAuthenticationProvider({
+            id: 'github',
+            label: 'GitHub',
+            supportsMultipleAccounts: false,
+            onDidChangeSessions: onDidChangeSessions.event,
+            getSessions: async () => {
+                if (session) {
+                    return [session];
+                } else {
+                    return [];
                 }
+            },
+            login: async (scopes: string[]) => {
+                const githubUser = await che.github.getUser();
+                session = {
+                    id: 'github-session',
+                    accessToken: await che.github.getToken(),
+                    account: {label: githubUser.login, id: githubUser.id.toString()},
+                    scopes
+                };
+                context.workspaceState.update('session', session);
+                onDidChangeSessions.fire({ added: [session.id], removed: [], changed: [] });
+                return session;
+            },
+            logout: async (id: string) => {
+                session = undefined;
+                context.workspaceState.update('session', session);
+                onDidChangeSessions.fire({ added: [], removed: [id], changed: [] });
             }
-        );
+        }
+    );
+    if (theia.plugins.getPlugin('github.vscode-pull-request-github')) {
         if (session) {
             onDidChangeSessions.fire({ added: [session.id], removed: [], changed: [] });
         // TODO Remove the notification when https://github.com/eclipse-theia/theia/issues/7178 is fixed.


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
* Add vscode github built-in plugin as a default plugin.
* Always register the github authentication provider (removed the condition of the GitHub Pull Request plugin presence).

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/18101
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
