### PR TITLE
Adapt WebView to Che in single-host mode

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-webview-environment.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-webview-environment.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-import { SERVER_TYPE_ATTR, SERVER_WEBVIEWS_ATTR_VALUE, getUrlDomain } from '../common/che-server-common';
+import { SERVER_TYPE_ATTR, SERVER_WEBVIEWS_ATTR_VALUE } from '../common/che-server-common';
 import { inject, injectable, postConstruct } from 'inversify';
 
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
@@ -28,19 +28,19 @@ export class CheWebviewEnvironment extends WebviewEnvironment {
   protected async init(): Promise<void> {
     try {
       const webviewExternalEndpointPattern = await this.environments.getValue(WebviewExternalEndpoint.pattern);
-      const webviewServer = await this.workspaceService.findUniqueEndpointByAttribute(
+      const webviewCheEndpoint = await this.workspaceService.findUniqueEndpointByAttribute(
         SERVER_TYPE_ATTR,
         SERVER_WEBVIEWS_ATTR_VALUE
       );
-      let webviewDomain: string | undefined;
-      if (webviewServer && webviewServer.url) {
-        webviewDomain = getUrlDomain(webviewServer.url);
+      let webviewCheEndpointHostname: string | undefined;
+      if (webviewCheEndpoint && webviewCheEndpoint.url) {
+        webviewCheEndpointHostname = new URL(webviewCheEndpoint.url).hostname;
       }
-      const hostName =
+      const webviewHostname =
         (webviewExternalEndpointPattern && webviewExternalEndpointPattern.value) ||
-        webviewDomain ||
-        WebviewExternalEndpoint.pattern;
-      this.externalEndpointHost.resolve(hostName.replace('{{hostname}}', window.location.host || 'localhost'));
+        webviewCheEndpointHostname ||
+        WebviewExternalEndpoint.defaultPattern;
+      this.externalEndpointHost.resolve(webviewHostname.replace('{{hostname}}', window.location.host || 'localhost'));
     } catch (e) {
       this.externalEndpointHost.reject(e);
     }

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-server-common.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-server-common.ts
@@ -8,17 +8,6 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-export function getUrlDomain(routeUrl: string): string {
-  // Remove trailing slash if any
-  if (routeUrl.endsWith('/')) {
-    routeUrl = routeUrl.substring(0, routeUrl.length - 1);
-  }
-  // Remove protocol
-  const webviewDomain = routeUrl.replace(/^https?:\/\//, '');
-
-  return webviewDomain;
-}
-
 export const SERVER_TYPE_ATTR = 'type';
 export const SERVER_IDE_ATTR_VALUE = 'ide';
 export const SERVER_WEBVIEWS_ATTR_VALUE = 'webview';

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/plugin-service.ts
@@ -11,7 +11,7 @@
 import * as express from 'express';
 import * as path from 'path';
 
-import { SERVER_TYPE_ATTR, SERVER_WEBVIEWS_ATTR_VALUE, getUrlDomain } from '../common/che-server-common';
+import { SERVER_TYPE_ATTR, SERVER_WEBVIEWS_ATTR_VALUE } from '../common/che-server-common';
 import { inject, injectable } from 'inversify';
 
 import { Deferred } from '@theia/core/lib/common/promise-util';
@@ -48,18 +48,18 @@ export class PluginApiContributionIntercepted extends PluginApiContribution {
 
     this.workspaceService
       .findUniqueEndpointByAttribute(SERVER_TYPE_ATTR, SERVER_WEBVIEWS_ATTR_VALUE)
-      .then(server => {
-        let domain;
-        if (server.url) {
-          domain = getUrlDomain(server.url);
+      .then(webviewCheEndpoint => {
+        let webviewCheEndpointHostname;
+        if (webviewCheEndpoint.url) {
+          webviewCheEndpointHostname = new URL(webviewCheEndpoint.url).hostname;
         }
-        const hostName = this.handleAliases(
-          process.env[WebviewExternalEndpoint.pattern] || domain || WebviewExternalEndpoint.pattern
+        const webviewHostname = this.handleAliases(
+          process.env[WebviewExternalEndpoint.pattern] || webviewCheEndpointHostname || WebviewExternalEndpoint.defaultPattern
         );
         webviewApp.use('/webview', serveStatic(webviewStaticResources));
 
-        this.logger.info(`Configuring to accept webviews on '${hostName}' hostname.`);
-        app.use(vhost(new RegExp(hostName, 'i'), webviewApp));
+        this.logger.info(`Configuring to accept webviews on '${webviewHostname}' hostname.`);
+        app.use(vhost(new RegExp(webviewHostname, 'i'), webviewApp));
 
         this.waitWebviewEndpoint.resolve();
       })

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/plugin-service.ts
@@ -54,7 +54,9 @@ export class PluginApiContributionIntercepted extends PluginApiContribution {
           webviewCheEndpointHostname = new URL(webviewCheEndpoint.url).hostname;
         }
         const webviewHostname = this.handleAliases(
-          process.env[WebviewExternalEndpoint.pattern] || webviewCheEndpointHostname || WebviewExternalEndpoint.defaultPattern
+          process.env[WebviewExternalEndpoint.pattern] ||
+            webviewCheEndpointHostname ||
+            WebviewExternalEndpoint.defaultPattern
         );
         webviewApp.use('/webview', serveStatic(webviewStaticResources));
 


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adapts WebView to Che in single-host mode. See more details in https://github.com/eclipse/che/issues/17694

It binds Express middleware handler for serving `/webview` endpoint
to the exposed by Che webview-endpoint's hostname
instead of webview-endpoint's url.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
WebView is loaded correctly in single-host mode.

![image](https://user-images.githubusercontent.com/1636395/100010707-56a8fa80-2dd9-11eb-8df2-8e29b7617a86.png)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Closes upstream https://github.com/eclipse/che/issues/17694 + downstream https://issues.redhat.com/browse/CRW-1336

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy Che in single host mode
`chectl server:deploy --platform=minikube --installer=operator --che-operator-cr-patch-yaml=patch.yaml`
where `patch.yaml` content is
```yaml
apiVersion: org.eclipse.che/v1
kind: CheCluster
metadata:
  name: eclipse-che
spec:
  server:
    serverExposureStrategy: 'single-host'
  k8s:
    singleHostExposureType: 'native'
```

2. Start a Workspace from the Devfile
```yaml
apiVersion: 1.0.0
metadata:
  name: pr-che_theia-932-94q64
attributes:
  persistVolumes: 'false'
components:
  - type: cheEditor
    reference: 'https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-932/simple/che-theia-editor.yaml'
```

3. Make sure that the Welcome page is rendered and works correctly, e.g. the links are working.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
