### PR TITLE
feat(namespace): Export @eclipse-che/plugin namespace using VS Code extension mechanism

### DIFF
--- a/che-theia-init-sources.yml
+++ b/che-theia-init-sources.yml
@@ -22,6 +22,7 @@ sources:
     - extensions/eclipse-che-theia-remote-impl-che-server
   plugins:
     - plugins/containers-plugin
+    - plugins/ext-plugin
     - plugins/workspace-plugin
     - plugins/resource-monitor-plugin
     - plugins/ports-plugin

--- a/plugins/ext-plugin/.gitignore
+++ b/plugins/ext-plugin/.gitignore
@@ -1,0 +1,4 @@
+lib/
+node_modules/
+*.theia
+coverage

--- a/plugins/ext-plugin/README.md
+++ b/plugins/ext-plugin/README.md
@@ -1,0 +1,15 @@
+# Ext Plug-in
+This plug-in is exposing some Eclipse Che API to be consumed by other VS Code extensions using the VS Code extension mechanism.
+
+## Example
+
+```typescript
+const eclipseCheExtPlugin = vscode.extensions.getExtension('@eclipse-che.ext-plugin');
+if (eclipseCheExtPlugin) {
+  // grab user
+  const user = await eclipseCheExtPlugin.exports.user.getCurrentUser();
+  vscode.window.showInformationMessage(`Eclipse Che user information: id ${user.id} with name ${user.name}`);
+}
+```
+
+Exported code is coming from https://github.com/eclipse/che-theia/blob/master/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts

--- a/plugins/ext-plugin/__mocks__/@eclipse-che/plugin.ts
+++ b/plugins/ext-plugin/__mocks__/@eclipse-che/plugin.ts
@@ -1,0 +1,28 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/**
+ * Mock of @eclipse-che/plugin module
+ * @author Florent Benoit
+ */
+const che: any = {};
+let currentWorkspace: any = undefined;
+
+che.setWorkspaceOutput = (input: any) => {
+  currentWorkspace = input;
+};
+
+che.workspace = {};
+
+che.workspace.getCurrentWorkspace = () => {
+  return currentWorkspace;
+};
+
+module.exports = che;

--- a/plugins/ext-plugin/package.json
+++ b/plugins/ext-plugin/package.json
@@ -1,29 +1,26 @@
 {
-  "name": "@eclipse-che/workspace-plugin",
-  "publisher": "Eclipse Che",
+  "name": "ext-plugin",
+  "publisher": "@eclipse-che",
   "version": "0.0.1",
   "keywords": [
     "theia-plugin"
   ],
+  "description": "Exports @eclipse-che/plugin namespace",
   "license": "EPL-2.0",
   "files": [
     "src"
   ],
-  "dependencies": {
-    "async-mutex": "^0.2.6",
-    "fs-extra": "7.0.1"
-  },
+  "activationEvents": [
+    "*"
+  ],
+  "dependencies": {},
   "devDependencies": {
-    "@eclipse-che/plugin": "0.0.1",
+    "@eclipse-che/plugin": "latest",
     "@theia/plugin": "next",
     "@theia/plugin-packager": "latest"
   },
-  "extensionDependencies": [
-    "Eclipse Che.@eclipse-che/theia-ssh-plugin",
-    "@eclipse-che.ext-plugin"
-  ],
   "scripts": {
-    "prepare": "yarn clean && yarn lint:fix && yarn build && yarn test",
+    "prepare": "yarn clean && yarn build && yarn lint:fix && yarn test",
     "clean": "rimraf lib",
     "format": "if-env SKIP_FORMAT=true && echo 'skip format check' || prettier --check '{src,tests}/**/*.ts' package.json",
     "format:fix": "prettier --write '{src,tests}/**/*.ts' package.json",
@@ -33,13 +30,13 @@
     "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\" && theia-plugin pack",
     "watch": "tsc -w",
     "test": "if-env SKIP_TEST=true && echo 'skip test' || jest --forceExit",
-    "test:watch": "jest --watchAll"
+    "test-watch": "jest --watchAll"
   },
   "engines": {
     "theiaPlugin": "next"
   },
   "theiaPlugin": {
-    "backend": "lib/workspace-plugin.js"
+    "backend": "lib/ext-plugin.js"
   },
   "jest": {
     "collectCoverage": true,
@@ -48,44 +45,18 @@
     ],
     "coverageDirectory": "./coverage",
     "transform": {
-      "^.+\\.tsx?$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
+      "^.+\\.tsx?$": "ts-jest"
     },
     "modulePathIgnorePatterns": [
-      "<rootDir>/lib"
+      "<rootDir>/dist"
     ],
-    "testRegex": "(/tests/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",
       "js",
       "jsx",
       "json"
-    ],
-    "testURL": "http://localhost/"
-  },
-  "activationEvents": [
-    "*"
-  ],
-  "contributes": {
-    "menus": {
-      "editor/context": [
-        {
-          "command": "workspace-plugin.create-workspace",
-          "when": "resourceFilename =~ /devfile/"
-        }
-      ],
-      "editor/title": [
-        {
-          "command": "workspace-plugin.create-workspace",
-          "when": "resourceFilename =~ /devfile/"
-        }
-      ],
-      "explorer/context": [
-        {
-          "command": "workspace-plugin.create-workspace",
-          "when": "resourceFilename =~ /devfile/"
-        }
-      ]
-    }
+    ]
   }
 }

--- a/plugins/ext-plugin/src/ext-plugin.ts
+++ b/plugins/ext-plugin/src/ext-plugin.ts
@@ -1,0 +1,18 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as che from '@eclipse-che/plugin';
+/**
+ * Export @eclipse-che/plugin namespace as extensions.getExtension('@eclipse-che/ext-plugin') value
+ */
+export async function start(): Promise<unknown> {
+  const apiObject = che;
+  return apiObject;
+}

--- a/plugins/ext-plugin/tests/ext-plugin.spec.ts
+++ b/plugins/ext-plugin/tests/ext-plugin.spec.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import * as che from '@eclipse-che/plugin';
+import * as extPlugin from '../src/ext-plugin';
+
+describe('Test ExtPlugin', () => {
+  test('start', async () => {
+    (che as any).setWorkspaceOutput({ id: '1234' });
+
+    const api: any = await extPlugin.start();
+    expect(api).toBeDefined();
+    const workspace = await api.workspace.getCurrentWorkspace();
+    expect(workspace.id).toBe('1234');
+  });
+});

--- a/plugins/ext-plugin/tsconfig.json
+++ b/plugins/ext-plugin/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "extends": "../../configs/base.tsconfig",
+    "compilerOptions": {
+        "target": "es5",
+        "lib": [
+            "es6",
+            "webworker"
+        ],
+        "sourceMap": true,
+        "rootDir": "src",
+        "outDir": "lib",
+        "types": [
+            "node", "jest"
+        ]
+    },
+    "include": [
+        "src"
+    ]
+}


### PR DESCRIPTION
### What does this PR do?
Export `@eclipse-che/plugin` namespace through export of VS Code extension export API

clients could lookup getExtension('@eclipse-che.ext-plugin') to grab this namespace

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/108041370-b6145080-703e-11eb-812c-80e6db56441b.mp4




### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18837

### How to test this PR?
Write an example using getExtension('@eclipse-che/ext-plugin') and then for example grab workspace details.
I've created a vscode extension doing this job
```typescript
const eclipseCheExtPlugin = vscode.extensions.getExtension('@eclipse-che.ext-plugin');
if (eclipseCheExtPlugin) {
  // grab user
  const user = await eclipseCheExtPlugin.exports.user.getCurrentUser();
 vscode.window.showInformationMessage(`Eclipse Che user information: id ${user.id} with name ${user.name}`);
} else {
  vscode.window.showWarningMessage('Not running inside che, not displaying any che user information');
}
```

Here to try this VS Code extensionon che.openshift.io
https://che.openshift.io/f?url=https://gist.githubusercontent.com/benoitf/b646af9e1cb9aacc23e3e588e413af47/raw/1f42b0a67bc40ed927a4215e26252fc12c9a3e58/devfile.yaml

or workspaces.openshift.com
https://workspaces.openshift.com/f?url=https://gist.githubusercontent.com/benoitf/b646af9e1cb9aacc23e3e588e413af47/raw/1f42b0a67bc40ed927a4215e26252fc12c9a3e58/devfile.yaml

bring the command palette and search for a `Test` command

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next

Change-Id: I4d8d6c49b6797bd98b76486127ec3e38f243e120
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
