### PR TITLE
Make Che-Theia spelling consistent with the docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Table of contents
  - [Contribute to Theia or Che-Theia extensions or built-in Che-Theia plugins](#contribute-to-theia-or-che-theia-extensions-or-built-in-che-theia-plugins)
    - [Just want to build the plugin and run with the existing Theia image](#just-want-to-build-the-plugin-and-run-with-the-existing-theia-image)
  - [Che-Theia development on che.openshift.io](#che-theia-development-on-cheopenshiftio)
- - [How to develop Che Theia remote plugin mechanism](#how-to-develop-che-theia-remote-plugin-mechanism)
+ - [How to develop Che-Theia remote plugin mechanism](#how-to-develop-che-theia-remote-plugin-mechanism)
 
 ## Introduction
 
@@ -221,7 +221,7 @@ $ yarn theia start /projects/theia-projects-dir --hostname=0.0.0.0 --port=3010
 
 In a real Che workspace, many plugins are run in their own "sidecar" container. The idea is that the container furnishes any "native" dependencies the plugin needs. For example the container that runs the theia IDE back end does not contain a Java SDK, so in order to run a plugin that needs a Java installation, we'll run the plugin inside a container that has Java installed.
 
-As when working on developing Che-Theia itself, the approach is to run a copy of the Theia back end on a different port than that we use for the self hosting workspace. 
+As when working on developing Che-Theia itself, the approach is to run a copy of the Theia back end on a different port than that we use for the self hosting workspace.
 
 ## Setting up the devfile
 
@@ -267,7 +267,7 @@ This way, the IDE and the remote plugin host process can find each other.
 
 The container in question must be able to work as a plugin sidecar for any plugin you want to run in it. If you are trying to debug a plugin that already has a sidecar container, it would make sense to base `remote-1` container on the sidecar that runs the original plugin. In that case, you would have to add a copy of node to sidecar container, since they generally don't contain one and we need to run the runtime host process, which is a node application. In this case, however, I've started with a `theia-dev` image and just point it to a JDK I've copied to `/projects/java-11-openjdk` by setting `JAVA_HOME`.
 
-If we want to debug later on, we'll have to add the `node-debug2` Che plugin to our workspace: 
+If we want to debug later on, we'll have to add the `node-debug2` Che plugin to our workspace:
 
 ```yaml
   - type: chePlugin
@@ -276,7 +276,7 @@ If we want to debug later on, we'll have to add the `node-debug2` Che plugin to 
     alias: node-debug
 ```
 
-Note that some earlier versions of the plugin did not work in a self-hosting setup, so make sure you are using a recent one. 
+Note that some earlier versions of the plugin did not work in a self-hosting setup, so make sure you are using a recent one.
 
 ## Setting up plugins to run
 
@@ -291,16 +291,16 @@ $ npm run compile
 
 ## Running the IDE
 
-Now we can run the IDE: 
+Now we can run the IDE:
 
-1. Open a terminal for the `remote-1`container. 
+1. Open a terminal for the `remote-1`container.
 
 2. In that container, type
    `cd /projects/theia/che/che-theia/extensions/eclipse-che-theia-plugin-remote/lib/node`
 
 3. And then run the remote backend like so:
    `node plugin-remote.js`
-   The terminal should spew out some text saying it's found the plugin we're trying to run 
+   The terminal should spew out some text saying it's found the plugin we're trying to run
 
 4. Open a terminal for the `theia-dev`container
 
@@ -333,4 +333,4 @@ The node process will wait upon startup until we connect the debugger using an `
 }
 ```
 
-Once the debugger has attached, the process will be suspended and you'll have to `continue` in order to complete the startup. You should now be able to put breakpoints in any source in the plugin host or target plugin source. 
+Once the debugger has attached, the process will be suspended and you'll have to `continue` in order to complete the startup. You should now be able to put breakpoints in any source in the plugin host or target plugin source.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <img src="https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia-logo.svg?sanitize=true" alt="Theia Logo" width="150" height="60"/>
 
-# Che Theia
+# Che-Theia
 
 
 </div>

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# Eclipse Che Theia release process
+# Eclipse Che-Theia release process
 
 Launch the [release script](make-release.sh) and wait until [CI Job](https://ci.centos.org/view/Devtools/job/devtools-che-theia-che-release) is completed:
 

--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -45,7 +45,7 @@ EXPOSE 3000 3030
 RUN npm config set prefix "${HOME}/.npm-global" && \
     echo "--global-folder \"${HOME}/.yarn-global\"" > ${HOME}/.yarnrc && \
     yarn config set network-timeout 600000 -g && \
-    # add eclipse che theia generator
+    # add eclipse che-theia generator
     yarn ${YARN_FLAGS} global add yo generator-code vsce @theia/generator-plugin@0.0.1-1562578105 file:${HOME}/eclipse-che-theia-generator && \
     rm -rf ${HOME}/eclipse-che-theia-generator && \
     # Generate .passwd.template \

--- a/dockerfiles/theia-dev/build.sh
+++ b/dockerfiles/theia-dev/build.sh
@@ -15,7 +15,7 @@ DIR=$(cd "$(dirname "$0")"; pwd)
 
 CHE_THEIA_GENERATOR_PACKAGE_NAME=eclipse-che-theia-generator.tgz
 CHE_THEIA_GENERATOR_PACKAGE="${base_dir}/../../generator/${CHE_THEIA_GENERATOR_PACKAGE_NAME}"
-# Rebuild Che Theia generator if:
+# Rebuild Che-Theia generator if:
 #  - it hasn't been built yet
 #  - there is any changes in the generator directory
 #  - there is a commit newer than the generator build time
@@ -26,10 +26,10 @@ if [ ! -f "$CHE_THEIA_GENERATOR_PACKAGE" ] || \
 then
     # Delete previous archive if any
     rm -f $CHE_THEIA_GENERATOR_PACKAGE
-    echo "Building Che Theia generator"
+    echo "Building Che-Theia generator"
     cd "${base_dir}"/../../generator/ && yarn && yarn pack --filename $CHE_THEIA_GENERATOR_PACKAGE_NAME
 fi
-echo "Copying Che Theia generator"
+echo "Copying Che-Theia generator"
 cp "${CHE_THEIA_GENERATOR_PACKAGE}" "${base_dir}/asset-${CHE_THEIA_GENERATOR_PACKAGE_NAME}"
 
 rm -rf ${base_dir}/asset-unpacked-generator && mkdir ${base_dir}/asset-unpacked-generator

--- a/dockerfiles/theia/README.md
+++ b/dockerfiles/theia/README.md
@@ -2,7 +2,7 @@
 
 ## Build image manually using build scripts
 
-To build all the images you can easily run [build.sh](../../build.sh) script located in the repository root. It will build container with Theia editor, dev container with tools to develop on TypeScript and containers containing remote plugins. 
+To build all the images you can easily run [build.sh](../../build.sh) script located in the repository root. It will build container with Theia editor, dev container with tools to develop on TypeScript and containers containing remote plugins.
 
 ```bash
 ./build.sh
@@ -13,16 +13,16 @@ CI for checking any pull request in this repository runs this script with `--pr`
 `build.sh --pr`.
 ```
 
-**Note**: `--pr` will build only [limited set](../../build.include) of docker images.	
+**Note**: `--pr` will build only [limited set](../../build.include) of docker images.
 
-## How to build own Che Theia image with Docker
+## How to build own Che-Theia image with Docker
 
 [Che-Theia](Dockerfile) image is based on [Theia-Dev](../theia-dev/Dockerfile) image, which contains a set of tools for TypeScript development.
 Also theia-dev image includes `@theia/generator-plugin` which can be easily used in both Theia-Dev and Che-Theia containers.
 
 Build script always use current Che-Theia sources. To test your changes you don't need to push your changes somewhere. Just go to `dockerfiles/theia` directory and run:
 
-```bash	
+```bash
 ./build.sh --build-args:GITHUB_TOKEN=${GITHUB_TOKEN},THEIA_VERSION=master --tag:next --branch:master --git-ref:refs\\/heads\\/master
 ```
 
@@ -107,7 +107,7 @@ This parameter is optional. Default value is `'refs\\/heads\\/master'`.
 
 Add this parameter to the build command to have a quick build and to skip running tests in dedicated container.
 
-By default tests are turned on. 
+By default tests are turned on.
 
 ## Build only for specific type of Docker images (Alpine, UBI8, etc.)
 
@@ -141,7 +141,7 @@ such as http://unpkg.com/ or https://www.jsdelivr.com/.
 
 NPM version number and file paths are added automatically by the Che-Theia CDN support.
 
-For example, using JSDelivr, the following build argument should be added: `MONACO_CDN_PREFIX=https://cdn.jsdelivr.net/npm/`. 
+For example, using JSDelivr, the following build argument should be added: `MONACO_CDN_PREFIX=https://cdn.jsdelivr.net/npm/`.
 
 Alternatively, if `CDN_PREFIX` and `MONACO_CDN_PREFIX` are provided as **environment variables**, the corresponding build arguments
 will be added automatically by the `build.sh` script. This will make CDN support configuration easier in CI builds.

--- a/dockerfiles/theia/src/entrypoint.sh
+++ b/dockerfiles/theia/src/entrypoint.sh
@@ -80,7 +80,7 @@ if [ "${NOCDN}" == "true" ]; then
 fi
 shopt -u nocasematch
 
-# run Che Theia
+# run Che-Theia
 PROJ_ROOT=${CHE_PROJECTS_ROOT:-/projects}
 node src-gen/backend/main.js ${PROJ_ROOT} --hostname=${THEIA_HOST} --port=${THEIA_PORT} &
 

--- a/extensions/eclipse-che-theia-about/scripts/generate-about-details.js
+++ b/extensions/eclipse-che-theia-about/scripts/generate-about-details.js
@@ -38,7 +38,7 @@ async function getTheiaGitSha1() {
         return stdout.trim();
     }
 
-    // suppose Che Theia is located inside theia folder in 'che/che-theia'
+    // suppose Che-Theia is located inside theia folder in 'che/che-theia'
     let theiaDir = path.resolve(__dirname, '../../../../..');
     if (await checkIfTheiaDir(theiaDir)) {
         return await getLastCommitHash(theiaDir);
@@ -55,7 +55,7 @@ async function getTheiaGitSha1() {
 }
 
 /**
- * Grab sha1 of Che Theia
+ * Grab sha1 of Che-Theia
  */
 async function getCheTheiaGitSha1() {
 

--- a/extensions/eclipse-che-theia-dashboard/src/browser/theia-dashboard-client.ts
+++ b/extensions/eclipse-che-theia-dashboard/src/browser/theia-dashboard-client.ts
@@ -19,7 +19,7 @@ import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/works
 const THEIA_ICON_ID = 'theia:icon';
 
 /**
- * Provides basic Eclipse Che Theia Dashboard extension that adds Show/Hide Dashboard button to the top menu.
+ * Provides basic Eclipse Che-Theia Dashboard extension that adds Show/Hide Dashboard button to the top menu.
  */
 @injectable()
 export class TheiaDashboardClient implements FrontendApplicationContribution {

--- a/extensions/eclipse-che-theia-plugin-remote/devfile.yaml
+++ b/extensions/eclipse-che-theia-plugin-remote/devfile.yaml
@@ -32,13 +32,13 @@ components:
         value: 'local-dir:///projects/remote-plugins/'
     memoryLimit: 1Gi
 commands:
-  - name: Init Che Theia
+  - name: Init Che-Theia
     actions:
       - type: exec
         component: theia-dev
         command: 'che-theia init'
         workdir: /projects/theia
-  - name: Clean Che Theia
+  - name: Clean Che-Theia
     actions:
       - type: exec
         component: theia-dev
@@ -50,7 +50,7 @@ commands:
         component: theia-dev
         command: 'yes | yo @theia/plugin && mkdir -p /projects/remote-plugins && cp y/y.theia /projects/remote-plugins/hello-world-plugin.theia && rm -rf /tmp/y'
         workdir: /tmp
-  - name: Build Che Theia
+  - name: Build Che-Theia
     actions:
       - type: exec
         component: theia-dev

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-backend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-backend-module.ts
@@ -44,7 +44,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     // Force to include theia-plugin-ext inside node_modules
     require('@eclipse-che/theia-plugin-ext/lib/node/che-plugin-api-provider.js');
   } catch (err) {
-    console.log('Unable to set up che theia plugin api: ', err);
+    console.log('Unable to set up che-theia plugin api: ', err);
   }
   bind(HostedPluginMapping).toSelf().inSingletonScope();
   bind(MetadataProcessor).to(RemoteMetadataProcessor).inSingletonScope();

--- a/generator/README.md
+++ b/generator/README.md
@@ -64,15 +64,15 @@ Dev mode is the way to use all new extensions from `master` branch:
 And `che-theia` will use `master` branch for all extensions and plugins, regardless of provided configuration
 
 ### Development life-cycle
-Che Theia should be built from root directory only (Root directory of Che Theia is the directory into which Theia was clonned and `che-theia init` was executed there). In case of building from subdirectories it will mess up dependencies, don't do it.
+Che-Theia should be built from root directory only (Root directory of Che-Theia is the directory into which Theia was clonned and `che-theia init` was executed there). In case of building from subdirectories it will mess up dependencies, don't do it.
 
-To build whole Che Theia just execute `yarn` command in the root directory.
+To build whole Che-Theia just execute `yarn` command in the root directory.
 If only one module should be built, use `npx run build <module-name>`. For example `npx run build @theia/plugin-ext`.
 
-Also one may set compilation on changes for some modules. To do so, run `npx run watch <module-name>` from the root directory. Then execute `yarn watch` from `examples/assembly` folder and run Che Theia with `yarn run start` command from the same directory. Make sure, you start watcher for all modules under development.
+Also one may set compilation on changes for some modules. To do so, run `npx run watch <module-name>` from the root directory. Then execute `yarn watch` from `examples/assembly` folder and run Che-Theia with `yarn run start` command from the same directory. Make sure, you start watcher for all modules under development.
 
 Note, this is not the case for embedded plugins.
-To develop them one should place copy of their sources somewhere else (outside of the Che Theia folder) and then include new binaries into the assembly.
+To develop them one should place copy of their sources somewhere else (outside of the Che-Theia folder) and then include new binaries into the assembly.
 
 ### Compiling the plugins
 Plugins have to be compiled separately with the script `plugins/foreach_yarn`. This script simply run the `yarn` command on each subfolders of `plugins` and copy the `.theia` package in `production/plugins` folder to be reused by the che-theia product.

--- a/make-release.sh
+++ b/make-release.sh
@@ -8,12 +8,12 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-# Release process automation script. 
+# Release process automation script.
 # Used to create branch/tag, update the necessary files
 # and trigger release by force pushing changes to the release branch.
 
 # set to 1 to actually trigger changes in the release branch
-TRIGGER_RELEASE=0 
+TRIGGER_RELEASE=0
 NOCOMMIT=0
 
 while [[ "$#" -gt 0 ]]; do
@@ -52,7 +52,7 @@ BRANCH=${VERSION%.*}.x
 # if doing a .0 release, use master; if doing a .z release, use $BRANCH
 if [[ ${VERSION} == *".0" ]]; then
   BASEBRANCH="master"
-else 
+else
   BASEBRANCH="${BRANCH}"
 fi
 
@@ -99,7 +99,7 @@ apply_files_edits () {
     exit 1
   fi
 
-  # update config for Che Theia generator
+  # update config for Che-Theia generator
   sed_in_place -e "/checkoutTo:/s/master/${BRANCH}/" che-theia-init-sources.yml
   sed_in_place -e "/checkoutTo:/s/master/${BRANCH}/" che-theia-init-sources.yml
 
@@ -147,7 +147,7 @@ if [[ $TRIGGER_RELEASE -eq 1 ]]; then
   # push new branch to release branch to trigger CI build
   git fetch origin "${BRANCH}:${BRANCH}"
   git checkout "${BRANCH}"
-  git branch release -f 
+  git branch release -f
   git push origin release -f
 
   # tag the release

--- a/plugins/workspace-plugin/README.md
+++ b/plugins/workspace-plugin/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/eclipse/che-theia-factory-extension.svg?branch=master)](https://travis-ci.org/eclipse/che-theia-factory-extension)
 
-# Che Theia factory
+# Che-Theia factory
 This Theia plug-in is performing additional actions while creating/starting a Che workspace through a factory URL.
 Provides basic factory client side clone feature
 
@@ -11,11 +11,11 @@ Provides basic factory client side clone feature
 From the factory definition:
 - cloning projects defined in the factory definition
 - checking out the right branch if needed
-- executing post loading actions such as running CHE commands/tasks or openning a specific file. 
+- executing post loading actions such as running CHE commands/tasks or openning a specific file.
 
 ## Testing this extension
 ### Setting up [deprecated: https://github.com/eclipse/che/issues/11632]
-1. Clone [eclipse/che](git@github.com:eclipse/che.git). 
+1. Clone [eclipse/che](git@github.com:eclipse/che.git).
     ```
     $ git clone https://github.com/eclipse/che.git
     $ cd che/dockerfiles/theia


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Makes Che-Theia spelling consistent with the rest of the docs. By request of the docs team.
Thanks @MichalMaler for noticing that.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
