### PR TITLE
Add new-line character at the end of JSON

### DIFF
--- a/generator/src/init-sources.ts
+++ b/generator/src/init-sources.ts
@@ -116,7 +116,7 @@ export class InitSources {
 
         // write it back
         const json = JSON.stringify(parsed, undefined, 2);
-        await fs.writeFile(rootCompilationUnitPath, json + '\n');
+        await fs.writeFile(rootCompilationUnitPath, `${json}\n`);
     }
 
     /**

--- a/generator/src/init-sources.ts
+++ b/generator/src/init-sources.ts
@@ -101,7 +101,6 @@ export class InitSources {
      * Update configs/root-compilation.tsconfig.json
      */
     async initRootCompilationUnits() {
-
         const rootCompilationUnitPath = path.join(this.rootFolder, 'configs/root-compilation.tsconfig.json');
         const rawData = await fs.readFile(rootCompilationUnitPath);
         const parsed = JSON.parse(rawData.toString());
@@ -117,8 +116,7 @@ export class InitSources {
 
         // write it back
         const json = JSON.stringify(parsed, undefined, 2);
-        await fs.writeFile(rootCompilationUnitPath, json);
-
+        await fs.writeFile(rootCompilationUnitPath, json + '\n');
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
After building your che-theia, you may notify that `generator/tests/init-sources/assembly-example/configs/root-compilation.tsconfig.json` file does not have new line character at the end.

![Screenshot from 2020-11-05 12-43-42](https://user-images.githubusercontent.com/1655894/98231798-919bd900-1f65-11eb-9194-57e246823a62.png)

It's because the file is being overwritten by https://github.com/eclipse/che-theia/blob/master/generator/src/init-sources.ts#L120, without adding new-line character at the end.

The solution is to add `'\n'` at the end of the file content.

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
- clone che-theia
- run `yarn` to build
- run `git status`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
