### PR TITLE
Authorize GitHub requests with header instead of query parameter

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-github-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-github-main.ts
@@ -26,10 +26,14 @@ export class CheGithubMainImpl implements CheGithubMain {
 
   async $uploadPublicSshKey(publicKey: string): Promise<void> {
     await this.fetchToken();
-    await this.axiosInstance.post('https://api.github.com/user/keys?access_token=' + this.token, {
-      title: 'che-theia',
-      key: publicKey,
-    });
+    await this.axiosInstance.post(
+      'https://api.github.com/user/keys',
+      {
+        title: 'che-theia',
+        key: publicKey,
+      },
+      { headers: { Authorization: `Bearer ${this.token}` } }
+    );
   }
 
   async $getToken(): Promise<string> {
@@ -47,7 +51,9 @@ export class CheGithubMainImpl implements CheGithubMain {
   }
 
   private async getUser(): Promise<GithubUser> {
-    const result = await this.axiosInstance.get<GithubUser>('https://api.github.com/user?access_token=' + this.token);
+    const result = await this.axiosInstance.get<GithubUser>('https://api.github.com/user', {
+      headers: { Authorization: `Bearer ${this.token}` },
+    });
     return result.data;
   }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Use GitHub Authorisation header in GitHub HTTP requests instead of token in query parameter. 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/16425

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Setup [GitHub Identity provider](https://www.eclipse.org/che/docs/che-7/end-user-guide/configuring-github-oauth/)
2. Start a workspace with GitHub Pull Requests plugin and a project cloned from GitHub by `https` url.
You can use this devfile to start a workspace:
```
apiVersion: 1.0.0
metadata:
  name: wksp-custom-dwdiu
projects:
  - name: che-theia
    source:
      location: 'https://github.com/eclipse/che-theia.git'
      type: git
      branch: master
components:
  - type: chePlugin
    reference: 'https://raw.githubusercontent.com/eclipse/che-plugin-registry/master/v3/plugins/ms-vscode/vscode-github-pullrequest/0.20.0/meta.yaml'
  - type: cheEditor
    reference: 'https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-924/simple/che-theia-editor.yaml'
```
3. Sign-in to the GitHub Pull Requests plugin.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
