### PR TITLE
Support 'inputs' for che tasks

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-task-resolver.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-task-resolver.ts
@@ -55,14 +55,15 @@ export class CheTaskResolver implements TaskResolver {
         resultTarget.workspaceId = target && target.workspaceId ? target.workspaceId : await this.getWorkspaceId();
         resultTarget.containerName = await this.getContainerName(target);
 
+        const variableResolverOptions = { configurationSection: 'tasks' };
         if (target && target.workingDir) {
-            resultTarget.workingDir = await this.variableResolverService.resolve(target.workingDir);
+            resultTarget.workingDir = await this.variableResolverService.resolve(target.workingDir, variableResolverOptions);
         }
 
         let commandLine = undefined;
         const command = taskConfig.command;
         if (command) {
-            commandLine = await this.variableResolverService.resolve(command) || command;
+            commandLine = await this.variableResolverService.resolve(command, variableResolverOptions) || command;
         }
 
         return { ...taskConfig, command: commandLine, target: resultTarget };


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
The changes allow to resolve input variables for `che` tasks

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![inputs_che_tasks](https://user-images.githubusercontent.com/5676062/98553050-dc8c5800-22a7-11eb-9497-d747fb734d29.gif)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/16264

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
You can use the following devfile for testing:
<details>
<summary>Devfile</summary>

```
apiVersion: 1.0.0
metadata:
  name: java-maven-bfvoz
projects:
  - name: console-java-simple
    source:
      location: 'https://github.com/che-samples/console-java-simple.git'
      type: git
      branch: java1.11
components:
  - id: redhat/java/latest
    preferences:
      java.server.launchMode: Standard
    type: chePlugin
  - type: cheEditor
    reference: 'https://raw.githubusercontent.com/RomanNikitenko/che-plugin-registry/master/v3/plugins/eclipse/che-theia/next/meta.yaml'
  - mountSources: true
    memoryLimit: 512Mi
    type: dockerimage
    volumes:
      - name: m2
        containerPath: /home/user/.m2
    image: 'quay.io/eclipse/che-java11-maven@sha256:6634f5fb7a4064553220e60f500363112ca0a8c621d1b52e0cb76851a9527c72'
    alias: maven
    env:
      - value: ''
        name: MAVEN_CONFIG
      - value: '-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/user'
        name: MAVEN_OPTS
      - value: '-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom'
        name: JAVA_OPTS
      - value: '-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom'
        name: JAVA_TOOL_OPTIONS
commands:
  - name: run
    actions:
      - referenceContent: |
          {
                  "version": "2.0.0",
                  "tasks": [],
                  "inputs": [
                    {
                      "type": "promptString",
                      "id": "groupId",
                       "description": "Define value for property 'groupId'",
                       "default": "org.eclipse.che.sample"
                    },
                    {
                     "type": "promptString",
                     "id": "artifactId",
                     "description": "Define value for property 'artifactId'",
                     "default": "example"
                    },
                    {
                    "type": "promptString",
                    "id": "version",
                    "description": "Define value for property 'version'",
                    "default": "1.0-SNAPSHOT"
                    }
                 ]
          }
        type: vscode-task
  - name: maven build
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/console-java-simple'
        type: exec
        command: mvn clean install
        component: maven
  - name: maven build and run
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/console-java-simple'
        type: exec
        command: mvn clean install && java -jar ./target/*.jar
        component: maven
  - name: 'maven archetype:generate'
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}'
        type: exec
        command: 'mvn archetype:generate -DgroupId=${input:groupId} -DartifactId=${input:artifactId} -Dversion=${input:version} -DarchetypeArtifactId=maven-archetype-webapp -DinteractiveMode=false'
        component: maven


```
</details>

The devfile contains `maven archetype:generate` command with `input` variables for testing.
Run the task ^^ from `My Workspace` panel or using `Terminal` => `Run Task` menu, the system should ask user `groupId`, `artifactId` and `version` and then create a new project.
The `Screenshot/screencast of this PR` section contains a short video how it works.
 
You could provide own commands, please see more details about input variables https://code.visualstudio.com/docs/editor/variables-reference#_input-variables

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
