### PR TITLE
Add docs notification if GitHub oAuth is not setup

### DIFF
--- a/extensions/eclipse-che-theia-remote-api/src/browser/oauth-utils.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/browser/oauth-utils.ts
@@ -13,6 +13,7 @@ import { inject, injectable } from 'inversify';
 
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { OAuthService } from '../common/oauth-service';
+import { UserService } from '../common/user-service';
 
 @injectable()
 export class OauthUtils {
@@ -27,7 +28,8 @@ export class OauthUtils {
 
   constructor(
     @inject(EnvVariablesServer) private readonly envVariableServer: EnvVariablesServer,
-    @inject(OAuthService) private readonly oAuthService: OAuthService
+    @inject(OAuthService) private readonly oAuthService: OAuthService,
+    @inject(UserService) private readonly userService: UserService
   ) {
     const onDidReceiveTokenEmitter = new Emitter<void>();
     this.onDidReceiveToken = onDidReceiveTokenEmitter.event;
@@ -57,29 +59,41 @@ export class OauthUtils {
   }
 
   async getUserToken(): Promise<string | undefined> {
-    if (this.userToken) {
-      return this.userToken;
-    } else if (this.machineToken && this.machineToken.length > 0) {
-      const timer = setTimeout(() => {
-        this.messageService.warn(
-          'Authentication is taking too long, the oauth pop-up may be blocked by your browser, ' +
-            'if so, allow popup windows for the current url and restart the workspace'
+    const updateToken: () => Promise<string | undefined> = async () => {
+      if (this.machineToken && this.machineToken.length > 0) {
+        const timer = setTimeout(() => {
+          this.messageService.warn(
+            'Authentication is taking too long, the oauth pop-up may be blocked by your browser, ' +
+              'if so, allow popup windows for the current url and restart the workspace'
+          );
+        }, 10000);
+        const popup = window.open(
+          `${this.apiUrl.substring(0, this.apiUrl.indexOf('/api'))}/_app/oauth.html`,
+          'popup',
+          'toolbar=no, status=no, menubar=no, scrollbars=no, width=10, height=10, visible=none'
         );
-      }, 10000);
-      const popup = window.open(
-        `${this.apiUrl.substring(0, this.apiUrl.indexOf('/api'))}/_app/oauth.html`,
-        'popup',
-        'toolbar=no, status=no, menubar=no, scrollbars=no, width=10, height=10, visible=none'
-      );
-      if (popup) {
-        this.oAuthPopup = popup;
-      }
-      return new Promise(async resolve => {
-        this.onDidReceiveToken(() => {
-          clearTimeout(timer);
-          resolve(this.userToken);
+        if (popup) {
+          this.oAuthPopup = popup;
+        }
+        return new Promise(async resolve => {
+          this.onDidReceiveToken(() => {
+            clearTimeout(timer);
+            resolve(this.userToken);
+          });
         });
-      });
+      }
+    };
+    if (this.userToken) {
+      try {
+        await this.userService.getCurrentUser(this.userToken);
+      } catch (e) {
+        if (/Request getCurrentUser failed with message: "401"/g.test(e.message)) {
+          return updateToken();
+        }
+      }
+      return this.userToken;
+    } else {
+      return updateToken();
     }
   }
 
@@ -105,7 +119,7 @@ export class OauthUtils {
       await this.oAuthService.getOAuthToken(provider, await this.getUserToken());
       return true;
     } catch (e) {
-      return e.message.indexOf('Request failed with status code 401') > 0;
+      return new RegExp(`User \[.*] is not associated with identity provider \[${provider}]\.`).test(e.message);
     }
   }
 

--- a/extensions/eclipse-che-theia-remote-api/src/browser/oauth-utils.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/browser/oauth-utils.ts
@@ -63,8 +63,8 @@ export class OauthUtils {
       if (this.machineToken && this.machineToken.length > 0) {
         const timer = setTimeout(() => {
           this.messageService.warn(
-            'Authentication is taking too long, the oauth pop-up may be blocked by your browser, ' +
-              'if so, allow popup windows for the current url and restart the workspace'
+            'Authentication is taking too long, the OAuth pop-up may be blocked by your browser, ' +
+              'if so, allow pop-up windows for the current url and restart the workspace'
           );
         }, 10000);
         const popup = window.open(
@@ -119,7 +119,7 @@ export class OauthUtils {
       await this.oAuthService.getOAuthToken(provider, await this.getUserToken());
       return true;
     } catch (e) {
-      return new RegExp(`User \[.*] is not associated with identity provider \[${provider}]\.`).test(e.message);
+      return new RegExp(`User \\[.*] is not associated with identity provider \\[${provider}]\\.`).test(e.message);
     }
   }
 

--- a/plugins/github-auth-plugin/src/github-auth-plugin.ts
+++ b/plugins/github-auth-plugin/src/github-auth-plugin.ts
@@ -25,11 +25,10 @@ export async function start(context: theia.PluginContext): Promise<void> {
     login: async (scopes: string[]) => {
       if (!(await che.oAuth.isRegistered('github'))) {
         if (
-          (await theia.window.showWarningMessage(
-            'GitHub OAuth provider is not setup! Would you like to open the documentation page?',
-            'Yes',
-            'No'
-          )) === 'Yes'
+          await theia.window.showWarningMessage(
+            'Che could not authenticate to your Github account. The setup for Github OAuth provider is not complete.',
+            'Setup instructions'
+          )
         ) {
           theia.commands.executeCommand(
             'theia.open',

--- a/plugins/github-auth-plugin/src/github-auth-plugin.ts
+++ b/plugins/github-auth-plugin/src/github-auth-plugin.ts
@@ -23,6 +23,21 @@ export async function start(context: theia.PluginContext): Promise<void> {
     onDidChangeSessions: onDidChangeSessions.event,
     getSessions: async () => sessions,
     login: async (scopes: string[]) => {
+      if (!(await che.oAuth.isRegistered('github'))) {
+        if (
+          (await theia.window.showWarningMessage(
+            'GitHub OAuth provider is not setup! Would you like to open the documentation page?',
+            'Yes',
+            'No'
+          )) === 'Yes'
+        ) {
+          theia.commands.executeCommand(
+            'theia.open',
+            'https://www.eclipse.org/che/docs/che-7/administration-guide/configuring-authorization/#configuring-github-oauth_che'
+          );
+        }
+        return;
+      }
       const githubUser = await che.github.getUser();
       const session = {
         id: v4(),
@@ -49,22 +64,6 @@ export async function start(context: theia.PluginContext): Promise<void> {
       }
     },
   });
-  if (theia.plugins.getPlugin('github.vscode-pull-request-github')) {
-    if (sessions.length > 0) {
-      onDidChangeSessions.fire({ added: sessions.map(s => s.id), removed: [], changed: [] });
-      // TODO Remove the notification when https://github.com/eclipse-theia/theia/issues/7178 is fixed.
-    } else {
-      const signIn = 'Sign in';
-      const result = await theia.window.showInformationMessage(
-        'In order to use the Pull Requests functionality, you must sign in to GitHub',
-        signIn
-      );
-
-      if (result === signIn) {
-        theia.authentication.getSession('github', ['read:user', 'user:email', 'repo'], { createIfNone: true });
-      }
-    }
-  }
 }
 
 export function stop(): void {}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* If GitHub oauth is not set-up, show a notification with a link to a guide how to set-up GitHub identity provider in keycloak in Che docs page.
* Fix authentication mechanism (if Che user token is expired, retrieve it again), little refactoring.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/18237

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Run Che with `quay.io/eclipse/che-server:nightly` image. It contains the [authentication fix](https://github.com/eclipse/che/pull/18815)
2. Create and open a workspace from dev-file:
```
apiVersion: 1.0.0
metadata:
  name: testnjz3q
components:
  - type: cheEditor
    reference: 'https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-969/che_theia_meta.yaml'
  - id: github/vscode-pull-request-github/latest
    type: chePlugin
projects:
  - name: environment-variable
    source:
      location: 'https://github.com/vinokurig/environment-variable.git'
      type: git
```
3. Try to login the GitHub PR plugin:
![screenshot-serverkcgc53mh-che-dev-server-3010 192 168 99 254 nip io-2021 01 22-13_21_04](https://user-images.githubusercontent.com/7668752/105484815-a2323480-5cb4-11eb-8378-681b5858f92f.png)
4. See the notification:
![screenshot-serverkcgc53mh-che-dev-server-3010 192 168 99 254 nip io-2021 01 22-13_23_02](https://user-images.githubusercontent.com/7668752/105484911-c5f57a80-5cb4-11eb-92cc-be5683d2c0e9.png)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
