### PR TITLE
feat(nodejs): Update to nodejs 12.8.4

### DIFF
--- a/dockerfiles/theia-dev/docker/alpine/builder-image-from.dockerfile
+++ b/dockerfiles/theia-dev/docker/alpine/builder-image-from.dockerfile
@@ -1,1 +1,1 @@
-FROM node:12.18.2-alpine3.12
+FROM node:12.18.4-alpine3.12

--- a/dockerfiles/theia-dev/docker/ubi8/builder-image-from.dockerfile
+++ b/dockerfiles/theia-dev/docker/ubi8/builder-image-from.dockerfile
@@ -1,2 +1,2 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-12
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-52
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-64

--- a/dockerfiles/theia-endpoint-runtime-binary/Dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/Dockerfile
@@ -9,6 +9,7 @@
 #   Red Hat, Inc. - initial API and implementation
 
 #{INCLUDE:docker/${BUILD_IMAGE_TARGET}/builder-from.dockerfile}
+ARG NEXE_SHA1=0f0869b292f1d7b68ba6e170d628de68a10c009f
 
 WORKDIR /home/theia
 
@@ -17,11 +18,13 @@ ENV PATH=${HOME}/.yarn/bin:${PATH}
 
 # setup extra stuff
 #{INCLUDE:docker/${BUILD_IMAGE_TARGET}/builder-setup.dockerfile}
-RUN yarn global add ${YARN_FLAGS} nexe@3.3.7
-RUN nexe -v && \
+# setup nexe
+#{INCLUDE:docker/${BUILD_IMAGE_TARGET}/builder-nexe-setup.dockerfile}
+
+RUN /tmp/nexe/index.js -v && \
     # Build remote binary with node runtime 12.x and che-theia node dependencies. nexe icludes to the binary only
     # necessary dependencies.
-    nexe node_modules/@eclipse-che/theia-remote/lib/node/plugin-remote.js ${NEXE_FLAGS} -o ${HOME}/plugin-remote-endpoint
+    eval /tmp/nexe/index.js -i node_modules/@eclipse-che/theia-remote/lib/node/plugin-remote.js ${NEXE_FLAGS} -o ${HOME}/plugin-remote-endpoint
 
 # Light image without node. We include remote binary to this image.
 #{INCLUDE:docker/${BUILD_IMAGE_TARGET}/runtime-from.dockerfile}

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/builder-from.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/builder-from.dockerfile
@@ -1,2 +1,2 @@
-FROM quay.io/eclipse/che-custom-nodejs-deasync:12.18.2 as custom-nodejs
+FROM quay.io/eclipse/che-custom-nodejs-deasync:12.18.4 as custom-nodejs
 FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia:${BUILD_TAG} as builder

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/builder-nexe-setup.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/builder-nexe-setup.dockerfile
@@ -1,0 +1,7 @@
+# install specific nexe
+WORKDIR /tmp
+RUN git clone https://github.com/nexe/nexe
+WORKDIR /tmp/nexe
+RUN git checkout ${NEXE_SHA1} && npm install && npm run build
+# Change back to root folder
+WORKDIR /home/theia

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/builder-setup.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/builder-setup.dockerfile
@@ -1,3 +1,3 @@
-ENV NEXE_FLAGS="--asset ${HOME}/pre-assembly-nodejs-static"
+ENV NEXE_FLAGS="--target 'alpine-x64-12' --temp /tmp/nexe-cache"
 
-COPY --from=custom-nodejs /pre-assembly-nodejs-static ${HOME}/pre-assembly-nodejs-static
+COPY --from=custom-nodejs /alpine-x64-12 /tmp/nexe-cache/alpine-x64-12

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/runtime-from.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/runtime-from.dockerfile
@@ -1,1 +1,1 @@
-FROM alpine:3.12.0 as runtime
+FROM alpine:3.12.1 as runtime

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/builder-from.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/builder-from.dockerfile
@@ -1,2 +1,2 @@
-FROM quay.io/eclipse/che-custom-nodejs-deasync:12.18.2 as custom-nodejs
+FROM quay.io/eclipse/che-custom-nodejs-deasync:12.18.4 as custom-nodejs
 FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia:${BUILD_TAG} as builder

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/builder-nexe-setup.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/builder-nexe-setup.dockerfile
@@ -1,0 +1,7 @@
+# install specific nexe
+WORKDIR /tmp
+RUN git clone https://github.com/nexe/nexe
+WORKDIR /tmp/nexe
+RUN git checkout ${NEXE_SHA1} && npm install && npm run build
+# Change back to root folder
+WORKDIR /home/theia

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/builder-setup.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/builder-setup.dockerfile
@@ -1,5 +1,5 @@
-ENV NEXE_FLAGS="--asset ${HOME}/pre-assembly-nodejs-static"
+ENV NEXE_FLAGS="--target 'alpine-x64-12' --temp /tmp/nexe-cache"
 
-COPY --from=custom-nodejs /pre-assembly-nodejs-static ${HOME}/pre-assembly-nodejs-static
+COPY --from=custom-nodejs /alpine-x64-12 /tmp/nexe-cache/alpine-x64-12
 
 USER root

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/runtime-from.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/runtime-from.dockerfile
@@ -1,2 +1,2 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.2-345 as runtime
+FROM registry.access.redhat.com/ubi8-minimal:8.3-201 as runtime

--- a/dockerfiles/theia/docker/alpine/build-result-from.dockerfile
+++ b/dockerfiles/theia/docker/alpine/build-result-from.dockerfile
@@ -1,1 +1,1 @@
-FROM node:12.18.2-alpine3.12 as build-result
+FROM node:12.18.4-alpine3.12 as build-result

--- a/dockerfiles/theia/docker/alpine/runtime-from.dockerfile
+++ b/dockerfiles/theia/docker/alpine/runtime-from.dockerfile
@@ -1,1 +1,1 @@
-FROM node:12.18.2-alpine3.12 as runtime
+FROM node:12.18.4-alpine3.12 as runtime

--- a/dockerfiles/theia/docker/ubi8/build-result-from.dockerfile
+++ b/dockerfiles/theia/docker/ubi8/build-result-from.dockerfile
@@ -1,3 +1,3 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-12
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-52 as build-result
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-64 as build-result
 USER root

--- a/dockerfiles/theia/docker/ubi8/runtime-from.dockerfile
+++ b/dockerfiles/theia/docker/ubi8/runtime-from.dockerfile
@@ -1,2 +1,2 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-12
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-52 as runtime
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-64 as runtime


### PR DESCRIPTION
### What does this PR do?
Latest version that we can build/use with nexe
It also includes enableNodeCli compilation option in prebuilt binary allowing to pass fork options (used in typescript VS Code extension)

updates ubi8 images as well to 12.18.4
```
$ docker run --rm -it --entrypoint=sh registry.access.redhat.com/ubi8/nodejs-12:1-64
$ node --version
v12.18.4
```
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16186


### How to test this PR?
Use remote sidecar containers with plug-ins running in sidecars

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next
