### PR TITLE
Downgrade `vscode-builtin-markdown-language-features` built-in plug-in to 1.39.1

### DIFF
--- a/generator/src/templates/theiaPlugins.json
+++ b/generator/src/templates/theiaPlugins.json
@@ -31,7 +31,7 @@
     "vscode-builtin-lua": "https://open-vsx.org/api/vscode/lua/1.45.1/file/vscode.lua-1.45.1.vsix",
     "vscode-builtin-make": "https://open-vsx.org/api/vscode/make/1.45.1/file/vscode.make-1.45.1.vsix",
     "vscode-builtin-markdown": "https://open-vsx.org/api/vscode/markdown/1.45.1/file/vscode.markdown-1.45.1.vsix",
-    "vscode-builtin-markdown-language-features": "https://open-vsx.org/api/vscode/markdown-language-features/1.45.1/file/vscode.markdown-language-features-1.45.1.vsix",
+    "vscode-builtin-markdown-language-features": "https://openvsxorg.blob.core.windows.net/resources/vscode/markdown-language-features/1.39.1/vscode.markdown-language-features-1.39.1.vsix",
     "vscode-builtin-merge-conflicts": "https://open-vsx.org/api/vscode/merge-conflict/1.45.1/file/vscode.merge-conflict-1.45.1.vsix",
     "vscode-builtin-npm": "https://open-vsx.org/api/vscode/npm/1.45.1/file/vscode.npm-1.45.1.vsix",
     "vscode-builtin-objective-c": "https://open-vsx.org/api/vscode/objective-c/1.45.1/file/vscode.objective-c-1.45.1.vsix",


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Downgrades `vscode-builtin-markdown-language-features` built-in plug-in to 1.39.1.
As 1.45.1 requires not implemented yet CustomEditor Plug-in API.
![image](https://user-images.githubusercontent.com/1636395/106704090-2610e880-65f4-11eb-8f1a-d474f498ba7c.png)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/18954

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
