### PR TITLE
feat(plugin-api): Allow to restart a workspace using @eclipse-che/plugin

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-workspace-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-workspace-main.ts
@@ -12,13 +12,23 @@ import { interfaces } from 'inversify';
 import { CheWorkspaceMain } from '../common/che-protocol';
 import { che as cheApi } from '@eclipse-che/api';
 import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
+import { ConfirmDialog } from '@theia/core/lib/browser';
+import { MessageService } from '@theia/core';
+import { RestartWorkspaceOptions } from '@eclipse-che/plugin';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
 
 export class CheWorkspaceMainImpl implements CheWorkspaceMain {
 
     private readonly workspaceService: WorkspaceService;
 
+    protected readonly messageService: MessageService;
+
+    private readonly windowService: WindowService;
+
     constructor(container: interfaces.Container) {
         this.workspaceService = container.get(WorkspaceService);
+        this.messageService = container.get(MessageService);
+        this.windowService = container.get(WindowService);
     }
 
     $getCurrentWorkspace(): Promise<cheApi.workspace.Workspace> {
@@ -39,4 +49,33 @@ export class CheWorkspaceMainImpl implements CheWorkspaceMain {
         return await this.workspaceService.updateWorkspace(workspaceId, workspace);
     }
 
+    async $restartWorkspace(machineToken: string, restartWorkspaceOptions?: RestartWorkspaceOptions): Promise<boolean> {
+        if (restartWorkspaceOptions && restartWorkspaceOptions.prompt) {
+            let msg = restartWorkspaceOptions.promptMessage;
+            if (!msg) {
+                msg = 'A plug-in has requested the restart of the workpspace. Do you want to proceed ?';
+            }
+            const confirm = new ConfirmDialog({
+                title: 'Restart Your Workspace',
+                msg,
+                ok: 'Restart'
+            });
+
+            const confirmRestart = await confirm.open();
+            if (!confirmRestart) {
+                return false;
+            }
+        }
+
+        // get workspace ID
+        const cheWorkspaceID = await this.workspaceService.getCurrentWorkspaceId();
+        this.messageService.info('Workspace is restarting...');
+        // disable any other popup that may be after that.
+        this.windowService.canUnload = () => true;
+
+        // ask Dashboard to restart the workspace giving him workspace ID & machine token
+        window.parent.postMessage(`restart-workspace:${cheWorkspaceID}:${machineToken}`, '*');
+        return true;
+
+    }
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -19,6 +19,7 @@ import { User, Preferences } from '@eclipse-che/theia-remote-api/lib/common/user
  * Workspace plugin API
  */
 export interface CheWorkspace {
+    restartWorkspace(restartWorkspaceOptions?: che.RestartWorkspaceOptions): Promise<boolean>;
 }
 
 export interface CheWorkspaceMain {
@@ -33,6 +34,7 @@ export interface CheWorkspaceMain {
     // startTemporary(config: WorkspaceConfig): Promise<any>;
     // stop(workspaceId: string): Promise<any>;
     // getSettings(): Promise<WorkspaceSettings>;
+    $restartWorkspace(machineToken: string, restartWorkspaceOptions?: che.RestartWorkspaceOptions): Promise<boolean>;
 }
 
 export interface CheDevfile {

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
@@ -90,6 +90,9 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
             },
             getSettings(): Promise<che.KeyValue> {
                 return cheWorkspaceImpl.getSettings();
+            },
+            restartWorkspace(restartWorkspaceOptions?: che.RestartWorkspaceOptions): Promise<boolean> {
+                return cheWorkspaceImpl.restartWorkspace(restartWorkspaceOptions);
             }
         };
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-workspace.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-workspace.ts
@@ -71,4 +71,9 @@ export class CheWorkspaceImpl implements CheWorkspace {
         return this.workspaceMain.$getCurrentWorkspace();
     }
 
+    async restartWorkspace(restartWorkspaceOptions?: che.RestartWorkspaceOptions): Promise<boolean> {
+        const machineToken = process.env['CHE_MACHINE_TOKEN'] || '';
+        return this.workspaceMain.$restartWorkspace(machineToken, restartWorkspaceOptions);
+    }
+
 }

--- a/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
+++ b/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
@@ -21,6 +21,11 @@ declare module '@eclipse-che/plugin' {
     export interface KeyValue {
         [key: string]: string;
     }
+    
+    export interface RestartWorkspaceOptions {
+        prompt?: boolean;
+        promptMessage? : string;
+    }
 
     export namespace workspace {
         export function getCurrentWorkspace(): Promise<cheApi.workspace.Workspace>;
@@ -34,6 +39,12 @@ declare module '@eclipse-che/plugin' {
         export function startTemporary(config: cheApi.workspace.WorkspaceConfig): Promise<any>;
         export function stop(workspaceId: string): Promise<any>;
         export function getSettings(): Promise<KeyValue>;
+        /**
+         * Restart the current workspace
+         * @param restartWorkspaceOptions options to restart
+         * @return true if restart will occur
+         */
+        export function restartWorkspace(restartWorkspaceOptions?: RestartWorkspaceOptions): Promise<boolean>;
     }
 
     export namespace devfile {


### PR DESCRIPTION
### What does this PR do?
Allow to restart a workspace from plugin API

```typescript
che.workspace.restartWorkspace(RestartWorkspaceOptions)
```

```typescript
interface RestartWorkspaceOptions: {
   prompt?: boolean;
   promptMessage? : string;
}
```

### Screenshot/screencast of this PR
![restart-workspace-from-plugin](https://user-images.githubusercontent.com/436777/97739724-86b5f400-1ae0-11eb-8297-8affb2bb7017.gif)


### What issues does this PR fix or reference?
N/A

### How to test this PR?
I'm providing a custom plug-in:
https://github.com/benoitf/restart-workspace-plugin

and a custom devfile with plug-in included + custom theia available:

http://che.openshift.io/f?url=https://gist.githubusercontent.com/benoitf/f211270d3b5dbfcfb8c18e0709b13f31/raw/bf4568f393d36c1ccee50fcfe9e2519c9c7bbdec/devfile-restart-workspace.yaml

Bring the command palette and search for `restart`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable


Change-Id: I4e2f17de64f972ece699016bee9c924e50cf3f0d
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
