### PR TITLE
chore(github): Add new PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,46 @@
 <!-- Please review the following before submitting a PR:
 Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
 Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-
-COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
 -->
 
 ### What does this PR do?
 
 
+### Screenshot/screencast of this PR
+<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
+
+
 ### What issues does this PR fix or reference?
-
-<!-- #### Changelog -->
-<!-- The changelog will be pulled from the PR's title. 
-     Please provide a clear and meaningful title to the PR and don't include issue number -->
-
-
-#### Release Notes
-<!-- markdown to be included in marketing announcement - N/A for bugs -->
+<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
+     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
+-->
 
 
-#### Docs PR
-<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
-Both will be merged at the same time. -->
+### How to test this PR?
+<!-- Please explain for example :
+  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
+  - Installation method: chectl / che-operator
+  - steps to reproduce
+ -->
+
+
+### PR Checklist
+
+[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)
+
+- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
+- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
+- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
+- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
+- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
+- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
+- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
+- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
+- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
+
+### Reviewers
+
+Reviewers, please comment how you tested the PR when approving it.
 
 ### Happy Path Channel
 <!-- Select the Happy Path Channel used for tests.


### PR DESCRIPTION
### What does this PR do?
Include new PR template

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17486

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable

Change-Id: I5ec2b81a99197719822ee88e4dca6d176bf45d37
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
