### PR TITLE
Adapt Telemetry Plug-in API to a single-host mode

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-telemetry-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-telemetry-main.ts
@@ -11,21 +11,26 @@
 import * as axios from 'axios';
 
 import { CheTelemetry, CheTelemetryMain, PLUGIN_RPC_CONTEXT } from '../common/che-protocol';
+import { SERVER_IDE_ATTR_VALUE, SERVER_TYPE_ATTR } from '../common/che-server-common';
 
 import { ClientAddressInfo } from '@eclipse-che/plugin';
 import { CommandRegistry } from '@theia/core';
 import { RPCProtocol } from '@theia/plugin-ext/lib/common/rpc-protocol';
 import { TelemetryService } from '@eclipse-che/theia-remote-api/lib/common/telemetry-service';
+import URI from '@theia/core/lib/common/uri';
+import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
 import { interfaces } from 'inversify';
 
 export class CheTelemetryMainImpl implements CheTelemetryMain {
   private readonly telemetryService: TelemetryService;
+  private readonly workspaceService: WorkspaceService;
   private ip: string;
 
   constructor(container: interfaces.Container, rpc: RPCProtocol) {
     const proxy: CheTelemetry = rpc.getProxy(PLUGIN_RPC_CONTEXT.CHE_TELEMETRY);
     this.telemetryService = container.get(TelemetryService);
     const commandRegistry = container.get(CommandRegistry);
+    this.workspaceService = container.get(WorkspaceService);
     commandRegistry.onWillExecuteCommand(event => {
       proxy.$onWillCommandExecute(event.commandId);
     });
@@ -59,13 +64,22 @@ export class CheTelemetryMainImpl implements CheTelemetryMain {
   }
 
   async getClientAddressInfo(): Promise<ClientAddressInfo> {
-    const response = await axios.default.get('/che/client-ip');
-    if (response.status === 200) {
-      return response.data;
-    }
-    console.log(
-      'Can`t obtain client adress information. Status: ' + response.status + 'Error message: ' + response.data
+    const ideEndpoint = await this.workspaceService.findUniqueEndpointByAttribute(
+      SERVER_TYPE_ATTR,
+      SERVER_IDE_ATTR_VALUE
     );
+    if (ideEndpoint && ideEndpoint.url) {
+      const ipServiceURL = new URI(ideEndpoint.url).resolve('che/client-ip').toString();
+      const response = await axios.default.get(ipServiceURL);
+      if (response.status === 200) {
+        return response.data;
+      }
+      console.log(
+        `Can\`t obtain client address information. Status: ${response.status} Error message: ${response.data}`
+      );
+    } else {
+      console.log('Can`t obtain client address information.');
+    }
     return {
       ip: undefined,
       ipFamily: undefined,

--- a/plugins/telemetry-plugin/src/telemetry-plugin.ts
+++ b/plugins/telemetry-plugin/src/telemetry-plugin.ts
@@ -23,7 +23,9 @@ export function start(context: theia.PluginContext): void {
   });
 
   theia.workspace.onDidChangeTextDocument((e: theia.TextDocumentChangeEvent) => {
-    che.telemetry.event('EDITOR_USED', context.extensionPath, [['programming language', e.document.languageId]]);
+    if (e.document.uri.scheme !== 'output') {
+      che.telemetry.event('EDITOR_USED', context.extensionPath, [['programming language', e.document.languageId]]);
+    }
   });
 }
 


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
1. Fixes `/client-ip` service URL for a single-host mode.
2. When sending the telemetry events about an editor usage, filters out the messages that come from the output channels, like `hosted-instance-log`. As such messages are recognized as `vscode.TextDocumentChangeEvent`s.
See the details in https://github.com/eclipse/che/issues/18598

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
closes https://github.com/eclipse/che/issues/18503
closes https://github.com/eclipse/che/issues/18489

### How to test this PR?
#### To test that the PR fixes https://github.com/eclipse/che/issues/18503:
1. Deploy Che in single host mode
`chectl server:deploy --platform=minikube --installer=operator --che-operator-cr-patch-yaml=patch.yaml`
where `patch.yaml` content is
```yaml
apiVersion: org.eclipse.che/v1
kind: CheCluster
metadata:
  name: eclipse-che
spec:
  server:
    serverExposureStrategy: 'single-host'
  k8s:
    singleHostExposureType: 'native'
```

2. Start a Workspace with the custom Che-Theia editor (with this patch included)
```yaml
components:
- type: cheEditor
  reference: https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-945/simple/che-theia-editor.yaml
```
3. Open Chrome/FireFox DevTools and make any edit in a file.
4. Make sure that there's a request to `/client-ip` service and it returns the data.
![image](https://user-images.githubusercontent.com/1636395/101828938-e8836800-3b3a-11eb-9fe8-9133b8cc447d.png)

5. Make sure the correct telemetry events are sent to Che-Theia backend, e.g.:
![image](https://user-images.githubusercontent.com/1636395/101828831-bd991400-3b3a-11eb-8617-eec6259a2de5.png)

#### To test that the PR fixes https://github.com/eclipse/che/issues/18489:
1. Start a Workspace.
2. Make any edit in a file.
3. Make sure that there's only one request to `/client-ip` service.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
