### PR TITLE
Use CA bundle when cloning ZIP projects

### DIFF
--- a/plugins/workspace-plugin/src/ca-bundle.ts
+++ b/plugins/workspace-plugin/src/ca-bundle.ts
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (c) 2019-2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as theia from '@theia/plugin';
+
+const PUBLIC_CRT_PATH = '/public-certs';
+const SS_CRT_PATH = '/tmp/che/secret/ca.crt';
+
+const CA_BUNDLE_PATH = '/tmp/ca-bundle.crt';
+
+let bundle: string | undefined = undefined;
+
+export async function getAuthorityCertificate(): Promise<string | undefined> {
+  if (bundle !== undefined) {
+    return bundle;
+  }
+
+  const certificateAuthority: Buffer[] = [];
+
+  const output = theia.window.createOutputChannel('workspace plugin');
+  output.appendLine('Prepare CA bundle:');
+
+  if (fs.existsSync(SS_CRT_PATH)) {
+    output.appendLine('   > ' + SS_CRT_PATH);
+
+    certificateAuthority.push(fs.readFileSync(SS_CRT_PATH));
+  }
+
+  if (fs.existsSync(PUBLIC_CRT_PATH)) {
+    const publicCertificates = fs.readdirSync(PUBLIC_CRT_PATH);
+    for (const publicCertificate of publicCertificates) {
+      if (publicCertificate.endsWith('.crt')) {
+        const certPath = path.join(PUBLIC_CRT_PATH, publicCertificate);
+
+        output.appendLine('   > ' + certPath);
+
+        certificateAuthority.push(fs.readFileSync(certPath));
+      }
+    }
+  }
+
+  if (certificateAuthority.length > 0) {
+    for (const certificate of certificateAuthority) {
+      fs.writeFileSync(CA_BUNDLE_PATH, certificate);
+    }
+
+    bundle = CA_BUNDLE_PATH;
+  } else {
+    bundle = '';
+  }
+
+  return bundle;
+}

--- a/plugins/workspace-plugin/src/ca-bundle.ts
+++ b/plugins/workspace-plugin/src/ca-bundle.ts
@@ -50,7 +50,7 @@ export async function getAuthorityCertificate(): Promise<string | undefined> {
 
   if (certificateAuthority.length > 0) {
     for (const certificate of certificateAuthority) {
-      fs.writeFileSync(CA_BUNDLE_PATH, certificate);
+      fs.appendFileSync(CA_BUNDLE_PATH, certificate);
     }
 
     bundle = CA_BUNDLE_PATH;

--- a/plugins/workspace-plugin/src/ca-cert.ts
+++ b/plugins/workspace-plugin/src/ca-cert.ts
@@ -10,7 +10,6 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import * as theia from '@theia/plugin';
 
 const PUBLIC_CRT_PATH = '/public-certs';
 const SS_CRT_PATH = '/tmp/che/secret/ca.crt';
@@ -26,12 +25,7 @@ export async function getAuthorityCertificate(): Promise<string | undefined> {
 
   const certificateAuthority: Buffer[] = [];
 
-  const output = theia.window.createOutputChannel('workspace plugin');
-  output.appendLine('Prepare CA bundle:');
-
   if (fs.existsSync(SS_CRT_PATH)) {
-    output.appendLine('   > ' + SS_CRT_PATH);
-
     certificateAuthority.push(fs.readFileSync(SS_CRT_PATH));
   }
 
@@ -40,9 +34,6 @@ export async function getAuthorityCertificate(): Promise<string | undefined> {
     for (const publicCertificate of publicCertificates) {
       if (publicCertificate.endsWith('.crt')) {
         const certPath = path.join(PUBLIC_CRT_PATH, publicCertificate);
-
-        output.appendLine('   > ' + certPath);
-
         certificateAuthority.push(fs.readFileSync(certPath));
       }
     }

--- a/plugins/workspace-plugin/src/theia-commands.ts
+++ b/plugins/workspace-plugin/src/theia-commands.ts
@@ -249,7 +249,8 @@ export class TheiaImportZipCommand implements TheiaImportCommand {
 
         if (cert) {
           output.appendLine(`--cacert ${cert}`);
-          curlArgs.push(`--cacert ${cert}`);
+          curlArgs.push('--cacert');
+          curlArgs.push(cert);
         } else {
           output.appendLine('certificate is not set');
         }

--- a/plugins/workspace-plugin/src/theia-commands.ts
+++ b/plugins/workspace-plugin/src/theia-commands.ts
@@ -18,7 +18,7 @@ import * as theia from '@theia/plugin';
 import { TaskScope } from '@eclipse-che/plugin';
 import { che as cheApi } from '@eclipse-che/api';
 import { execute } from './exec';
-import { getAuthorityCertificate } from './ca-bundle';
+import { getAuthorityCertificate } from './ca-cert';
 
 const CHE_TASK_TYPE = 'che';
 
@@ -244,15 +244,10 @@ export class TheiaImportZipCommand implements TheiaImportCommand {
         // download
         const curlArgs = ['-sSL', '--output', this.zipfilePath];
 
+        // with certificate
         const cert = await getAuthorityCertificate();
-        const output = theia.window.createOutputChannel('certificate');
-
         if (cert) {
-          output.appendLine(`--cacert ${cert}`);
-          curlArgs.push('--cacert');
-          curlArgs.push(cert);
-        } else {
-          output.appendLine('certificate is not set');
+          curlArgs.push('--cacert', cert);
         }
 
         curlArgs.push(this.locationURI!);

--- a/plugins/workspace-plugin/src/theia-commands.ts
+++ b/plugins/workspace-plugin/src/theia-commands.ts
@@ -18,7 +18,7 @@ import * as theia from '@theia/plugin';
 import { TaskScope } from '@eclipse-che/plugin';
 import { che as cheApi } from '@eclipse-che/api';
 import { execute } from './exec';
-import { getAuthorityCertificate } from './ca-cert';
+import { getCertificate } from './ca-cert';
 
 const CHE_TASK_TYPE = 'che';
 
@@ -245,7 +245,7 @@ export class TheiaImportZipCommand implements TheiaImportCommand {
         const curlArgs = ['-sSL', '--output', this.zipfilePath];
 
         // with certificate
-        const cert = await getAuthorityCertificate();
+        const cert = await getCertificate;
         if (cert) {
           curlArgs.push('--cacert', cert);
         }


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- creates ca-bundle in `/tmp` containing '/tmp/che/secret/ca.crt' and all available certificates from '/public-certs'
- uses that bundle when downloading ZIP projects with `curl`

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/18654

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

1. generate new public and private certificates, setup somewhere https server
  if you want to test this PR on local minikube deployment, you can setup https server on your local machine

2. add public certificate to Che
```
kubectl create configmap custom-certs --from-file=/home/vitaliy/tmp/ca-bundle.crt -n=che
kubectl label configmap custom-certs app.kubernetes.io/part-of=che.eclipse.org app.kubernetes.io/component=ca-bundle -n che
```

3. Take the devfile for this PR
- remove all commands and components, but leave che-theia 
- add few zippped projects, that hosted on https server

```
---
apiVersion: 1.0.0
metadata:
  name: petclinic-dev-environment
projects:
  -
    name: petclinic
    source:
      type: git
      location: "https://github.com/spring-projects/spring-petclinic.git"
  -
    name: greeting-extension
    source:
      type: zip
      location: "https://192.168.44.103:9090/projects/greeting-extension.zip"
  -
    name: ports-plugin
    source:
      type: zip
      location: "https://192.168.44.103:9090/projects/ports-plugin.zip"
  -
    name: telemetry-plugin
    source:
      type: zip
      location: "https://192.168.44.103:9090/projects/telemetry-plugin.zip"
  -
    name: welcome-plugin
    source:
      type: zip
      location: "https://192.168.44.103:9090/projects/welcome-plugin.zip"
components:
  - type: cheEditor
    alias: che-theia
    reference: https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-960/che_theia_meta.yaml
    memoryLimit: 512Mi
```

4. Create the workspace. All projects must be cloned.
    Check that your workspace has two certificates
    - `/public-certs/custom-certs.ca-bundle.crt`
    - `/tmp/che/secret/ca.crt`
    and one ca-bundle
    - `/tmp/ca-bundle.crt`

![Screenshot from 2021-01-06 19-15-52](https://user-images.githubusercontent.com/1655894/103800997-c60b3e80-5055-11eb-8370-de6fd9a211e2.png)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next
