### PR TITLE
Implement simple side car file system which fetches file content

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/package.json
+++ b/extensions/eclipse-che-theia-plugin-ext/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@eclipse-che/plugin": "0.0.1",
     "@theia/core": "next",
+    "@theia/filesystem": "next",
     "@theia/task": "next",
     "@theia/mini-browser": "next",
     "@theia/plugin-ext": "next",

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-api-provider.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-api-provider.ts
@@ -17,6 +17,7 @@ import { CheOauthMainImpl } from './che-oauth-main';
 import { CheOpenshiftMainImpl } from './che-openshift-main';
 import { CheProductMainImpl } from './che-product-main';
 import { CheSideCarContentReaderMainImpl } from './che-sidecar-content-reader-main';
+import { CheSideCarFileSystemMainImpl } from './che-sidecar-file-system-main';
 import { CheSshMainImpl } from './che-ssh-main';
 import { CheTaskMainImpl } from './che-task-main';
 import { CheTelemetryMainImpl } from './che-telemetry-main';
@@ -43,5 +44,6 @@ export class CheApiProvider implements MainPluginApiProvider {
     rpc.set(PLUGIN_RPC_CONTEXT.CHE_PRODUCT_MAIN, new CheProductMainImpl(container, rpc));
     rpc.set(PLUGIN_RPC_CONTEXT.CHE_SIDERCAR_CONTENT_READER_MAIN, new CheSideCarContentReaderMainImpl(container, rpc));
     rpc.set(PLUGIN_RPC_CONTEXT.CHE_LANGUAGES_TEST_API_MAIN, new CheLanguagesTestAPIImpl(container));
+    rpc.set(PLUGIN_RPC_CONTEXT.CHE_SIDECAR_FILE_SYSTEM_MAIN, new CheSideCarFileSystemMainImpl(container, rpc));
   }
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-sidecar-file-system-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-sidecar-file-system-main.ts
@@ -1,0 +1,118 @@
+/**********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { CheSideCarFileSystem, CheSideCarFileSystemMain, PLUGIN_RPC_CONTEXT } from '../common/che-protocol';
+import { Disposable, Emitter, Event } from '@theia/core/lib/common';
+import {
+  FileChange,
+  FileDeleteOptions,
+  FileOverwriteOptions,
+  FileSystemProviderCapabilities,
+  FileSystemProviderWithFileReadWriteCapability,
+  FileType,
+  FileWriteOptions,
+  Stat,
+  WatchOptions,
+} from '@theia/filesystem/lib/common/files';
+
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { RPCProtocol } from '@theia/plugin-ext/lib/common/rpc-protocol';
+import URI from '@theia/core/lib/common/uri';
+import { interfaces } from 'inversify';
+
+export abstract class AbstractSideCarFileSystemProvider implements FileSystemProviderWithFileReadWriteCapability {
+  private readonly _onDidChange = new Emitter<readonly FileChange[]>();
+
+  readonly onDidChangeFile: Event<readonly FileChange[]> = this._onDidChange.event;
+  readonly onFileWatchError: Event<void> = new Emitter<void>().event;
+
+  readonly capabilities: FileSystemProviderCapabilities;
+  readonly onDidChangeCapabilities: Event<void> = Event.None;
+
+  protected constructor(capabilities: FileSystemProviderCapabilities) {
+    this.capabilities = capabilities;
+  }
+
+  delete(resource: URI, opts: FileDeleteOptions): Promise<void> {
+    throw new Error('Not implemented.');
+  }
+
+  mkdir(resource: URI): Promise<void> {
+    throw new Error('Not implemented.');
+  }
+
+  readFile(resource: URI): Promise<Uint8Array> {
+    throw new Error('Not implemented.');
+  }
+
+  readdir(resource: URI): Promise<[string, FileType][]> {
+    throw new Error('Not implemented.');
+  }
+
+  rename(from: URI, to: URI, opts: FileOverwriteOptions): Promise<void> {
+    throw new Error('Not implemented.');
+  }
+
+  stat(resource: URI): Promise<Stat> {
+    throw new Error('Not implemented.');
+  }
+
+  watch(resource: URI, opts: WatchOptions): Disposable {
+    throw new Error('Not implemented.');
+  }
+
+  writeFile(resource: URI, content: Uint8Array, opts: FileWriteOptions): Promise<void> {
+    throw new Error('Not implemented.');
+  }
+}
+
+export class CheSideCarFileSystemMainImpl implements CheSideCarFileSystemMain {
+  private readonly registrations = new Map<string, Disposable>();
+  private readonly delegate: CheSideCarFileSystem;
+  private readonly fileService: FileService;
+
+  constructor(container: interfaces.Container, rpc: RPCProtocol) {
+    this.delegate = rpc.getProxy(PLUGIN_RPC_CONTEXT.CHE_SIDECAR_FILE_SYSTEM);
+    this.fileService = container.get(FileService);
+  }
+
+  $disposeFileSystemProvider(scheme: string): Promise<void> {
+    const disposable = this.registrations.get(scheme);
+    if (disposable !== undefined) {
+      disposable.dispose();
+      this.registrations.delete(scheme);
+    }
+    return Promise.resolve(undefined);
+  }
+
+  $registerFileSystemProvider(scheme: string): Promise<void> {
+    const provider = new CheSideCarFileSystemProvider(this.delegate, FileSystemProviderCapabilities.FileReadWrite);
+    const disposable = this.fileService.registerProvider(scheme, provider);
+    this.registrations.set(scheme, disposable);
+    return Promise.resolve(undefined);
+  }
+}
+
+export class CheSideCarFileSystemProvider extends AbstractSideCarFileSystemProvider {
+  private readonly delegate: CheSideCarFileSystem;
+
+  constructor(delegate: CheSideCarFileSystem, capabilities: FileSystemProviderCapabilities) {
+    super(capabilities);
+    this.delegate = delegate;
+  }
+
+  async stat(resource: URI): Promise<Stat> {
+    return await this.delegate.$stat(resource.path.toString());
+  }
+
+  async readFile(resource: URI): Promise<Uint8Array> {
+    return (await this.delegate.$readFile(resource.path.toString())).buffer;
+  }
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -13,7 +13,9 @@ import * as che from '@eclipse-che/plugin';
 import { Event, JsonRpcServer } from '@theia/core';
 import { Preferences, User } from '@eclipse-che/theia-remote-api/lib/common/user-service';
 
+import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 import { CheLanguagesTestAPI } from './che-languages-test-protocol';
+import { Stat } from '@theia/filesystem/lib/common/files';
 import { che as cheApi } from '@eclipse-che/api';
 import { createProxyIdentifier } from '@theia/plugin-ext/lib/common/rpc-protocol';
 
@@ -136,6 +138,16 @@ export interface CheSideCarContentReader {
 
 export interface CheSideCarContentReaderMain {
   $registerContentReader(scheme: string): Promise<void>;
+}
+
+export interface CheSideCarFileSystem {
+  $stat(resource: string): Promise<Stat>;
+  $readFile(resource: string): Promise<BinaryBuffer>;
+}
+
+export interface CheSideCarFileSystemMain {
+  $registerFileSystemProvider(scheme: string): Promise<void>;
+  $disposeFileSystemProvider(scheme: string): Promise<void>;
 }
 
 export interface Variable {
@@ -418,6 +430,9 @@ export const PLUGIN_RPC_CONTEXT = {
 
   CHE_SIDERCAR_CONTENT_READER: createProxyIdentifier<CheSideCarContentReader>('CheSideCarContentReader'),
   CHE_SIDERCAR_CONTENT_READER_MAIN: createProxyIdentifier<CheSideCarContentReaderMain>('CheSideCarContentReaderMain'),
+
+  CHE_SIDECAR_FILE_SYSTEM: createProxyIdentifier<CheSideCarFileSystem>('CheSideCarFileSystem'),
+  CHE_SIDECAR_FILE_SYSTEM_MAIN: createProxyIdentifier<CheSideCarFileSystemMain>('CheSideCarFileSystemMain'),
 
   CHE_LANGUAGES_TEST_API_MAIN: createProxyIdentifier<CheLanguagesTestAPI>('CheLanguagesTestAPI'),
 };

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
@@ -19,6 +19,7 @@ import { CheOauthImpl } from './che-oauth';
 import { CheOpenshiftImpl } from './che-openshift';
 import { CheProductImpl } from './che-product';
 import { CheSideCarContentReaderImpl } from './che-sidecar-content-reader';
+import { CheSideCarFileSystemImpl } from './che-sidecar-file-system';
 import { CheSshImpl } from './che-ssh';
 import { CheTelemetryImpl } from './che-telemetry';
 import { CheUserImpl } from './che-user';
@@ -46,6 +47,7 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
   const cheOauthImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_OAUTH, new CheOauthImpl(rpc));
   const cheUserImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_USER, new CheUserImpl(rpc));
   rpc.set(PLUGIN_RPC_CONTEXT.CHE_SIDERCAR_CONTENT_READER, new CheSideCarContentReaderImpl(rpc));
+  rpc.set(PLUGIN_RPC_CONTEXT.CHE_SIDECAR_FILE_SYSTEM, new CheSideCarFileSystemImpl(rpc));
 
   const cheProductImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_PRODUCT, new CheProductImpl(rpc));
   const cheTelemetryImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_TELEMETRY, new CheTelemetryImpl(rpc));

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-sidecar-file-system.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-sidecar-file-system.ts
@@ -1,0 +1,158 @@
+/**********************************************************************
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import { CheSideCarFileSystem, PLUGIN_RPC_CONTEXT } from '../common/che-protocol';
+import {
+  FileSystemProviderError,
+  FileSystemProviderErrorCode,
+  FileType,
+  Stat,
+  createFileSystemProviderError,
+} from '@theia/filesystem/lib/common/files';
+import { Stats, lstat, readFile, stat } from 'fs';
+
+import { BinaryBuffer } from '@theia/core/lib/common/buffer';
+import { RPCProtocol } from '@theia/plugin-ext/lib/common/rpc-protocol';
+import { URI } from 'vscode-uri';
+import { promisify } from 'util';
+
+export namespace SideCarFileSystemProvider {
+  export interface StatAndLink {
+    // The stats of the file. If the file is a symbolic
+    // link, the stats will be of that target file and
+    // not the link itself.
+    // If the file is a symbolic link pointing to a non
+    // existing file, the stat will be of the link and
+    // the `dangling` flag will indicate this.
+    stat: Stats;
+
+    // Will be provided if the resource is a symbolic link
+    // on disk. Use the `dangling` flag to find out if it
+    // points to a resource that does not exist on disk.
+    symbolicLink?: { dangling: boolean };
+  }
+}
+
+export class CheSideCarFileSystemImpl implements CheSideCarFileSystem {
+  constructor(rpc: RPCProtocol) {
+    const delegate = rpc.getProxy(PLUGIN_RPC_CONTEXT.CHE_SIDECAR_FILE_SYSTEM_MAIN);
+    const machineName = process.env.CHE_MACHINE_NAME;
+    if (machineName) {
+      delegate.$registerFileSystemProvider(`file-sidecar-${machineName}`);
+    }
+  }
+
+  async $stat(resource: string): Promise<Stat> {
+    try {
+      const statAndLink = await this.statLink(resource); // cannot use fs.stat() here to support links properly
+
+      return {
+        type: this.toType(statAndLink.stat, statAndLink.symbolicLink),
+        ctime: statAndLink.stat.birthtime.getTime(), // intentionally not using ctime here, we want the creation time
+        mtime: statAndLink.stat.mtime.getTime(),
+        size: statAndLink.stat.size,
+      };
+    } catch (error) {
+      throw this.toFileSystemProviderError(error);
+    }
+  }
+
+  async $readFile(resource: string): Promise<BinaryBuffer> {
+    const _uri = URI.parse(resource);
+    try {
+      return BinaryBuffer.wrap(await promisify(readFile)(_uri.fsPath, undefined));
+    } catch (error) {
+      return Promise.reject(this.toFileSystemProviderError(error));
+    }
+  }
+
+  protected async statLink(path: string): Promise<SideCarFileSystemProvider.StatAndLink> {
+    // First stat the link
+    let lstats: Stats | undefined;
+    try {
+      lstats = await promisify(lstat)(path);
+
+      // Return early if the stat is not a symbolic link at all
+      if (!lstats.isSymbolicLink()) {
+        return { stat: lstats };
+      }
+    } catch (error) {
+      /* ignore - use stat() instead */
+    }
+
+    // If the stat is a symbolic link or failed to stat, use fs.stat()
+    // which for symbolic links will stat the target they point to
+    try {
+      const stats = await promisify(stat)(path);
+
+      return { stat: stats, symbolicLink: lstats?.isSymbolicLink() ? { dangling: false } : undefined };
+    } catch (error) {
+      // If the link points to a non-existing file we still want
+      // to return it as result while setting dangling: true flag
+      if (error.code === 'ENOENT' && lstats) {
+        return { stat: lstats, symbolicLink: { dangling: true } };
+      }
+
+      throw error;
+    }
+  }
+
+  private toType(entry: Stats, symbolicLink?: { dangling: boolean }): FileType {
+    // Signal file type by checking for file / directory, except:
+    // - symbolic links pointing to non-existing files are FileType.Unknown
+    // - files that are neither file nor directory are FileType.Unknown
+    let type: FileType;
+    if (symbolicLink?.dangling) {
+      type = FileType.Unknown;
+    } else if (entry.isFile()) {
+      type = FileType.File;
+    } else if (entry.isDirectory()) {
+      type = FileType.Directory;
+    } else {
+      type = FileType.Unknown;
+    }
+
+    // Always signal symbolic link as file type additionally
+    if (symbolicLink) {
+      type |= FileType.SymbolicLink;
+    }
+
+    return type;
+  }
+
+  private toFileSystemProviderError(error: NodeJS.ErrnoException): FileSystemProviderError {
+    if (error instanceof FileSystemProviderError) {
+      return error; // avoid double conversion
+    }
+
+    let code: FileSystemProviderErrorCode;
+    switch (error.code) {
+      case 'ENOENT':
+        code = FileSystemProviderErrorCode.FileNotFound;
+        break;
+      case 'EISDIR':
+        code = FileSystemProviderErrorCode.FileIsADirectory;
+        break;
+      case 'ENOTDIR':
+        code = FileSystemProviderErrorCode.FileNotADirectory;
+        break;
+      case 'EEXIST':
+        code = FileSystemProviderErrorCode.FileExists;
+        break;
+      case 'EPERM':
+      case 'EACCES':
+        code = FileSystemProviderErrorCode.NoPermissions;
+        break;
+      default:
+        code = FileSystemProviderErrorCode.Unknown;
+    }
+
+    return createFileSystemProviderError(error, code);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2330,7 +2330,7 @@
     fuzzy "^0.1.3"
     vscode-ripgrep "^1.2.4"
 
-"@theia/filesystem@1.9.0-next.2d422afd":
+"@theia/filesystem@1.9.0-next.2d422afd", "@theia/filesystem@next":
   version "1.9.0-next.2d422afd"
   resolved "https://registry.yarnpkg.com/@theia/filesystem/-/filesystem-1.9.0-next.2d422afd.tgz#13a35eeae01d46718f7355e9e2ad5ec985a507cb"
   integrity sha512-/0Kcq+NAsBkIRsgSG4MZU4X8Z3+EGg2FDBI7UMPFKN6YrnqnzsEPj0IXXvow0/sxbjpnZKZSW5hBzg2ssjaTJw==


### PR DESCRIPTION
### What does this PR do?
This changes proposal adds a registration for sidecar file scheme: `file-sidecar-${machineName}`. As the first iteration across [dependent issue #16870](https://github.com/eclipse/che/issues/16870) only two methods from file system have been implemented: `stat` and `readFile`.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### Screenshot/screencast of this PR
This changes doesn't provide any UI feedback. Just internal feature.
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18405
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
Here is the devfile for the workspace, based on this PR:
```yaml
apiVersion: 1.0.0
metadata:
  name: che-18405
components:
  - memoryLimit: 256Mi
    type: chePlugin
    reference: 'https://gist.githubusercontent.com/vzhukovs/29fccda72fbbd63e0c8aa8f751c9745a/raw/713d0b9ab47576ddb25c5a1a423346dd8f645268/meta.yaml'
  - memoryLimit: 1024Mi
    type: cheEditor
    reference: 'https://gist.githubusercontent.com/vzhukovs/e341154d8cbd33d5e56b1cbd719238ae/raw/c7ff20bbeb8a36c97559987cb2a4c79beba56c46/meta.yaml'
```

I've created a simple VS Code plugin that located here: [sample-0.0.1.vsix](https://github.com/vzhukovs/vscode-webview-sample/blob/sidecar/sample-0.0.1.vsix). Source code of extension located here: [extension.ts](https://github.com/vzhukovs/vscode-webview-sample/blob/sidecar/src/extension.ts)

There is a sample command in command palette called: **Side Car: Show Webview**

Expected behavior - webview will be opened and resources, that are locaed on the dedicate container will be successfully loaded (css, js and font).

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
