### PR TITLE
Fix "goto definition"

### DIFF
--- a/extensions/eclipse-che-theia-plugin-remote/src/node/languages-container-aware.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/languages-container-aware.ts
@@ -11,6 +11,7 @@
 import * as theia from '@theia/plugin';
 import { LanguagesExtImpl } from '@theia/plugin-ext/lib/plugin/languages';
 import { overrideUri } from './che-content-aware-utils';
+import { PluginInfo } from '@theia/plugin-ext/lib/common/plugin-api-rpc';
 
 export class LanguagesContainerAware {
 
@@ -21,7 +22,7 @@ export class LanguagesContainerAware {
 
     overrideDefinitionProvider(languagesExt: LanguagesExtImpl): void {
         const originalRegisterDefinitionProvider = languagesExt.registerDefinitionProvider.bind(languagesExt);
-        const registerDefinitionProvider = (selector: theia.DocumentSelector, provider: theia.DefinitionProvider) =>
+        const registerDefinitionProvider = (selector: theia.DocumentSelector, provider: theia.DefinitionProvider, pluginInfo: PluginInfo) =>
             originalRegisterDefinitionProvider(selector, {
                 provideDefinition: async (
                     document: theia.TextDocument,
@@ -43,7 +44,7 @@ export class LanguagesContainerAware {
 
                     return result;
                 }
-            });
+            }, pluginInfo);
 
         languagesExt.registerDefinitionProvider = registerDefinitionProvider;
     }


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes a wrong override of a method in `LanguagesContainerAware`.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18175
<!-- #### Changelog -->
n/a
#### Release Notes
n/a


#### Docs PR

### Happy Path Channel

HAPPY_PATH_CHANNEL=next
