### PR TITLE
fix(java-highlighting): disabling semantic highlighting

### DIFF
--- a/generator/src/templates/assembly-package.mst
+++ b/generator/src/templates/assembly-package.mst
@@ -10,6 +10,7 @@
         "defaultIconTheme": "theia-file-icons",
         "preferences": {
           "editor.autoSave": "on",
+          "editor.semanticHighlighting.enabled": false,
           "git.defaultCloneDirectory": "/projects",
           "application.confirmExit": "always",
           "files.enableTrash": false


### PR DESCRIPTION
### What does this PR do?
Fix syntax highlighting when semantic highlighting is available. Will reconsider re-enabling it once we fix this: https://github.com/eclipse-theia/theia/issues/9058

### Screenshot/screencast of this PR

![Selection_221](https://user-images.githubusercontent.com/650571/107790939-a7cee780-6d53-11eb-810d-3d3df7e95dbd.png)


### What issues does this PR fix or reference?
PR alternative#2 for https://github.com/eclipse/che/issues/18448

### How to test this PR?
1. Start a workspace with Java/maven devfile provided https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-993/simple/che-theia-maven-devfile.yaml
2. Open a java file
3. Wait for language server to be activated
4. The syntax highlighting is OK



### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
