### PR TITLE
Use express library instead redundant connect

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/node/plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/plugin-service.ts
@@ -20,8 +20,6 @@ import { PluginApiContribution } from '@theia/plugin-ext/lib/main/node/plugin-se
 import { WebviewExternalEndpoint } from '@theia/plugin-ext/lib/main/common/webview-protocol';
 import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
 
-import connect = require('connect');
-import serveStatic = require('serve-static');
 const vhost = require('vhost');
 
 const pluginPath = (process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE) + './theia/plugins/';
@@ -42,7 +40,7 @@ export class PluginApiContributionIntercepted extends PluginApiContribution {
       res.sendFile(pluginPath + filePath);
     });
 
-    const webviewApp = connect();
+    const webviewApp = express();
     const pluginExtModulePath = path.dirname(require.resolve('@theia/plugin-ext/package.json'));
     const webviewStaticResources = path.join(pluginExtModulePath, 'src/main/browser/webview/pre');
 
@@ -58,7 +56,7 @@ export class PluginApiContributionIntercepted extends PluginApiContribution {
             webviewCheEndpointHostname ||
             WebviewExternalEndpoint.defaultPattern
         );
-        webviewApp.use('/webview', serveStatic(webviewStaticResources));
+        webviewApp.use('/webview', express.static(webviewStaticResources));
 
         this.logger.info(`Configuring to accept webviews on '${webviewHostname}' hostname.`);
         app.use(vhost(new RegExp(webviewHostname, 'i'), webviewApp));


### PR DESCRIPTION
### What does this PR do?
This changes proposal adapts Che-Theia to upstream changes.

Upstream commit https://github.com/eclipse-theia/theia/commit/143f589a2183adb469301612775773f2ad776723 brings changes that prevent normal workspace start. In upstream, PluginApiContribution now doesn't have usage of connect library, and as far as we extend this class and rebind it on Che-Theia side [PluginApiContributionIntercepted](https://github.com/eclipse/che-theia/blob/8f0d22e7b141b696af70b924dd48c85117daf052/extensions/eclipse-che-theia-plugin-ext/src/node/plugin-service.ts#L28) needs to be aligned to upstream class.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18618

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
