### PR TITLE
Directly reference che api setup module

### DIFF
--- a/extensions/eclipse-che-theia-plugin-remote/src/node/hosted-plugin-process-log.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/hosted-plugin-process-log.ts
@@ -33,14 +33,16 @@ export class LogHostedPluginProcess extends HostedPluginProcess {
 
     if (childProcess) {
       if (childProcess.stdout) {
-        childProcess.stdout.on('data', data =>
-          client.log({ data: `Extension-Host:${data.toString().trim()}`, type: LogType.Info })
-        );
+        childProcess.stdout.on('data', data => {
+          console.info(data);
+          client.log({ data: `Extension-Host:${data.toString().trim()}`, type: LogType.Info });
+        });
       }
       if (childProcess.stderr) {
-        childProcess.stderr.on('data', data =>
-          client.log({ data: `Extension-Host:${data.toString().trim()}`, type: LogType.Error })
-        );
+        childProcess.stderr.on('data', data => {
+          console.error(data);
+          client.log({ data: `Extension-Host:${data.toString().trim()}`, type: LogType.Error });
+        });
       }
     }
   }

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-backend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-backend-module.ts
@@ -40,12 +40,6 @@ const localModule = ConnectionContainerModule.create(({ bind, unbind, isBound, r
 });
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
-  try {
-    // Force to include theia-plugin-ext inside node_modules
-    require('@eclipse-che/theia-plugin-ext/lib/node/che-plugin-api-provider.js');
-  } catch (err) {
-    console.log('Unable to set up che-theia plugin api: ', err);
-  }
   bind(HostedPluginMapping).toSelf().inSingletonScope();
   bind(MetadataProcessor).to(RemoteMetadataProcessor).inSingletonScope();
   bind(PluginReaderExtension).toSelf().inSingletonScope();

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote.ts
@@ -9,6 +9,9 @@
  ***********************************************************************/
 
 import { PluginRemoteInit } from './plugin-remote-init';
+import { provideApi } from '@eclipse-che/theia-plugin-ext/lib/plugin/node/che-api-node-provider';
+
+console.log('imported ' + provideApi.name);
 
 /**
  * Entry point of a Remote Endpoint. It is executed as a new separate nodejs process.


### PR DESCRIPTION
### What does this PR do?
The PR does two things:
1. Instead of statically requiring `che-plugin-api-provider.js`, which is the code that contributes the back-end ext-api provider, it requires the file that needs to be loaded in the plugin host process: `che-api-node-provider`. Also, since this is only to make nexe include the file in the executable, it does not really matter whether it's required in a container module or not. So just moved it to the main process file
2. Stdout/stderr from the plugin host process is now mirrored to the console of the process that starts it (either the theia plugin host or the remote plugin host process running in the sidecars). This allows us to detect errors more simply and also in cases where we can't properly start the "output" view in Theia.

### What issues does this PR fix or reference?
Plugin host throws exception at startup #18455

### How to test this PR?
1. Create a devfile including at least one plugin that runs inside a sidecar (I used the typescript plugin)
2. Use the Che-Theia version that is built for the happy path test on this PR: https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-938/che_theia_meta.yaml in the devfile
3. Start the devfile and make sure the plugin is activated
4. Check that the out "Extension host" channel for the plugin does not show the "require" exception mentioned in the issue
5. Check that there are no "Unknown actor CheTelemetry" messages in the browser log.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
