### PR TITLE
Handle case where err is not defined

### DIFF
--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote.ts
@@ -40,7 +40,7 @@ process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
         unhandledPromises.splice(index, 1);
         const containerName = process.env['CHE_MACHINE_NAME'];
         console.error(`Remote plugin in ${containerName}: promise rejection is not handled in two seconds: ${err}`);
-        if (err.stack) {
+        if (err && err.stack) {
           console.error(`Remote plugin in ${containerName}: promise rejection stack trace: ${err.stack}`);
         }
       });


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

### What does this PR do?
Fixes error handling in the plugin host process

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17601


### How to test this PR?

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
