### PR TITLE
Open Explorer on start

### DIFF
--- a/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-module.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-module.ts
@@ -9,9 +9,11 @@
  **********************************************************************/
 import { ContainerModule } from 'inversify';
 import { QuickOpenCheWorkspace } from './che-quick-open-workspace';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
 import { CheWorkspaceContribution } from './che-workspace-contribution';
 import { CheWorkspaceController } from './che-workspace-controller';
+import { ExplorerContribution } from './explorer-contribution';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(QuickOpenCheWorkspace).toSelf().inSingletonScope();
@@ -20,4 +22,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     for (const identifier of [CommandContribution, MenuContribution]) {
         bind(identifier).toService(CheWorkspaceContribution);
     }
+
+    bind(ExplorerContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).to(ExplorerContribution);
 });

--- a/extensions/eclipse-che-theia-workspace/src/browser/explorer-contribution.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/explorer-contribution.ts
@@ -1,0 +1,25 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { inject, injectable } from 'inversify';
+import { FrontendApplicationContribution, FrontendApplication, ApplicationShell } from '@theia/core/lib/browser';
+import { FILE_NAVIGATOR_ID } from '@theia/navigator/lib/browser';
+
+@injectable()
+export class ExplorerContribution implements FrontendApplicationContribution {
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    // Note, it's called only when there is no previous workbench layout state is stored.
+    async initializeLayout(app: FrontendApplication): Promise<void> {
+        this.shell.revealWidget(FILE_NAVIGATOR_ID);
+    }
+}

--- a/plugins/welcome-plugin/package.json
+++ b/plugins/welcome-plugin/package.json
@@ -35,6 +35,9 @@
     "@theia/plugin-packager": "latest",
     "@eclipse-che/plugin": "0.0.1"
   },
+  "extensionDependencies": [
+    "Eclipse Che.@eclipse-che/workspace-plugin"
+  ],
   "scripts": {
     "prepare": "yarn run clean && yarn run build",
     "clean": "rimraf lib",

--- a/plugins/welcome-plugin/src/welcome-plugin.ts
+++ b/plugins/welcome-plugin/src/welcome-plugin.ts
@@ -123,7 +123,13 @@ export function start(context: theia.PluginContext): void {
     if (showWelcomePage && theia.window.visibleTextEditors.length === 0) {
         setTimeout(async () => {
             addPanel(context);
-            handleReadmeFiles();
+
+            const workspacePlugin = theia.plugins.getPlugin('Eclipse Che.@eclipse-che/workspace-plugin');
+            if (workspacePlugin) {
+                workspacePlugin.exports.onDidCloneSources(() => handleReadmeFiles());
+            } else {
+                handleReadmeFiles();
+            }
         }, 100);
     }
 }

--- a/plugins/workspace-plugin/src/workspace-plugin.ts
+++ b/plugins/workspace-plugin/src/workspace-plugin.ts
@@ -9,12 +9,16 @@
  **********************************************************************/
 
 import * as theia from '@theia/plugin';
-import { handleWorkspaceProjects } from './workspace-projects-manager';
+import { handleWorkspaceProjects, onDidCloneSources } from './workspace-projects-manager';
 import { EphemeralWorkspaceChecker } from './ephemeral-workspace-checker';
 import { Devfile } from './devfile';
 import { initAskpassEnv } from './askpass';
 
-export async function start(context: theia.PluginContext): Promise<void> {
+interface API {
+    readonly onDidCloneSources: theia.Event<void>
+}
+
+export async function start(context: theia.PluginContext): Promise<API> {
     let projectsRoot = '/projects';
     const projectsRootEnvVar = await theia.env.getEnvVariable('CHE_PROJECTS_ROOT');
     if (projectsRootEnvVar) {
@@ -25,6 +29,12 @@ export async function start(context: theia.PluginContext): Promise<void> {
     new EphemeralWorkspaceChecker().check();
     await initAskpassEnv();
     handleWorkspaceProjects(context, projectsRoot);
+
+    return {
+        get onDidCloneSources(): theia.Event<void> {
+            return onDidCloneSources;
+        }
+    };
 }
 
 export function stop(): void {

--- a/plugins/workspace-plugin/src/workspace-projects-manager.ts
+++ b/plugins/workspace-plugin/src/workspace-projects-manager.ts
@@ -18,6 +18,9 @@ import * as theia from '@theia/plugin';
 import * as che from '@eclipse-che/plugin';
 import { che as cheApi } from '@eclipse-che/api';
 
+const onDidCloneSourcesEmitter = new theia.EventEmitter<void>();
+export const onDidCloneSources = onDidCloneSourcesEmitter.event;
+
 export function handleWorkspaceProjects(pluginContext: theia.PluginContext, projectsRoot: string): void {
     che.workspace.getCurrentWorkspace().then((workspace: cheApi.workspace.Workspace) => {
         if (workspace.devfile) {
@@ -65,6 +68,7 @@ abstract class WorkspaceProjectsManager {
             cloneCommandList.map(cloneCommand => cloneCommand.execute())
         );
         theia.window.showInformationMessage('Che Workspace: Finished importing projects.');
+        onDidCloneSourcesEmitter.fire();
     }
 
     async startSyncWorkspaceProjects(): Promise<void> {


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR adds a couple of UX enhancements to a new user flow:
- each time when a new Workspace started, Project Explorer is opened automatically
- fixed opening `README.md` file - Che Theia starts looking for a file only after finishing cloning the project's sources
- project folder that contains a `README.md` file is auto-expanded

![Peek 2020-10-27 10-07](https://user-images.githubusercontent.com/1636395/97275711-f0af6e80-183e-11eb-8849-200b1a25c564.gif)

### What issues does this PR fix or reference?
closes https://github.com/eclipse/che/issues/17969

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
