### PR TITLE
fix(tests): Ensure no-unnecessary-type-assertion

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -485,8 +485,8 @@ export class ChePluginServiceImpl implements ChePluginService {
     const components = devfileComponents.filter(component => component.plugin !== undefined);
 
     components.forEach(component => {
-      const id = component.plugin!.url ? this.normalizeId(component.plugin!.url) : component.plugin!.id;
-      const foundIndex = plugins.indexOf(id!);
+      const id = component.plugin!.url ? this.normalizeId(component.plugin!.url) : component.plugin?.id!;
+      const foundIndex = plugins.indexOf(id);
       if (foundIndex >= 0) {
         plugins.splice(foundIndex, 1);
       } else {

--- a/extensions/eclipse-che-theia-preferences-provider-extension/package.json
+++ b/extensions/eclipse-che-theia-preferences-provider-extension/package.json
@@ -24,7 +24,7 @@
     "lint": "if-env SKIP_LINT=true && echo 'skip lint check' || eslint --cache=true --no-error-on-unmatched-pattern=true '{src,tests}/**/*.ts'",
     "lint:fix": "eslint --fix --cache=true --no-error-on-unmatched-pattern=true \"{src,tests}/**/*.{ts,tsx}\"",
     "compile": "tsc",
-    "build": "concurrently -n \"format,lint,compile,test\" -c \"red,green,blue,purple\" \"yarn format\" \"yarn lint\" \"yarn compile\" \"yarn test\"",
+    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue,purple\" \"yarn format\" \"yarn lint\" \"yarn compile\"",
     "test": "if-env SKIP_TEST=true && echo 'skip test' || jest --forceExit"
   },
   "theiaExtensions": [

--- a/extensions/eclipse-che-theia-remote-impl-che-server/package.json
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/package.json
@@ -25,7 +25,8 @@
     "lint": "if-env SKIP_LINT=true && echo 'skip lint check' || eslint --cache=true --no-error-on-unmatched-pattern=true '{src,tests}/**/*.ts'",
     "lint:fix": "eslint --fix --cache=true --no-error-on-unmatched-pattern=true \"{src,tests}/**/*.{ts,tsx}\"",
     "compile": "tsc",
-    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue\" \"yarn format\" \"yarn lint\" \"yarn compile\"",
+    "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue,purple\" \"yarn format\" \"yarn lint\" \"yarn compile\"",
+    "test": "if-env SKIP_TEST=true && echo 'skip test' || jest --forceExit",
     "watch": "tsc -w",
     "publish:next": "yarn publish  --registry=https://registry.npmjs.org/ --no-git-tag-version --new-version 0.0.1-\"$(date +%s)\""
   },

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-devfile-service-impl.spec.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-devfile-service-impl.spec.ts
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 
 import 'reflect-metadata';
 
@@ -55,8 +56,8 @@ describe.only('Test CheServerDevfileServiceImpl', () => {
     expect(devfile).toBeDefined();
 
     // check projects
-    expect(devfile.projects.length).toBe(1);
-    const devfileProject = devfile.projects[0];
+    expect(devfile.projects?.length).toBe(1);
+    const devfileProject = devfile.projects![0];
     expect(devfileProject.name).toBe('console-java-simple');
     expect(devfileProject.git).toStrictEqual({
       checkoutFrom: { revision: 'java1.11' },
@@ -71,9 +72,9 @@ describe.only('Test CheServerDevfileServiceImpl', () => {
     expect(devfileAttributes.persistVolumes).toBe('false');
 
     // check components
-    expect(devfile.components.length).toBe(2);
+    expect(devfile.components?.length).toBe(2);
 
-    const cheRedhatComponent = devfile.components.find(
+    const cheRedhatComponent = devfile.components?.find(
       component => component.plugin !== undefined && component.plugin.id === 'redhat/java/latest'
     );
     expect(cheRedhatComponent).toBeDefined();
@@ -81,7 +82,7 @@ describe.only('Test CheServerDevfileServiceImpl', () => {
     const cheRedhatPlugin = cheRedhatComponent!.plugin!;
     expect(cheRedhatPlugin.id).toBe('redhat/java/latest');
 
-    const mavenComponent = devfile.components.find(component => component.name === 'maven');
+    const mavenComponent = devfile.components?.find(component => component.name === 'maven');
     expect(mavenComponent).toBeDefined();
     const mavenContainer: any = mavenComponent!.container! || {};
     expect(mavenContainer.image).toBe('quay.io/eclipse/che-java11-maven:nightly');

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-endpoint-service-impl.spec.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-endpoint-service-impl.spec.ts
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 
 import 'reflect-metadata';
 


### PR DESCRIPTION
### What does this PR do?
Ensure type assertion is valid in code or we can skip it in tests

### Screenshot/screencast of this PR


### What issues does this PR fix or reference?
Issue reported by a comment in PR https://github.com/eclipse/che-theia/pull/989#issuecomment-780460831

### How to test this PR?
update che-theia-init-sources.yaml to use checkout to `enable-tests`
clone theia and run theia init inside, launch build

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next


Change-Id: I295b8dfcb3c8f483b8fb6b1ed205ecf133494824
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
