### PR TITLE
Use of k8s services for devworkspace operator

### DIFF
--- a/che-theia-init-sources.yml
+++ b/che-theia-init-sources.yml
@@ -20,6 +20,7 @@ sources:
     - extensions/eclipse-che-theia-workspace
     - extensions/eclipse-che-theia-remote-api
     - extensions/eclipse-che-theia-remote-impl-che-server
+    - extensions/eclipse-che-theia-remote-impl-k8s
   plugins:
     - plugins/containers-plugin
     - plugins/ext-plugin

--- a/extensions/eclipse-che-theia-file-sync-tracker/src/browser/sync-process-tracker.ts
+++ b/extensions/eclipse-che-theia-file-sync-tracker/src/browser/sync-process-tracker.ts
@@ -12,11 +12,11 @@ import { Disposable, DisposableCollection } from '@theia/core';
 import { StatusBar, StatusBarAlignment, StatusBarEntry } from '@theia/core/lib/browser/status-bar/status-bar';
 import { inject, injectable } from 'inversify';
 
+import { EndpointService } from '@eclipse-che/theia-remote-api/lib/common/endpoint-service';
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { MessageService } from '@theia/core/lib/common';
 import ReconnectingWebSocket from 'reconnecting-websocket';
 import URI from '@theia/core/lib/common/uri';
-import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
 
 @injectable()
 export class SyncProcessTracker implements FrontendApplicationContribution {
@@ -24,8 +24,8 @@ export class SyncProcessTracker implements FrontendApplicationContribution {
   private statusBar: StatusBar;
   @inject(MessageService)
   protected readonly messageService: MessageService;
-  @inject(WorkspaceService)
-  protected workspaceService: WorkspaceService;
+  @inject(EndpointService)
+  protected endpointService: EndpointService;
   private readonly ID = 'file-synchronization-indicator-id';
   protected readonly statusBarDisposable = new DisposableCollection();
 
@@ -38,9 +38,9 @@ export class SyncProcessTracker implements FrontendApplicationContribution {
   }
 
   async getSyncServiceURL(): Promise<string> {
-    const server = await this.workspaceService.findUniqueEndpointByAttribute('type', 'rsync');
-    if (server) {
-      return new URI(server.url).resolve('track').toString();
+    const endpoints = await this.endpointService.getEndpointsByType('rsync');
+    if (endpoints.length === 1) {
+      return new URI(endpoints[0].url).resolve('track').toString();
     } else {
       return Promise.reject(new Error('Server rsync not found'));
     }

--- a/extensions/eclipse-che-theia-mini-browser/src/node/che-mini-browser-endpoint.ts
+++ b/extensions/eclipse-che-theia-mini-browser/src/node/che-mini-browser-endpoint.ts
@@ -8,28 +8,22 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-import {
-  SERVER_MINI_BROWSER_ATTR_VALUE,
-  SERVER_TYPE_ATTR,
-} from '@eclipse-che/theia-plugin-ext/lib/common/che-server-common';
-
+import { EndpointService } from '@eclipse-che/theia-remote-api/lib/common/endpoint-service';
 import { MiniBrowserEndpoint } from '@theia/mini-browser/lib/node/mini-browser-endpoint';
 import { MiniBrowserEndpoint as MiniBrowserEndpointNS } from '@theia/mini-browser/lib/common/mini-browser-endpoint';
-import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
+import { SERVER_MINI_BROWSER_ATTR_VALUE } from '@eclipse-che/theia-plugin-ext/lib/common/che-server-common';
 import { inject } from 'inversify';
 
 export class CheMiniBrowserEndpoint extends MiniBrowserEndpoint {
-  @inject(WorkspaceService)
-  private workspaceService: WorkspaceService;
+  @inject(EndpointService)
+  private endpointService: EndpointService;
 
   protected async getVirtualHostRegExp(): Promise<RegExp> {
-    const miniBrowserCheEndpoint = await this.workspaceService.findUniqueEndpointByAttribute(
-      SERVER_TYPE_ATTR,
-      SERVER_MINI_BROWSER_ATTR_VALUE
-    );
+    const endpoints = await this.endpointService.getEndpointsByType(SERVER_MINI_BROWSER_ATTR_VALUE);
+
     let miniBrowserCheEndpointHostname: string | undefined;
-    if (miniBrowserCheEndpoint && miniBrowserCheEndpoint.url) {
-      const url = new URL(miniBrowserCheEndpoint.url);
+    if (endpoints.length === 1 && endpoints[0].url) {
+      const url = new URL(endpoints[0].url);
       miniBrowserCheEndpointHostname = url.hostname;
     }
     const pattern =

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-devfile-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-devfile-main.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2018-2020 Red Hat, Inc.
+ * Copyright (c) 2018-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
+
+import {
+  Devfile,
+  DevfileComponentStatus,
+  DevfileService,
+} from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
 
 import { AbstractDialog } from '@theia/core/lib/browser';
 import { CheDevfileMain } from '../common/che-protocol';
@@ -19,11 +25,14 @@ export class CheDevfileMainImpl implements CheDevfileMain {
 
   private readonly windowService: WindowService;
 
+  private readonly devfileService: DevfileService;
+
   private readonly openFactoryLinkDialog: OpenFactoryLinkDialog;
 
   constructor(container: interfaces.Container) {
     this.factoryService = container.get(FactoryService);
     this.windowService = container.get(WindowService);
+    this.devfileService = container.get(DevfileService);
     this.openFactoryLinkDialog = new OpenFactoryLinkDialog(this.windowService);
   }
 
@@ -31,6 +40,18 @@ export class CheDevfileMainImpl implements CheDevfileMain {
     const fileDownloadURI = window.location.origin + '/files/?uri=' + devfilePath;
     const factoryURI = await this.factoryService.getFactoryLink(fileDownloadURI);
     await this.openFactoryWindow(factoryURI);
+  }
+
+  async $get(): Promise<Devfile> {
+    return this.devfileService.get();
+  }
+
+  async $update(updatedDevfile: Devfile): Promise<void> {
+    return this.devfileService.updateDevfile(updatedDevfile);
+  }
+
+  async $getComponentStatuses(): Promise<DevfileComponentStatus[]> {
+    return this.devfileService.getComponentStatuses();
   }
 
   /**

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-webview-environment.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-webview-environment.ts
@@ -8,22 +8,22 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-import { SERVER_TYPE_ATTR, SERVER_WEBVIEWS_ATTR_VALUE } from '../common/che-server-common';
 import { inject, injectable, postConstruct } from 'inversify';
 
+import { EndpointService } from '@eclipse-che/theia-remote-api/lib/common/endpoint-service';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { SERVER_WEBVIEWS_ATTR_VALUE } from '../common/che-server-common';
 import URI from '@theia/core/lib/common/uri';
 import { WebviewEnvironment } from '@theia/plugin-ext/lib/main/browser/webview/webview-environment';
 import { WebviewExternalEndpoint } from '@theia/plugin-ext/lib/main/common/webview-protocol';
-import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
 
 @injectable()
 export class CheWebviewEnvironment extends WebviewEnvironment {
   @inject(EnvVariablesServer)
   protected readonly environments: EnvVariablesServer;
 
-  @inject(WorkspaceService)
-  private workspaceService: WorkspaceService;
+  @inject(EndpointService)
+  private endpointService: EndpointService;
 
   @postConstruct()
   protected async init(): Promise<void> {
@@ -46,13 +46,10 @@ export class CheWebviewEnvironment extends WebviewEnvironment {
   }
 
   protected async getWebviewCheEndpoint(): Promise<string | undefined> {
-    try {
-      const webviewCheEndpoint = await this.workspaceService.findUniqueEndpointByAttribute(
-        SERVER_TYPE_ATTR,
-        SERVER_WEBVIEWS_ATTR_VALUE
-      );
-      return webviewCheEndpoint.url;
-    } catch (error) {
+    const webviewCheEndpoints = await this.endpointService.getEndpointsByType(SERVER_WEBVIEWS_ATTR_VALUE);
+    if (webviewCheEndpoints.length === 1) {
+      return webviewCheEndpoints[0].url;
+    } else {
       return undefined;
     }
   }

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2018-2020 Red Hat, Inc.
+ * Copyright (c) 2018-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -45,7 +45,10 @@ export interface CheWorkspaceMain {
 export interface CheDevfile {}
 
 export interface CheDevfileMain {
+  $get(): Promise<che.devfile.Devfile>;
+  $getComponentStatuses(): Promise<che.devfile.DevfileComponentStatus[]>;
   $createWorkspace(devfilePath: string): Promise<void>;
+  $update(updatedDevfile: che.devfile.Devfile): Promise<void>;
 }
 
 export interface CheSsh {}

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2018-2020 Red Hat, Inc.
+ * Copyright (c) 2018-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -104,6 +104,15 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
     };
 
     const devfile: typeof che.devfile = {
+      get(): Promise<che.devfile.Devfile> {
+        return cheDevfileImpl.get();
+      },
+      update(updatedDevfile: che.devfile.Devfile): Promise<void> {
+        return cheDevfileImpl.update(updatedDevfile);
+      },
+      getComponentStatuses(): Promise<che.devfile.DevfileComponentStatus[]> {
+        return cheDevfileImpl.getComponentStatuses();
+      },
       createWorkspace(devfilePath: string): Promise<void> {
         return cheDevfileImpl.createWorkspace(devfilePath);
       },

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-devfile.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-devfile.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2018-2020 Red Hat, Inc.
+ * Copyright (c) 2018-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,12 +11,25 @@
 import { CheDevfile, CheDevfileMain, PLUGIN_RPC_CONTEXT } from '../common/che-protocol';
 
 import { RPCProtocol } from '@theia/plugin-ext/lib/common/rpc-protocol';
+import { devfile } from '@eclipse-che/plugin';
 
 export class CheDevfileImpl implements CheDevfile {
   private readonly devfileMain: CheDevfileMain;
 
   constructor(rpc: RPCProtocol) {
     this.devfileMain = rpc.getProxy(PLUGIN_RPC_CONTEXT.CHE_DEVFILE_MAIN);
+  }
+
+  async get(): Promise<devfile.Devfile> {
+    return this.devfileMain.$get();
+  }
+
+  async update(updatedDevfile: devfile.Devfile): Promise<void> {
+    return this.devfileMain.$update(updatedDevfile);
+  }
+
+  async getComponentStatuses(): Promise<devfile.DevfileComponentStatus[]> {
+    return this.devfileMain.$getComponentStatuses();
   }
 
   async createWorkspace(devfilePath: string): Promise<void> {

--- a/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
+++ b/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2018-2020 Red Hat, Inc.
+ * Copyright (c) 2018-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,7 @@ declare module '@eclipse-che/plugin' {
     export interface KeyValue {
         [key: string]: string;
     }
-    
+
     export interface RestartWorkspaceOptions {
         prompt?: boolean;
         promptMessage? : string;
@@ -48,6 +48,171 @@ declare module '@eclipse-che/plugin' {
     }
 
     export namespace devfile {
+
+        export interface DevfileComponentStatus {
+            name: string;
+            isUser: boolean;
+            endpoints?: {
+                [endpointName: string]: {
+                    url?: string;
+                };
+            };
+        }
+        export interface DevfileMetadata {
+            attributes?: { [attributeName: string]: string };
+            description?: string;
+            displayName?: string;
+            globalMemoryLimit?: string;
+            icon?: string;
+            name?: string;
+            tags?: string[];
+            version?: string;
+        }
+
+        export interface Devfile {
+            apiVersion: string;
+            attributes?: { [attributeName: string]: string };
+            metadata: DevfileMetadata;
+            projects?: DevfileProject[];
+            components?: DevfileComponent[];
+            commands?: DevfileCommand[];
+        }
+        export interface DevfileCommandGroup {
+            isDefault?: boolean;
+            kind: 'build' | 'run' | 'test' | 'debug';
+        }
+
+        export interface DevfileCommand {
+            apply?: {
+                component: string;
+                group?: DevfileCommandGroup;
+                label?: string;
+            };
+            composite?: {
+                commands: string[];
+                group?: DevfileCommandGroup;
+                label?: string;
+                parallel?: boolean;
+            };
+            exec?: {
+                commandLine?: string;
+                component: string;
+                env?: DevfileComponentEnv[];
+                group?: DevfileCommandGroup;
+                hotReloadCapable?: boolean;
+                label?: string;
+                workingDir?: string;
+            };
+            vscodeLaunch?: {
+                inline?: string;
+                uri?: string;
+                group?: DevfileCommandGroup;
+            };
+            vscodeTask?: {
+                inline?: string;
+                uri?: string;
+                group?: DevfileCommandGroup;
+            };
+            attributes?: { [attributeName: string]: string };
+            id: string;
+        }
+
+        export interface DevfileComponentVolumeMount {
+            name?: string;
+            path?: string;
+        }
+
+        export interface DevfileComponentEnv {
+            name: string;
+            value: string;
+        }
+
+        export interface DevfileComponentEndpoint {
+            attributes?: { [attributeName: string]: string };
+            exposure?: 'public' | 'internal' | 'none';
+            name: string;
+            path?: string;
+            protocol?: 'http' | 'https' | 'ws' | 'wss' | 'tcp' | 'udp';
+            secure?: boolean;
+            targetPort: number;
+        }
+
+        export interface DevfileKubernetesComponent {
+            inlined?: string;
+            uri?: string;
+            endpoints?: DevfileComponentEndpoint[];
+        }
+
+        export interface DevfileKubernetesComponent {
+            inlined?: string;
+            uri?: string;
+            endpoints?: DevfileComponentEndpoint[];
+        }
+
+        export interface DevfileContainerComponent {
+            args?: string[];
+            command?: string[];
+            cpuLimit?: string;
+            cpuRequest?: string;
+            dedicatedPod?: boolean;
+            endpoints?: DevfileComponentEndpoint[];
+            env?: DevfileComponentEnv[];
+            image: string;
+            memoryLimit?: string;
+            memoryRequest?: string;
+            mountSources?: boolean;
+            sourceMapping?: string;
+            volumeMounts?: DevfileComponentVolumeMount[];
+        }
+
+        export interface DevfileV1PluginComponent {
+            id?: string;
+            url?: string;
+            registryUrl?: string;
+            cpuLimit?: string;
+            cpuRequest?: string;
+            endpoints?: DevfileComponentEndpoint[];
+            env?: DevfileComponentEnv[];
+            memoryLimit?: string;
+            memoryRequest?: string;
+            mountSources?: boolean;
+            sourceMapping?: string;
+            volumeMounts?: DevfileComponentVolumeMount[];
+            preferences?: { [preferenceName: string]: unknown };
+        }
+        export interface DevfileComponent {
+            name?: string;
+            container?: DevfileContainerComponent;
+            kubernetes?: DevfileKubernetesComponent;
+            openshift?: DevfileKubernetesComponent;
+            plugin?: DevfileV1PluginComponent;
+            attributes?: { [attributeName: string]: string };
+            volume?: {
+                size?: string;
+            };
+        }
+
+        export interface DevfileProjectInfo {
+            checkoutFrom?: {
+                remote?: string;
+                revision?: string;
+            };
+            remotes: { [remoteName: string]: string };
+        }
+        export interface DevfileProject {
+            name: string;
+            attributes?: { [attributeName: string]: string };
+            clonePath?: string;
+            git?: DevfileProjectInfo;
+            github?: DevfileProjectInfo;
+            zip?: {
+                location: string;
+            };
+            sparseCheckoutDirs?: string[];
+        }
+        export function update(updatedDevfile: Devfile): Promise<void>;
+        export function get(): Promise<Devfile>;
+        export function getComponentStatuses(): Promise<DevfileComponentStatus[]>;
         export function createWorkspace(devfilePath: string): Promise<void>;
     }
 

--- a/extensions/eclipse-che-theia-remote-api/src/common/devfile-service.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/common/devfile-service.ts
@@ -34,6 +34,7 @@ export interface DevfileMetadata {
 
 export interface Devfile {
   apiVersion: string;
+  attributes?: { [attributeName: string]: string };
   metadata: DevfileMetadata;
   projects?: DevfileProject[];
   components?: DevfileComponent[];
@@ -163,7 +164,7 @@ export interface DevfileProjectInfo {
 }
 export interface DevfileProject {
   name: string;
-  attributes: { [attributeName: string]: string };
+  attributes?: { [attributeName: string]: string };
   clonePath?: string;
   git?: DevfileProjectInfo;
   github?: DevfileProjectInfo;

--- a/extensions/eclipse-che-theia-remote-api/src/common/workspace-service.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/common/workspace-service.ts
@@ -60,8 +60,6 @@ export interface WorkspaceService {
   getWorkspaceById(workspaceId: string): Promise<Workspace>;
   getAll(userToken?: string): Promise<Workspace[]>;
   getAllByNamespace(namespace: string, userToken?: string): Promise<Workspace[]>;
-  getCurrentWorkspacesContainers(): Promise<{ [key: string]: Container }>;
-  findUniqueEndpointByAttribute(attributeName: string, attributeValue: string): Promise<Endpoint>;
   updateWorkspace(workspaceId: string, workspace: cheApi.workspace.Workspace): Promise<Workspace>;
   updateWorkspaceActivity(): Promise<void>;
   getWorkspaceSettings(): Promise<WorkspaceSettings>;

--- a/extensions/eclipse-che-theia-remote-impl-che-server/package.json
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/package.json
@@ -27,8 +27,7 @@
     "compile": "tsc",
     "build": "concurrently -n \"format,lint,compile\" -c \"red,green,blue,purple\" \"yarn format\" \"yarn lint\" \"yarn compile\"",
     "test": "if-env SKIP_TEST=true && echo 'skip test' || jest --forceExit",
-    "watch": "tsc -w",
-    "publish:next": "yarn publish  --registry=https://registry.npmjs.org/ --no-git-tag-version --new-version 0.0.1-\"$(date +%s)\""
+    "watch": "tsc -w"
   },
   "license": "EPL-2.0",
   "theiaExtensions": [

--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-devfile-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-devfile-service-impl.ts
@@ -408,7 +408,10 @@ export class CheServerDevfileServiceImpl implements DevfileService {
           remotes,
         };
         let checkoutFromRevision;
-
+        if (!devfileV2Project.attributes) {
+          const projectAttributes = {};
+          devfileV2Project.attributes = projectAttributes;
+        }
         if (source.branch) {
           checkoutFromRevision = source.branch;
           devfileV2Project.attributes['source-origin'] = 'branch';
@@ -443,6 +446,10 @@ export class CheServerDevfileServiceImpl implements DevfileService {
     const gitSource: cheApi.workspace.devfile.Source = {};
 
     if (projectInfo.checkoutFrom) {
+      if (!project.attributes) {
+        const projectAttributes = {};
+        project.attributes = projectAttributes;
+      }
       if (project.attributes['source-origin']) {
         const origin = project.attributes['source-origin'];
         delete project.attributes['source-origin'];

--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-workspace-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-workspace-service-impl.ts
@@ -10,7 +10,6 @@
 
 import {
   Container,
-  Endpoint,
   Workspace,
   WorkspaceService,
   WorkspaceSettings,
@@ -75,48 +74,6 @@ export class CheServerWorkspaceServiceImpl implements WorkspaceService {
     return this.cheServerRemoteApiImpl.getAPI().getSettings();
   }
 
-  public async getCurrentWorkspacesContainers(): Promise<{ [key: string]: Container }> {
-    const result: { [key: string]: Container } = {};
-    try {
-      const workspace = await this.currentWorkspace();
-      const containers = workspace.runtime!.machines;
-      if (containers) {
-        for (const containerName of Object.keys(containers)) {
-          const container: Container = { name: containerName, ...containers[containerName] };
-          container.name = containerName;
-          if (container) {
-            result[containerName] = container;
-          }
-        }
-      }
-    } catch (e) {
-      throw new Error(`Unable to get workspace containers. Cause: ${e}`);
-    }
-    return result;
-  }
-
-  public async findUniqueEndpointByAttribute(attributeName: string, attributeValue: string): Promise<Endpoint> {
-    const containers = await this.getCurrentWorkspacesContainers();
-    try {
-      if (containers) {
-        for (const containerName of Object.keys(containers)) {
-          const servers = containers[containerName].servers;
-          if (servers) {
-            for (const serverName of Object.keys(servers)) {
-              const server = servers[serverName];
-              if (server && server.attributes && server.attributes[attributeName] === attributeValue) {
-                return server;
-              }
-            }
-          }
-        }
-      }
-      return Promise.reject(`Server by attributes '${attributeName}'='${attributeValue}' was not found.`);
-    } catch (e) {
-      return Promise.reject(`Unable to get workspace servers. Cause: ${e}`);
-    }
-  }
-
   public async getContainerList(): Promise<Container[]> {
     const containers: Container[] = [];
     try {
@@ -134,7 +91,7 @@ export class CheServerWorkspaceServiceImpl implements WorkspaceService {
         }
       }
     } catch (e) {
-      throw new Error('Unable to get list workspace containers. Cause: ' + e);
+      throw new Error('Unable to get list of workspace containers. Cause: ' + e);
     }
 
     return containers;

--- a/extensions/eclipse-che-theia-remote-impl-k8s/.gitignore
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/.gitignore
@@ -1,0 +1,2 @@
+lib
+coverage

--- a/extensions/eclipse-che-theia-remote-impl-k8s/package.json
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@eclipse-che/theia-remote-api",
+  "name": "@eclipse-che/theia-remote-impl-k8s",
   "keywords": [
     "theia-extension"
   ],
@@ -12,7 +12,8 @@
     "src"
   ],
   "dependencies": {
-    "@kubernetes/client-node": "^0.12.1"
+    "@kubernetes/client-node": "^0.12.1",
+    "@eclipse-che/theia-remote-api": "^0.0.1"
   },
   "scripts": {
     "prepare": "yarn clean && yarn build",
@@ -28,7 +29,29 @@
   "license": "EPL-2.0",
   "theiaExtensions": [
     {
-      "frontend": "lib/browser/che-remote-api-frontend-module"
+      "backend": "lib/node/k8s-backend-module"
     }
-  ]
+  ],
+  "jest": {
+    "testEnvironment": "node",
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.ts"
+    ],
+    "coverageDirectory": "./coverage",
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "modulePathIgnorePatterns": [
+      "<rootDir>/dist"
+    ],
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json"
+    ]
+  }
 }

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-backend-module.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-backend-module.ts
@@ -1,0 +1,114 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import {
+  CertificateService,
+  cheCertificateServicePath,
+} from '@eclipse-che/theia-remote-api/lib/common/certificate-service';
+import { CheK8SService, cheK8SServicePath } from '@eclipse-che/theia-remote-api/lib/common/k8s-service';
+import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core';
+import { DevfileService, cheDevfileServicePath } from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
+import { EndpointService, cheEndpointServicePath } from '@eclipse-che/theia-remote-api/lib/common/endpoint-service';
+import { FactoryService, cheFactoryServicePath } from '@eclipse-che/theia-remote-api/lib/common/factory-service';
+import { OAuthService, cheOAuthServicePath } from '@eclipse-che/theia-remote-api/lib/common/oauth-service';
+import { SshKeyService, cheSshKeyServicePath } from '@eclipse-che/theia-remote-api/lib/common/ssh-key-service';
+import { TelemetryService, cheTelemetryServicePath } from '@eclipse-che/theia-remote-api/lib/common/telemetry-service';
+import { UserService, cheUserServicePath } from '@eclipse-che/theia-remote-api/lib/common/user-service';
+import { WorkspaceService, cheWorkspaceServicePath } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
+
+import { ContainerModule } from 'inversify';
+import { K8SServiceImpl } from './k8s-service-impl';
+import { K8sCertificateServiceImpl } from './k8s-certificate-service-impl';
+import { K8sDevfileServiceImpl } from './k8s-devfile-service-impl';
+import { K8sEndpointServiceImpl } from './k8s-endpoint-service-impl';
+import { K8sFactoryServiceImpl } from './k8s-factory-service-impl';
+import { K8sOAuthServiceImpl } from './k8s-oauth-service-impl';
+import { K8sSshKeyServiceImpl } from './k8s-ssh-key-service-impl';
+import { K8sTelemetryServiceImpl } from './k8s-telemetry-service-impl';
+import { K8sUserServiceImpl } from './k8s-user-service-impl';
+import { K8sWorkspaceServiceImpl } from './k8s-workspace-service-impl';
+
+export default new ContainerModule(bind => {
+  // skip K8s binding if we're in che-server mode
+  const devWorkspaceName = process.env['DEVWORKSPACE_NAME'];
+  if (!devWorkspaceName) {
+    return;
+  }
+
+  bind(K8sCertificateServiceImpl).toSelf().inSingletonScope();
+  bind(K8sFactoryServiceImpl).toSelf().inSingletonScope();
+  bind(K8sOAuthServiceImpl).toSelf().inSingletonScope();
+  bind(K8sSshKeyServiceImpl).toSelf().inSingletonScope();
+  bind(K8sTelemetryServiceImpl).toSelf().inSingletonScope();
+  bind(K8sUserServiceImpl).toSelf().inSingletonScope();
+  bind(K8sWorkspaceServiceImpl).toSelf().inSingletonScope();
+  bind(K8SServiceImpl).toSelf().inSingletonScope();
+  bind(K8sDevfileServiceImpl).toSelf().inSingletonScope();
+  bind(K8sEndpointServiceImpl).toSelf().inSingletonScope();
+
+  bind(CertificateService).to(K8sCertificateServiceImpl).inSingletonScope();
+  bind(FactoryService).to(K8sFactoryServiceImpl).inSingletonScope();
+  bind(OAuthService).to(K8sOAuthServiceImpl).inSingletonScope();
+  bind(SshKeyService).to(K8sSshKeyServiceImpl).inSingletonScope();
+  bind(TelemetryService).to(K8sTelemetryServiceImpl).inSingletonScope();
+  bind(UserService).to(K8sUserServiceImpl).inSingletonScope();
+  bind(WorkspaceService).to(K8sWorkspaceServiceImpl).inSingletonScope();
+  bind(CheK8SService).to(K8SServiceImpl).inSingletonScope();
+  bind(DevfileService).to(K8sDevfileServiceImpl).inSingletonScope();
+  bind(EndpointService).to(K8sEndpointServiceImpl).inSingletonScope();
+
+  bind(ConnectionHandler)
+    .toDynamicValue(
+      ctx => new JsonRpcConnectionHandler(cheCertificateServicePath, () => ctx.container.get(CertificateService))
+    )
+    .inSingletonScope();
+
+  bind(ConnectionHandler)
+    .toDynamicValue(ctx => new JsonRpcConnectionHandler(cheFactoryServicePath, () => ctx.container.get(FactoryService)))
+    .inSingletonScope();
+
+  bind(ConnectionHandler)
+    .toDynamicValue(ctx => new JsonRpcConnectionHandler(cheOAuthServicePath, () => ctx.container.get(OAuthService)))
+    .inSingletonScope();
+
+  bind(ConnectionHandler)
+    .toDynamicValue(ctx => new JsonRpcConnectionHandler(cheSshKeyServicePath, () => ctx.container.get(SshKeyService)))
+    .inSingletonScope();
+
+  bind(ConnectionHandler)
+    .toDynamicValue(
+      ctx => new JsonRpcConnectionHandler(cheTelemetryServicePath, () => ctx.container.get(TelemetryService))
+    )
+    .inSingletonScope();
+
+  bind(ConnectionHandler)
+    .toDynamicValue(ctx => new JsonRpcConnectionHandler(cheUserServicePath, () => ctx.container.get(UserService)))
+    .inSingletonScope();
+
+  bind(ConnectionHandler)
+    .toDynamicValue(
+      ctx => new JsonRpcConnectionHandler(cheWorkspaceServicePath, () => ctx.container.get(WorkspaceService))
+    )
+    .inSingletonScope();
+
+  bind(ConnectionHandler)
+    .toDynamicValue(ctx => new JsonRpcConnectionHandler(cheK8SServicePath, () => ctx.container.get(CheK8SService)))
+    .inSingletonScope();
+
+  bind(ConnectionHandler)
+    .toDynamicValue(ctx => new JsonRpcConnectionHandler(cheDevfileServicePath, () => ctx.container.get(DevfileService)))
+    .inSingletonScope();
+
+  bind(ConnectionHandler)
+    .toDynamicValue(
+      ctx => new JsonRpcConnectionHandler(cheEndpointServicePath, () => ctx.container.get(EndpointService))
+    )
+    .inSingletonScope();
+});

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-certificate-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-certificate-service-impl.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+import { PUBLIC_CRT_PATH, SS_CRT_PATH } from './k8s-server-https';
+
+import { CertificateService } from '@eclipse-che/theia-remote-api/lib/common/certificate-service';
+import { injectable } from 'inversify';
+
+@injectable()
+export class K8sCertificateServiceImpl implements CertificateService {
+  public async getCertificateAuthority(): Promise<Array<Buffer> | undefined> {
+    const certificateAuthority: Buffer[] = [];
+    const existsSSCRT = await fs.pathExists(SS_CRT_PATH);
+    if (existsSSCRT) {
+      const content = await fs.readFile(SS_CRT_PATH);
+      certificateAuthority.push(content);
+    }
+
+    const existsPublicCrt = await fs.pathExists(PUBLIC_CRT_PATH);
+    if (existsPublicCrt) {
+      const publicCertificates = await fs.readdir(PUBLIC_CRT_PATH);
+      for (const publicCertificate of publicCertificates) {
+        if (publicCertificate.endsWith('.crt')) {
+          const certPath = path.join(PUBLIC_CRT_PATH, publicCertificate);
+          const content = await fs.readFile(certPath);
+          certificateAuthority.push(content);
+        }
+      }
+    }
+
+    return certificateAuthority.length > 0 ? certificateAuthority : undefined;
+  }
+}

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-devfile-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-devfile-service-impl.ts
@@ -1,0 +1,218 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as jsYaml from 'js-yaml';
+import * as k8s from '@kubernetes/client-node';
+
+import {
+  Devfile,
+  DevfileComponentStatus,
+  DevfileService,
+} from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
+import { inject, injectable } from 'inversify';
+
+import { K8SServiceImpl } from './k8s-service-impl';
+import { V1Pod } from '@kubernetes/client-node';
+import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
+
+@injectable()
+export class K8sDevfileServiceImpl implements DevfileService {
+  @inject(K8SServiceImpl)
+  private k8SService: K8SServiceImpl;
+
+  @inject(WorkspaceService)
+  private workspaceService: WorkspaceService;
+
+  async getRaw(): Promise<string> {
+    const devfile = await this.get();
+    const devfileContent = jsYaml.safeDump(devfile);
+    return devfileContent;
+  }
+
+  async get(): Promise<Devfile> {
+    // Grab custom resource object
+    const customObjectsApi = this.k8SService.makeApiClient(k8s.CustomObjectsApi);
+    const group = 'workspace.devfile.io';
+    const version = 'v1alpha2';
+    const workspace = await this.workspaceService.currentWorkspace();
+    const namespace = workspace.namespace || '';
+    const name = workspace.name || '';
+    const response = await customObjectsApi.getNamespacedCustomObject(group, version, namespace, 'devworkspaces', name);
+
+    // devfile is stored inside the dev workspace inside spec.template object
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const devfile = (response.body as any).spec.template as Devfile;
+    return devfile;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getWorkspaceRouting(): Promise<any> {
+    // grab current workspace
+    const workspace = await this.workspaceService.currentWorkspace();
+
+    // get workspace pod
+    const group = 'controller.devfile.io';
+    const version = 'v1alpha1';
+    const namespace = workspace.namespace || '';
+    const customObjectsApi = this.k8SService.makeApiClient(k8s.CustomObjectsApi);
+    const labelSelector = `controller.devfile.io/workspace_id=${workspace.id}`;
+    const response = await customObjectsApi.listNamespacedCustomObject(
+      group,
+      version,
+      namespace,
+      'workspaceroutings',
+      undefined,
+      undefined,
+      undefined,
+      labelSelector
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const workspaceRoutings: any = response.body;
+
+    // check if we have items
+    if (!workspaceRoutings.items) {
+      throw new Error(
+        `Got missing workspace routings objects when searching for objects with label selector ${labelSelector}`
+      );
+    }
+
+    // ensure there is only one item
+    if (!workspaceRoutings.items.length || workspaceRoutings.items.length !== 1) {
+      throw new Error(
+        `Got invalid items when searching for objects with label selector ${labelSelector}. Expected only one resource`
+      );
+    }
+
+    return workspaceRoutings.items[0];
+  }
+
+  async getWorkspacePod(): Promise<V1Pod> {
+    // grab current workspace
+    const workspace = await this.workspaceService.currentWorkspace();
+
+    // get workspace pod
+    const namespace = workspace.namespace || '';
+    const k8sCoreV1Api = this.k8SService.makeApiClient(k8s.CoreV1Api);
+    const labelSelector = `controller.devfile.io/workspace_id=${workspace.id}`;
+    const { body } = await k8sCoreV1Api.listNamespacedPod(
+      namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      labelSelector
+    );
+
+    // ensure there is only one item
+    if (body.items.length !== 1) {
+      throw new Error(
+        `Got invalid items when searching for objects with label selector ${labelSelector}. Expected only one resource`
+      );
+    }
+
+    return body.items[0];
+  }
+
+  async getComponentStatuses(): Promise<DevfileComponentStatus[]> {
+    // grab workspace routing
+    const workspaceRouting = await this.getWorkspaceRouting();
+
+    // grab pod object
+    const workspacePod = await this.getWorkspacePod();
+
+    // get devfile
+    // const devfile = await this.get();
+
+    const componentStatuses: DevfileComponentStatus[] = [];
+
+    // iterate over each container of the pod
+    if (!workspacePod.spec) {
+      return componentStatuses;
+    }
+    workspacePod.spec.containers.forEach(container => {
+      // name
+      const componentStatusName = container.name;
+
+      // isUser or not
+      // FIXME: find a right way of finding if it's coming or not from the devfile or added at runtime
+      // for now, let's make it everything being user
+      const isUser = true;
+
+      // endpoints for this container
+      const componentStatusEndpoints: {
+        [endpointName: string]: {
+          url?: string;
+        };
+      } = {};
+
+      // add endpoints
+      if (
+        workspaceRouting.status &&
+        workspaceRouting.status.exposedEndpoints &&
+        workspaceRouting.status.exposedEndpoints[componentStatusName]
+      ) {
+        // search routing part for component name
+        const endpoints = workspaceRouting.status.exposedEndpoints[componentStatusName];
+
+        // endpoint contains something like:
+        //   {
+        //     "attributes": {
+        //         "cookiesAuthEnabled": "true",
+        //         "type": "ide"
+        //     },
+        //     "name": "theia",
+        //     "url": "http://workspaceeb55021d3cff42e0-theia-3100.192.168.64.31.nip.io"
+        // },
+        Object.keys(endpoints).forEach(endpointKey => {
+          const endpoint = endpoints[endpointKey];
+          componentStatusEndpoints[endpoint.name] = { url: endpoint.url };
+        });
+      }
+      componentStatuses.push({ isUser, name: componentStatusName, endpoints: componentStatusEndpoints });
+    });
+    return componentStatuses;
+  }
+
+  async updateDevfile(devfile: Devfile): Promise<void> {
+    // Grab custom resource object
+    const customObjectsApi = this.k8SService.makeApiClient(k8s.CustomObjectsApi);
+    const group = 'workspace.devfile.io';
+    const version = 'v1alpha2';
+    const workspace = await this.workspaceService.currentWorkspace();
+    const namespace = workspace.namespace || '';
+    const name = workspace.name || '';
+
+    const patch = [
+      {
+        op: 'replace',
+        path: '/spec/template',
+        value: devfile,
+      },
+    ];
+    const options = {
+      headers: {
+        'Content-type': k8s.PatchUtils.PATCH_FORMAT_JSON_PATCH,
+      },
+    };
+    await customObjectsApi.patchNamespacedCustomObject(
+      group,
+      version,
+      namespace,
+      'devworkspaces',
+      name,
+      patch,
+      undefined,
+      undefined,
+      undefined,
+      options
+    );
+  }
+}

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-endpoint-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-endpoint-service-impl.ts
@@ -1,0 +1,87 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import {
+  ComponentExposedEndpoint,
+  EndpointService,
+  ExposedEndpoint,
+} from '@eclipse-che/theia-remote-api/lib/common/endpoint-service';
+import { inject, injectable } from 'inversify';
+
+import { K8sDevfileServiceImpl } from './k8s-devfile-service-impl';
+
+@injectable()
+export class K8sEndpointServiceImpl implements EndpointService {
+  @inject(K8sDevfileServiceImpl)
+  private k8sDevfileService: K8sDevfileServiceImpl;
+
+  async getEndpoints(): Promise<ComponentExposedEndpoint[]> {
+    const componentExposedEndpoints: ComponentExposedEndpoint[] = [];
+    const workspaceRouting = await this.k8sDevfileService.getWorkspaceRouting();
+
+    const specComponentEndpoints = workspaceRouting.spec.endpoints;
+    const statusComponentExposedEndpoints = workspaceRouting.status.exposedEndpoints;
+
+    Object.keys(specComponentEndpoints).forEach(componentName => {
+      const endpoints: ExposedEndpoint[] = [];
+      const specComponentEndpointList = specComponentEndpoints[componentName];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      specComponentEndpointList.forEach((specEndpoint: any) => {
+        // search url from the status/exposedEndpoints part
+        let statusExposedEndpointUrl;
+        const statusComponentExposedEndpoint = statusComponentExposedEndpoints[componentName];
+        let attributes;
+        if (specEndpoint.attributes) {
+          attributes = specEndpoint.attributes;
+        }
+
+        if (statusComponentExposedEndpoint) {
+          const statusExposedEndpoint = statusComponentExposedEndpoint.find(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (sub: any) => sub.name === specEndpoint.name
+          );
+          statusExposedEndpointUrl = statusExposedEndpoint?.url;
+        }
+
+        const componentExposedEndpoint = {
+          attributes,
+          name: specEndpoint.name,
+          component: componentName,
+          url: statusExposedEndpointUrl,
+        };
+        endpoints.push(componentExposedEndpoint);
+      });
+      componentExposedEndpoints.push({ name: componentName, endpoints });
+    });
+    return componentExposedEndpoints;
+  }
+
+  async getEndpointsByName(...names: string[]): Promise<ExposedEndpoint[]> {
+    let exposedEndpoints: ExposedEndpoint[] = [];
+    const all = await this.getEndpoints();
+    all.forEach(componentEndpoint => {
+      const endpoints = componentEndpoint.endpoints;
+      const filteredEndpoints = endpoints.filter(endpoint => names.includes(endpoint.name));
+      exposedEndpoints = exposedEndpoints.concat(filteredEndpoints);
+    });
+    return exposedEndpoints;
+  }
+
+  async getEndpointsByType(type: string): Promise<ExposedEndpoint[]> {
+    let exposedEndpoints: ExposedEndpoint[] = [];
+    const all = await this.getEndpoints();
+    all.forEach(componentEndpoint => {
+      const endpoints = componentEndpoint.endpoints;
+      const filteredEndpoints = endpoints.filter(endpoint => endpoint.attributes && endpoint.attributes.type === type);
+      exposedEndpoints = exposedEndpoints.concat(filteredEndpoints);
+    });
+    return exposedEndpoints;
+  }
+}

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-factory-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-factory-service-impl.ts
@@ -1,0 +1,20 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { FactoryService } from '@eclipse-che/theia-remote-api/lib/common/factory-service';
+import { injectable } from 'inversify';
+
+@injectable()
+export class K8sFactoryServiceImpl implements FactoryService {
+  public async getFactoryLink(url: string): Promise<string> {
+    // should have dashboard URL provided ?
+    throw new Error(`K8sFactoryServiceImpl.getFactoryLink(${url}) not supported`);
+  }
+}

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-oauth-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-oauth-service-impl.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { OAuthService } from '@eclipse-che/theia-remote-api/lib/common/oauth-service';
+import { injectable } from 'inversify';
+
+@injectable()
+export class K8sOAuthServiceImpl implements OAuthService {
+  public async getOAuthToken(oAuthProvider: string, userToken?: string): Promise<string | undefined> {
+    throw new Error(`K8sOAuthServiceImpl.getOAuthToken(${oAuthProvider}, ${userToken}) is not supported`);
+  }
+
+  public async getOAuthProviders(userToken?: string): Promise<string[]> {
+    throw new Error(`K8sOAuthServiceImpl.getOAuthProviders(${userToken}) is not supported`);
+  }
+}

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-server-https.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-server-https.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2018-2020 Red Hat, Inc.
+ * Copyright (c) 2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,7 +8,5 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-export const SERVER_IDE_ATTR_VALUE = 'ide';
-export const SERVER_WEBVIEWS_ATTR_VALUE = 'webview';
-export const SERVER_MINI_BROWSER_ATTR_VALUE = 'mini-browser';
-export const SERVER_IDE_DEV_ATTR_VALUE = 'ide-dev';
+export const SS_CRT_PATH = '/tmp/che/secret/ca.crt';
+export const PUBLIC_CRT_PATH = '/public-certs';

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-service-impl.ts
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as k8s from '@kubernetes/client-node';
+
+import { CheK8SService, K8SRawResponse } from '@eclipse-che/theia-remote-api/lib/common/k8s-service';
+
+import { ApiType } from '@kubernetes/client-node';
+import { injectable } from 'inversify';
+
+const request = require('request');
+
+@injectable()
+export class K8SServiceImpl implements CheK8SService {
+  private kc: k8s.KubeConfig;
+
+  constructor() {
+    this.kc = new k8s.KubeConfig();
+    this.kc.loadFromCluster();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sendRawQuery(requestURL: string, opts: any): Promise<K8SRawResponse> {
+    this.kc.applyToRequest(opts);
+    const cluster = this.kc.getCurrentCluster();
+    if (!cluster) {
+      throw new Error('K8S cluster is not defined');
+    }
+    const URL = `${cluster.server}${requestURL}`;
+
+    return this.makeRequest(URL, opts);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  makeRequest(URL: string, opts: any): Promise<K8SRawResponse> {
+    return new Promise((resolve, reject) => {
+      request.get(URL, opts, (error: string, response: { statusCode: number }, body: string) => {
+        resolve({
+          statusCode: response.statusCode,
+          data: body,
+          error: error,
+        });
+      });
+    });
+  }
+
+  getConfig(): k8s.KubeConfig {
+    return this.kc;
+  }
+
+  makeApiClient<T extends ApiType>(apiClientType: new (server: string) => T): T {
+    return this.kc.makeApiClient(apiClientType);
+  }
+}

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-ssh-key-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-ssh-key-service-impl.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { SshKeyService, SshPair } from '@eclipse-che/theia-remote-api/lib/common/ssh-key-service';
+
+import { injectable } from 'inversify';
+
+@injectable()
+export class K8sSshKeyServiceImpl implements SshKeyService {
+  generate(service: string, name: string): Promise<SshPair> {
+    throw new Error('Unsupported operation');
+  }
+
+  async create(sshKeyPair: SshPair): Promise<void> {
+    console.log('K8sSshKeyServiceImpl.create() is not implemented');
+  }
+
+  get(service: string, name: string): Promise<SshPair> {
+    throw new Error(`K8sSshKeyServiceImpl.get(${service}, ${name}) is not implemented`);
+  }
+
+  getAll(service: string): Promise<SshPair[]> {
+    throw new Error('K8sSshKeyServiceImpl.getAll() is not implemented');
+  }
+
+  async delete(service: string, name: string): Promise<void> {
+    console.log('K8sSshKeyServiceImpl.delete() is not implemented');
+  }
+}

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-telemetry-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-telemetry-service-impl.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { EventProperty, TelemetryClient } from '@eclipse-che/workspace-telemetry-client';
+
+import { TelemetryService } from '@eclipse-che/theia-remote-api/lib/common/telemetry-service';
+import { injectable } from 'inversify';
+
+@injectable()
+export class K8sTelemetryServiceImpl implements TelemetryService {
+  private readonly telemetryClient: TelemetryClient | undefined;
+
+  constructor() {
+    if (process.env.DEVWORKSPACE_TELEMETRY_BACKEND_PORT === undefined) {
+      console.error('Unable to create telemetry client: "DEVWORKSPACE_TELEMETRY_BACKEND_PORT" is not set.');
+    } else {
+      this.telemetryClient = new TelemetryClient(
+        undefined,
+        'http://localhost:' + process.env.DEVWORKSPACE_TELEMETRY_BACKEND_PORT
+      );
+    }
+  }
+
+  async submitTelemetryEvent(
+    id: string,
+    ownerId: string,
+    ip: string,
+    agent: string,
+    resolution: string,
+    properties: [string, string][]
+  ): Promise<void> {
+    if (!this.telemetryClient) {
+      return;
+    }
+
+    await this.telemetryClient.event({
+      id: id,
+      ip: ip,
+      ownerId: ownerId,
+      agent: agent,
+      resolution: resolution,
+      properties: properties.map((prop: [string, string]) => {
+        const eventProp: EventProperty = {
+          id: prop[0],
+          value: prop[1],
+        };
+        return eventProp;
+      }),
+    });
+  }
+
+  async submitTelemetryActivity(): Promise<void> {
+    if (!this.telemetryClient) {
+      return;
+    }
+    await this.telemetryClient.activity();
+  }
+}

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-user-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-user-service-impl.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { Preferences, User, UserService } from '@eclipse-che/theia-remote-api/lib/common/user-service';
+
+import { injectable } from 'inversify';
+
+@injectable()
+export class K8sUserServiceImpl implements UserService {
+  private preferences: { [key: string]: string } = {};
+
+  async getUserId(userToken?: string): Promise<string> {
+    return 'unknown';
+  }
+
+  async getCurrentUser(userToken?: string): Promise<User> {
+    return { id: 'unknown', name: 'unknown' };
+  }
+
+  async getUserPreferences(filter?: string): Promise<Preferences> {
+    return this.preferences;
+  }
+
+  async updateUserPreferences(update: Preferences): Promise<Preferences> {
+    Object.keys(update).forEach(key => {
+      this.preferences[key] = update[key];
+    });
+    return update;
+  }
+
+  async replaceUserPreferences(preferences: Preferences): Promise<Preferences> {
+    this.preferences = preferences;
+    return preferences;
+  }
+
+  async deleteUserPreferences(list?: string[]): Promise<void> {
+    (list || []).forEach(key => {
+      delete this.preferences[key];
+    });
+  }
+}

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-workspace-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-workspace-service-impl.ts
@@ -1,0 +1,123 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import {
+  Container,
+  Workspace,
+  WorkspaceService,
+  WorkspaceSettings,
+} from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
+import { inject, injectable } from 'inversify';
+
+import { DevfileService } from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
+
+@injectable()
+export class K8sWorkspaceServiceImpl implements WorkspaceService {
+  @inject(DevfileService)
+  private devfileService: DevfileService;
+
+  /**
+   * workspaceId - workspace ID taken from environment variable, always the same at workspace lifecycle
+   */
+  private readonly workspaceId: string;
+
+  /**
+   * workspaceName - workspace name taken from environment variable, always the same at workspace lifecycle
+   */
+  private readonly workspaceName: string;
+
+  /**
+   * workspaceNamespace - workspace namespace taken from environment variable, always the same at workspace lifecycle
+   */
+  private readonly workspaceNamespace: string;
+
+  constructor() {
+    if (process.env.DEVWORKSPACE_ID === undefined) {
+      console.error('Environment variable DEVWORKSPACE_ID is not set');
+    } else {
+      this.workspaceId = process.env.DEVWORKSPACE_ID;
+    }
+    if (process.env.DEVWORKSPACE_NAMESPACE === undefined) {
+      console.error('Environment variable DEVWORKSPACE_NAMESPACE is not set');
+    } else {
+      this.workspaceNamespace = process.env.DEVWORKSPACE_NAMESPACE;
+    }
+    if (process.env.DEVWORKSPACE_NAME === undefined) {
+      console.error('Environment variable DEVWORKSPACE_NAME is not set');
+    } else {
+      this.workspaceName = process.env.DEVWORKSPACE_NAME;
+    }
+  }
+
+  public async getCurrentNamespace(): Promise<string> {
+    return this.workspaceNamespace;
+  }
+
+  public async getCurrentWorkspaceId(): Promise<string> {
+    return this.workspaceId;
+  }
+
+  public async currentWorkspace(): Promise<Workspace> {
+    return {
+      id: this.workspaceId,
+      name: this.workspaceName,
+      namespace: this.workspaceNamespace,
+      // running as we're in the pod
+      status: 'RUNNING',
+    };
+  }
+
+  public async getWorkspaceById(workspaceId: string): Promise<Workspace> {
+    throw new Error('workspaceService.getWorkspaceById() not supported');
+  }
+
+  public async getAll(userToken?: string): Promise<Workspace[]> {
+    throw new Error('workspaceService.getAll() not supported');
+  }
+
+  public async getAllByNamespace(namespace: string, userToken?: string): Promise<Workspace[]> {
+    throw new Error(`workspaceService.getAllByNamespace(${namespace}) not supported`);
+  }
+
+  public async updateWorkspace(workspaceId: string, workspace: Workspace): Promise<Workspace> {
+    throw new Error(`workspaceService.updateWorkspace(${workspaceId}) not supported`);
+  }
+
+  public async updateWorkspaceActivity(): Promise<void> {
+    throw new Error('workspaceService.updateWorkspaceActivity() not supported');
+  }
+
+  public async stop(): Promise<void> {
+    // stopping the workspace is changing the state to false
+    throw new Error('workspaceService.stop() not supported');
+  }
+
+  public async getWorkspaceSettings(): Promise<WorkspaceSettings> {
+    console.log('workspaceService.getWorkspaceSettings() not supported');
+    return {};
+  }
+
+  public async getContainerList(): Promise<Container[]> {
+    const containers: Container[] = [];
+    try {
+      const devfile = await this.devfileService.get();
+      (devfile.components || []).forEach(component => {
+        if (component.container && component.name) {
+          const container: Container = { name: component.name };
+          containers.push(container);
+        }
+      });
+    } catch (e) {
+      throw new Error('Unable to get the list of workspace containers. Cause: ' + e);
+    }
+
+    return containers;
+  }
+}

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/get-devworkspace-response-body.json
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/get-devworkspace-response-body.json
@@ -1,0 +1,351 @@
+{
+    "apiVersion": "workspace.devfile.io/v1alpha2",
+    "kind": "DevWorkspace",
+    "metadata": {
+      "annotations": {
+        "controller.devfile.io/timing.components.created": "1612285049877",
+        "controller.devfile.io/timing.components.duration": "1 ms",
+        "controller.devfile.io/timing.components.ready": "1612285049878",
+        "controller.devfile.io/timing.deployment.created": "1612285051868",
+        "controller.devfile.io/timing.deployment.duration": "36898 ms",
+        "controller.devfile.io/timing.deployment.ready": "1612285088766",
+        "controller.devfile.io/timing.duration": "40306 ms",
+        "controller.devfile.io/timing.healthchecks.duration": "1417 ms",
+        "controller.devfile.io/timing.ready": "1612285090183",
+        "controller.devfile.io/timing.routing.created": "1612285050457",
+        "controller.devfile.io/timing.routing.duration": "904 ms",
+        "controller.devfile.io/timing.routing.ready": "1612285051361",
+        "controller.devfile.io/timing.started": "1612285049877",
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"workspace.devfile.io/v1alpha2\",\"kind\":\"DevWorkspace\",\"metadata\":{\"annotations\":{},\"name\":\"theia\",\"namespace\":\"che\"},\"spec\":{\"started\":true,\"template\":{\"commands\":[{\"exec\":{\"commandLine\":\"echo \\\"Hello from $(pwd)\\\"\",\"component\":\"plugin\",\"workingDir\":\"${PROJECTS_ROOT}/project/app\"},\"id\":\"say-hello\"},{\"apply\":{\"component\":\"remote-runtime-injector\"},\"id\":\"inject-theia-in-remote-sidecar\"},{\"apply\":{\"component\":\"vsx-installer\"},\"id\":\"copy-vsx\"}],\"components\":[{\"attributes\":{\"app.kubernetes.io/component\":\"terminal\",\"app.kubernetes.io/name\":\"che-terminal.eclipse.org\",\"app.kubernetes.io/part-of\":\"che.eclipse.org\"},\"container\":{\"args\":[\"--url\",\"0.0.0.0:4444\",\"--pod-selector\",\"controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)\"],\"command\":[\"/go/bin/che-machine-exec\"],\"endpoints\":[{\"attributes\":{\"cookiesAuthEnabled\":\"true\",\"type\":\"terminal\"},\"exposure\":\"public\",\"name\":\"che-mach-exec\",\"protocol\":\"ws\",\"secure\":true,\"targetPort\":4444}],\"image\":\"quay.io/eclipse/che-machine-exec:nightly\"},\"name\":\"terminal\"},{\"name\":\"plugins\",\"volume\":{}},{\"name\":\"remote-endpoint\",\"volume\":{}},{\"attributes\":{\"app.kubernetes.io/component\":\"bootstrapper\",\"app.kubernetes.io/part-of\":\"che-theia.eclipse.org\"},\"container\":{\"args\":[\"/bin/sh\",\"-c\",\"echo \\\"kube api endpoint is https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}\\\" \\u0026\\u0026\\\\\\nKUBE_API_ENDPOINT=\\\"https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}\\\" \\u0026\\u0026\\\\\\nTOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) \\u0026\\u0026\\\\\\necho \\\"calling curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H \\\"Authorization: Bearer ${TOKEN}\\\" $KUBE_API_ENDPOINT\\\" \\u0026\\u0026\\\\\\nWORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H \\\"Authorization: Bearer ${TOKEN}\\\" $KUBE_API_ENDPOINT) \\u0026\\u0026\\\\\\nfor container in $(echo $WORKSPACE | sed -e 's;[[,]\\\\({\\\"attributes\\\":{\\\"app.kubernetes.io\\\\);\\\\n\\\\1;g' | grep '\\\"che-theia.eclipse.org/vscode-extensions\\\":' | grep -e '^{\\\"attributes\\\".*'); do \\\\\\n  dest=$(echo \\\"$container\\\" | sed 's;.*{\\\"name\\\":\\\"THEIA_PLUGINS\\\",\\\"value\\\":\\\"local-dir://\\\\([^\\\"][^\\\"]*\\\\)\\\"}.*;\\\\1;' - ) ;\\\\\\n  urls=$(echo \\\"$container\\\" | sed 's;.*\\\"che-theia.eclipse.org/vscode-extensions\\\":\\\\[\\\\([^]][^]]*\\\\)\\\\]}.*;\\\\1;' - ) ;\\\\\\n  mkdir -p $dest ;\\\\\\n  for url in $(echo $urls | sed 's/[\\\",]/ /g' - ); do \\\\\\n    echo; echo downloading $urls to $dest; curl -L $url \\u003e $dest/$(basename $url) ;\\\\\\n  done \\\\\\ndone \\\\\\n\"],\"image\":\"quay.io/samsahai/curl:latest\",\"volumeMounts\":[{\"name\":\"plugins\",\"path\":\"/plugins\"}]},\"name\":\"vsx-installer\"},{\"attributes\":{\"app.kubernetes.io/component\":\"bootstrapper\",\"app.kubernetes.io/part-of\":\"che-theia.eclipse.org\"},\"container\":{\"env\":[{\"name\":\"PLUGIN_REMOTE_ENDPOINT_EXECUTABLE\",\"value\":\"/remote-endpoint/plugin-remote-endpoint\"},{\"name\":\"REMOTE_ENDPOINT_VOLUME_NAME\",\"value\":\"remote-endpoint\"}],\"image\":\"quay.io/eclipse/che-theia-endpoint-runtime-binary:7.20.0\",\"volumeMounts\":[{\"name\":\"remote-endpoint\",\"path\":\"/remote-endpoint\"}]},\"name\":\"remote-runtime-injector\"},{\"attributes\":{\"app.kubernetes.io/component\":\"editor\",\"app.kubernetes.io/name\":\"che-theia.eclipse.org\",\"app.kubernetes.io/part-of\":\"che.eclipse.org\",\"che-theia.eclipse.org/vscode-extensions\":[\"https://github.com/microsoft/vscode-pull-request-github/releases/download/v0.8.0/vscode-pull-request-github-0.8.0.vsix\"]},\"container\":{\"endpoints\":[{\"attributes\":{\"cookiesAuthEnabled\":\"true\",\"type\":\"ide\"},\"exposure\":\"public\",\"name\":\"theia\",\"protocol\":\"http\",\"secure\":true,\"targetPort\":3100},{\"attributes\":{\"cookiesAuthEnabled\":\"true\",\"type\":\"webview\",\"unique\":\"true\"},\"exposure\":\"public\",\"name\":\"webviews\",\"protocol\":\"http\",\"secure\":true,\"targetPort\":3100},{\"attributes\":{\"type\":\"ide-dev\"},\"exposure\":\"public\",\"name\":\"theia-dev\",\"protocol\":\"http\",\"targetPort\":3130},{\"exposure\":\"public\",\"name\":\"theia-redir-1\",\"protocol\":\"http\",\"targetPort\":13131},{\"exposure\":\"public\",\"name\":\"theia-redir-2\",\"protocol\":\"http\",\"targetPort\":13132},{\"exposure\":\"public\",\"name\":\"theia-redir-3\",\"protocol\":\"http\",\"targetPort\":13133}],\"env\":[{\"name\":\"THEIA_PLUGINS\",\"value\":\"local-dir:///plugins\"},{\"name\":\"HOSTED_PLUGIN_HOSTNAME\",\"value\":\"0.0.0.0\"},{\"name\":\"HOSTED_PLUGIN_PORT\",\"value\":\"3130\"},{\"name\":\"THEIA_HOST\",\"value\":\"0.0.0.0\"}],\"image\":\"quay.io/eclipse/che-theia:next\",\"memoryLimit\":\"512M\",\"mountSources\":true,\"volumeMounts\":[{\"name\":\"plugins\",\"path\":\"/plugins\"}]},\"name\":\"theia-ide\"}],\"events\":{\"preStart\":[\"inject-theia-in-remote-sidecar\",\"copy-vsx\"]},\"projects\":[{\"git\":{\"remotes\":{\"origin\":\"https://github.com/che-samples/web-nodejs-sample.git\"}},\"name\":\"web-nodejs-sample\"}]}}}\n"
+      },
+      "creationTimestamp": "2021-02-02T16:57:14Z",
+      "finalizers": [
+        "storage.controller.devfile.io"
+      ],
+      "generation": 1,
+      "managedFields": [
+        {
+          "apiVersion": "workspace.devfile.io/v1alpha2",
+          "fieldsType": "FieldsV1",
+          "fieldsV1": {
+            "f:metadata": {
+              "f:annotations": {
+                ".": {},
+                "f:kubectl.kubernetes.io/last-applied-configuration": {}
+              }
+            },
+            "f:spec": {
+              ".": {},
+              "f:started": {},
+              "f:template": {
+                ".": {},
+                "f:commands": {},
+                "f:components": {},
+                "f:events": {
+                  ".": {},
+                  "f:preStart": {}
+                },
+                "f:projects": {}
+              }
+            }
+          },
+          "manager": "kubectl-client-side-apply",
+          "operation": "Update",
+          "time": "2021-02-02T16:57:14Z"
+        },
+        {
+          "apiVersion": "workspace.devfile.io/v1alpha2",
+          "fieldsType": "FieldsV1",
+          "fieldsV1": {
+            "f:metadata": {
+              "f:annotations": {
+                "f:controller.devfile.io/timing.components.created": {},
+                "f:controller.devfile.io/timing.components.duration": {},
+                "f:controller.devfile.io/timing.components.ready": {},
+                "f:controller.devfile.io/timing.deployment.created": {},
+                "f:controller.devfile.io/timing.deployment.duration": {},
+                "f:controller.devfile.io/timing.deployment.ready": {},
+                "f:controller.devfile.io/timing.duration": {},
+                "f:controller.devfile.io/timing.healthchecks.duration": {},
+                "f:controller.devfile.io/timing.ready": {},
+                "f:controller.devfile.io/timing.routing.created": {},
+                "f:controller.devfile.io/timing.routing.duration": {},
+                "f:controller.devfile.io/timing.routing.ready": {},
+                "f:controller.devfile.io/timing.started": {}
+              },
+              "f:finalizers": {
+                ".": {},
+                "v:\"storage.controller.devfile.io\"": {}
+              }
+            },
+            "f:status": {
+              ".": {},
+              "f:conditions": {},
+              "f:ideUrl": {},
+              "f:phase": {},
+              "f:workspaceId": {}
+            }
+          },
+          "manager": "devworkspace-controller",
+          "operation": "Update",
+          "time": "2021-02-18T22:57:36Z"
+        }
+      ],
+      "name": "theia",
+      "namespace": "che",
+      "resourceVersion": "644788",
+      "selfLink": "/apis/workspace.devfile.io/v1alpha2/namespaces/che/devworkspaces/theia",
+      "uid": "eb55021d-3cff-42e0-b091-624708504bf7"
+    },
+    "spec": {
+      "started": true,
+      "template": {
+        "commands": [
+          {
+            "exec": {
+              "commandLine": "echo \"Hello from $(pwd)\"",
+              "component": "plugin",
+              "workingDir": "${PROJECTS_ROOT}/project/app"
+            },
+            "id": "say-hello"
+          },
+          {
+            "apply": {
+              "component": "remote-runtime-injector"
+            },
+            "id": "inject-theia-in-remote-sidecar"
+          },
+          {
+            "apply": {
+              "component": "vsx-installer"
+            },
+            "id": "copy-vsx"
+          }
+        ],
+        "components": [
+          {
+            "attributes": {
+              "app.kubernetes.io/component": "terminal",
+              "app.kubernetes.io/name": "che-terminal.eclipse.org",
+              "app.kubernetes.io/part-of": "che.eclipse.org"
+            },
+            "container": {
+              "args": [
+                "--url",
+                "0.0.0.0:4444",
+                "--pod-selector",
+                "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"
+              ],
+              "command": [
+                "/go/bin/che-machine-exec"
+              ],
+              "endpoints": [
+                {
+                  "attributes": {
+                    "cookiesAuthEnabled": "true",
+                    "type": "terminal"
+                  },
+                  "exposure": "public",
+                  "name": "che-mach-exec",
+                  "protocol": "ws",
+                  "secure": true,
+                  "targetPort": 4444
+                }
+              ],
+              "image": "quay.io/eclipse/che-machine-exec:nightly",
+              "sourceMapping": "/projects"
+            },
+            "name": "terminal"
+          },
+          {
+            "name": "plugins",
+            "volume": {}
+          },
+          {
+            "name": "remote-endpoint",
+            "volume": {}
+          },
+          {
+            "attributes": {
+              "app.kubernetes.io/component": "bootstrapper",
+              "app.kubernetes.io/part-of": "che-theia.eclipse.org"
+            },
+            "container": {
+              "args": [
+                "/bin/sh",
+                "-c",
+                "echo \"kube api endpoint is https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}\" &&\\\nKUBE_API_ENDPOINT=\"https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}\" &&\\\nTOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) &&\\\necho \"calling curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H \"Authorization: Bearer ${TOKEN}\" $KUBE_API_ENDPOINT\" &&\\\nWORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H \"Authorization: Bearer ${TOKEN}\" $KUBE_API_ENDPOINT) &&\\\nfor container in $(echo $WORKSPACE | sed -e 's;[[,]\\({\"attributes\":{\"app.kubernetes.io\\);\\n\\1;g' | grep '\"che-theia.eclipse.org/vscode-extensions\":' | grep -e '^{\"attributes\".*'); do \\\n  dest=$(echo \"$container\" | sed 's;.*{\"name\":\"THEIA_PLUGINS\",\"value\":\"local-dir://\\([^\"][^\"]*\\)\"}.*;\\1;' - ) ;\\\n  urls=$(echo \"$container\" | sed 's;.*\"che-theia.eclipse.org/vscode-extensions\":\\[\\([^]][^]]*\\)\\]}.*;\\1;' - ) ;\\\n  mkdir -p $dest ;\\\n  for url in $(echo $urls | sed 's/[\",]/ /g' - ); do \\\n    echo; echo downloading $urls to $dest; curl -L $url > $dest/$(basename $url) ;\\\n  done \\\ndone \\\n"
+              ],
+              "image": "quay.io/samsahai/curl:latest",
+              "sourceMapping": "/projects",
+              "volumeMounts": [
+                {
+                  "name": "plugins",
+                  "path": "/plugins"
+                }
+              ]
+            },
+            "name": "vsx-installer"
+          },
+          {
+            "attributes": {
+              "app.kubernetes.io/component": "bootstrapper",
+              "app.kubernetes.io/part-of": "che-theia.eclipse.org"
+            },
+            "container": {
+              "env": [
+                {
+                  "name": "PLUGIN_REMOTE_ENDPOINT_EXECUTABLE",
+                  "value": "/remote-endpoint/plugin-remote-endpoint"
+                },
+                {
+                  "name": "REMOTE_ENDPOINT_VOLUME_NAME",
+                  "value": "remote-endpoint"
+                }
+              ],
+              "image": "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.20.0",
+              "sourceMapping": "/projects",
+              "volumeMounts": [
+                {
+                  "name": "remote-endpoint",
+                  "path": "/remote-endpoint"
+                }
+              ]
+            },
+            "name": "remote-runtime-injector"
+          },
+          {
+            "attributes": {
+              "app.kubernetes.io/component": "editor",
+              "app.kubernetes.io/name": "che-theia.eclipse.org",
+              "app.kubernetes.io/part-of": "che.eclipse.org",
+              "che-theia.eclipse.org/vscode-extensions": [
+                "https://github.com/microsoft/vscode-pull-request-github/releases/download/v0.8.0/vscode-pull-request-github-0.8.0.vsix"
+              ]
+            },
+            "container": {
+              "endpoints": [
+                {
+                  "attributes": {
+                    "cookiesAuthEnabled": "true",
+                    "type": "ide"
+                  },
+                  "exposure": "public",
+                  "name": "theia",
+                  "protocol": "http",
+                  "secure": true,
+                  "targetPort": 3100
+                },
+                {
+                  "attributes": {
+                    "cookiesAuthEnabled": "true",
+                    "type": "webview",
+                    "unique": "true"
+                  },
+                  "exposure": "public",
+                  "name": "webviews",
+                  "protocol": "http",
+                  "secure": true,
+                  "targetPort": 3100
+                },
+                {
+                  "attributes": {
+                    "type": "ide-dev"
+                  },
+                  "exposure": "public",
+                  "name": "theia-dev",
+                  "protocol": "http",
+                  "targetPort": 3130
+                },
+                {
+                  "exposure": "public",
+                  "name": "theia-redir-1",
+                  "protocol": "http",
+                  "targetPort": 13131
+                },
+                {
+                  "exposure": "public",
+                  "name": "theia-redir-2",
+                  "protocol": "http",
+                  "targetPort": 13132
+                },
+                {
+                  "exposure": "public",
+                  "name": "theia-redir-3",
+                  "protocol": "http",
+                  "targetPort": 13133
+                }
+              ],
+              "env": [
+                {
+                  "name": "THEIA_PLUGINS",
+                  "value": "local-dir:///plugins"
+                },
+                {
+                  "name": "HOSTED_PLUGIN_HOSTNAME",
+                  "value": "0.0.0.0"
+                },
+                {
+                  "name": "HOSTED_PLUGIN_PORT",
+                  "value": "3130"
+                },
+                {
+                  "name": "THEIA_HOST",
+                  "value": "0.0.0.0"
+                }
+              ],
+              "image": "quay.io/eclipse/che-theia:next",
+              "memoryLimit": "512M",
+              "mountSources": true,
+              "sourceMapping": "/projects",
+              "volumeMounts": [
+                {
+                  "name": "plugins",
+                  "path": "/plugins"
+                }
+              ]
+            },
+            "name": "theia-ide"
+          }
+        ],
+        "events": {
+          "preStart": [
+            "inject-theia-in-remote-sidecar",
+            "copy-vsx"
+          ]
+        },
+        "projects": [
+          {
+            "git": {
+              "remotes": {
+                "origin": "https://github.com/che-samples/web-nodejs-sample.git"
+              }
+            },
+            "name": "web-nodejs-sample"
+          }
+        ]
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "lastTransitionTime": "2021-02-18T22:57:36Z",
+          "status": "True",
+          "type": "ServiceAccountReady"
+        },
+        {
+          "lastTransitionTime": "2021-02-18T22:57:36Z",
+          "status": "True",
+          "type": "RoutingReady"
+        },
+        {
+          "lastTransitionTime": "2021-02-18T22:57:36Z",
+          "status": "True",
+          "type": "Ready"
+        }
+      ],
+      "ideUrl": "http://workspaceeb55021d3cff42e0-theia-3100.192.168.64.31.nip.io",
+      "phase": "Running",
+      "workspaceId": "workspaceeb55021d3cff42e0"
+    }
+  }

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/get-pod-response-body.json
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/get-pod-response-body.json
@@ -1,0 +1,1531 @@
+{
+    "apiVersion": "v1",
+    "items": [
+      {
+        "metadata": {
+          "creationTimestamp": "2021-02-02T16:57:31.000Z",
+          "generateName": "workspaceeb55021d3cff42e0-77f7bd767f-",
+          "labels": {
+            "controller.devfile.io/workspace_id": "workspaceeb55021d3cff42e0",
+            "controller.devfile.io/workspace_name": "theia",
+            "pod-template-hash": "77f7bd767f"
+          },
+          "managedFields": [
+            {
+              "apiVersion": "v1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:generateName": {},
+                  "f:labels": {
+                    ".": {},
+                    "f:controller.devfile.io/workspace_id": {},
+                    "f:controller.devfile.io/workspace_name": {},
+                    "f:pod-template-hash": {}
+                  },
+                  "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"3c7e3b78-0ae2-4d45-ac32-342f4664e5a1\"}": {
+                      ".": {},
+                      "f:apiVersion": {},
+                      "f:blockOwnerDeletion": {},
+                      "f:controller": {},
+                      "f:kind": {},
+                      "f:name": {},
+                      "f:uid": {}
+                    }
+                  }
+                },
+                "f:spec": {
+                  "f:containers": {
+                    "k:{\"name\":\"che-rest-apis\"}": {
+                      ".": {},
+                      "f:env": {
+                        ".": {},
+                        "k:{\"name\":\"CHE_WORKSPACE_DEVFILE_YAML_PATH\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_ID\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_NAMESPACE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_RUNTIME_JSON_PATH\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_CREATOR\"}": {
+                          ".": {},
+                          "f:name": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_ID\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_IDLE_TIMEOUT\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_NAMESPACE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        }
+                      },
+                      "f:image": {},
+                      "f:imagePullPolicy": {},
+                      "f:name": {},
+                      "f:ports": {
+                        ".": {},
+                        "k:{\"containerPort\":9999,\"protocol\":\"TCP\"}": {
+                          ".": {},
+                          "f:containerPort": {},
+                          "f:protocol": {}
+                        }
+                      },
+                      "f:resources": {},
+                      "f:terminationMessagePath": {},
+                      "f:terminationMessagePolicy": {},
+                      "f:volumeMounts": {
+                        ".": {},
+                        "k:{\"mountPath\":\"/workspace/\"}": {
+                          ".": {},
+                          "f:mountPath": {},
+                          "f:name": {},
+                          "f:readOnly": {}
+                        }
+                      }
+                    },
+                    "k:{\"name\":\"terminal\"}": {
+                      ".": {},
+                      "f:args": {},
+                      "f:command": {},
+                      "f:env": {
+                        ".": {},
+                        "k:{\"name\":\"CHE_API\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_API_EXTERNAL\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_API_INTERNAL\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_AUTH_ENABLED\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_MACHINE_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_MACHINE_TOKEN\"}": {
+                          ".": {},
+                          "f:name": {}
+                        },
+                        "k:{\"name\":\"CHE_PROJECTS_ROOT\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_ID\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_NAMESPACE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_CREATOR\"}": {
+                          ".": {},
+                          "f:name": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_ID\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_IDLE_TIMEOUT\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_NAMESPACE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"PROJECTS_ROOT\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"PROJECTS_SOURCE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        }
+                      },
+                      "f:image": {},
+                      "f:imagePullPolicy": {},
+                      "f:name": {},
+                      "f:ports": {
+                        ".": {},
+                        "k:{\"containerPort\":4444,\"protocol\":\"TCP\"}": {
+                          ".": {},
+                          "f:containerPort": {},
+                          "f:name": {},
+                          "f:protocol": {}
+                        }
+                      },
+                      "f:resources": {
+                        ".": {},
+                        "f:limits": {
+                          ".": {},
+                          "f:memory": {}
+                        },
+                        "f:requests": {
+                          ".": {},
+                          "f:memory": {}
+                        }
+                      },
+                      "f:terminationMessagePath": {},
+                      "f:terminationMessagePolicy": {},
+                      "f:volumeMounts": {
+                        ".": {},
+                        "k:{\"mountPath\":\"/projects\"}": {
+                          ".": {},
+                          "f:mountPath": {},
+                          "f:name": {},
+                          "f:subPath": {}
+                        }
+                      }
+                    },
+                    "k:{\"name\":\"theia-ide\"}": {
+                      ".": {},
+                      "f:env": {
+                        ".": {},
+                        "k:{\"name\":\"CHE_API\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_API_EXTERNAL\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_API_INTERNAL\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_AUTH_ENABLED\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_MACHINE_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_MACHINE_TOKEN\"}": {
+                          ".": {},
+                          "f:name": {}
+                        },
+                        "k:{\"name\":\"CHE_PROJECTS_ROOT\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_ID\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_NAMESPACE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_CREATOR\"}": {
+                          ".": {},
+                          "f:name": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_ID\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_IDLE_TIMEOUT\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_NAMESPACE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"HOSTED_PLUGIN_HOSTNAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"HOSTED_PLUGIN_PORT\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"PROJECTS_ROOT\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"PROJECTS_SOURCE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"THEIA_HOST\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"THEIA_PLUGINS\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        }
+                      },
+                      "f:image": {},
+                      "f:imagePullPolicy": {},
+                      "f:name": {},
+                      "f:ports": {
+                        ".": {},
+                        "k:{\"containerPort\":3100,\"protocol\":\"TCP\"}": {
+                          ".": {},
+                          "f:containerPort": {},
+                          "f:name": {},
+                          "f:protocol": {}
+                        },
+                        "k:{\"containerPort\":3130,\"protocol\":\"TCP\"}": {
+                          ".": {},
+                          "f:containerPort": {},
+                          "f:name": {},
+                          "f:protocol": {}
+                        },
+                        "k:{\"containerPort\":13131,\"protocol\":\"TCP\"}": {
+                          ".": {},
+                          "f:containerPort": {},
+                          "f:name": {},
+                          "f:protocol": {}
+                        },
+                        "k:{\"containerPort\":13132,\"protocol\":\"TCP\"}": {
+                          ".": {},
+                          "f:containerPort": {},
+                          "f:name": {},
+                          "f:protocol": {}
+                        },
+                        "k:{\"containerPort\":13133,\"protocol\":\"TCP\"}": {
+                          ".": {},
+                          "f:containerPort": {},
+                          "f:name": {},
+                          "f:protocol": {}
+                        }
+                      },
+                      "f:resources": {
+                        ".": {},
+                        "f:limits": {
+                          ".": {},
+                          "f:memory": {}
+                        },
+                        "f:requests": {
+                          ".": {},
+                          "f:memory": {}
+                        }
+                      },
+                      "f:terminationMessagePath": {},
+                      "f:terminationMessagePolicy": {},
+                      "f:volumeMounts": {
+                        ".": {},
+                        "k:{\"mountPath\":\"/plugins\"}": {
+                          ".": {},
+                          "f:mountPath": {},
+                          "f:name": {},
+                          "f:subPath": {}
+                        },
+                        "k:{\"mountPath\":\"/projects\"}": {
+                          ".": {},
+                          "f:mountPath": {},
+                          "f:name": {},
+                          "f:subPath": {}
+                        }
+                      }
+                    }
+                  },
+                  "f:dnsPolicy": {},
+                  "f:enableServiceLinks": {},
+                  "f:initContainers": {
+                    ".": {},
+                    "k:{\"name\":\"remote-runtime-injector\"}": {
+                      ".": {},
+                      "f:env": {
+                        ".": {},
+                        "k:{\"name\":\"CHE_API\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_API_EXTERNAL\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_API_INTERNAL\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_AUTH_ENABLED\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_MACHINE_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_MACHINE_TOKEN\"}": {
+                          ".": {},
+                          "f:name": {}
+                        },
+                        "k:{\"name\":\"CHE_PROJECTS_ROOT\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_ID\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_NAMESPACE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_CREATOR\"}": {
+                          ".": {},
+                          "f:name": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_ID\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_IDLE_TIMEOUT\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_NAMESPACE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"PLUGIN_REMOTE_ENDPOINT_EXECUTABLE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"PROJECTS_ROOT\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"PROJECTS_SOURCE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"REMOTE_ENDPOINT_VOLUME_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        }
+                      },
+                      "f:image": {},
+                      "f:imagePullPolicy": {},
+                      "f:name": {},
+                      "f:resources": {
+                        ".": {},
+                        "f:limits": {
+                          ".": {},
+                          "f:memory": {}
+                        },
+                        "f:requests": {
+                          ".": {},
+                          "f:memory": {}
+                        }
+                      },
+                      "f:terminationMessagePath": {},
+                      "f:terminationMessagePolicy": {},
+                      "f:volumeMounts": {
+                        ".": {},
+                        "k:{\"mountPath\":\"/projects\"}": {
+                          ".": {},
+                          "f:mountPath": {},
+                          "f:name": {},
+                          "f:subPath": {}
+                        },
+                        "k:{\"mountPath\":\"/remote-endpoint\"}": {
+                          ".": {},
+                          "f:mountPath": {},
+                          "f:name": {},
+                          "f:subPath": {}
+                        }
+                      }
+                    },
+                    "k:{\"name\":\"vsx-installer\"}": {
+                      ".": {},
+                      "f:args": {},
+                      "f:env": {
+                        ".": {},
+                        "k:{\"name\":\"CHE_API\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_API_EXTERNAL\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_API_INTERNAL\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_AUTH_ENABLED\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_MACHINE_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_MACHINE_TOKEN\"}": {
+                          ".": {},
+                          "f:name": {}
+                        },
+                        "k:{\"name\":\"CHE_PROJECTS_ROOT\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_ID\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"CHE_WORKSPACE_NAMESPACE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_CREATOR\"}": {
+                          ".": {},
+                          "f:name": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_ID\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_IDLE_TIMEOUT\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_NAME\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"DEVWORKSPACE_NAMESPACE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"PROJECTS_ROOT\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        },
+                        "k:{\"name\":\"PROJECTS_SOURCE\"}": {
+                          ".": {},
+                          "f:name": {},
+                          "f:value": {}
+                        }
+                      },
+                      "f:image": {},
+                      "f:imagePullPolicy": {},
+                      "f:name": {},
+                      "f:resources": {
+                        ".": {},
+                        "f:limits": {
+                          ".": {},
+                          "f:memory": {}
+                        },
+                        "f:requests": {
+                          ".": {},
+                          "f:memory": {}
+                        }
+                      },
+                      "f:terminationMessagePath": {},
+                      "f:terminationMessagePolicy": {},
+                      "f:volumeMounts": {
+                        ".": {},
+                        "k:{\"mountPath\":\"/plugins\"}": {
+                          ".": {},
+                          "f:mountPath": {},
+                          "f:name": {},
+                          "f:subPath": {}
+                        },
+                        "k:{\"mountPath\":\"/projects\"}": {
+                          ".": {},
+                          "f:mountPath": {},
+                          "f:name": {},
+                          "f:subPath": {}
+                        },
+                        "k:{\"mountPath\":\"/tmp/workspace-storage\"}": {
+                          ".": {},
+                          "f:mountPath": {},
+                          "f:name": {},
+                          "f:subPath": {}
+                        }
+                      }
+                    }
+                  },
+                  "f:restartPolicy": {},
+                  "f:schedulerName": {},
+                  "f:securityContext": {
+                    ".": {},
+                    "f:runAsGroup": {},
+                    "f:runAsNonRoot": {},
+                    "f:runAsUser": {}
+                  },
+                  "f:serviceAccount": {},
+                  "f:serviceAccountName": {},
+                  "f:terminationGracePeriodSeconds": {},
+                  "f:volumes": {
+                    ".": {},
+                    "k:{\"name\":\"che-rest-apis-data\"}": {
+                      ".": {},
+                      "f:configMap": {
+                        ".": {},
+                        "f:defaultMode": {},
+                        "f:name": {}
+                      },
+                      "f:name": {}
+                    },
+                    "k:{\"name\":\"claim-devworkspace\"}": {
+                      ".": {},
+                      "f:name": {},
+                      "f:persistentVolumeClaim": {
+                        ".": {},
+                        "f:claimName": {}
+                      }
+                    }
+                  }
+                }
+              },
+              "manager": "kube-controller-manager",
+              "operation": "Update",
+              "time": "2021-02-02T16:57:31.000Z"
+            },
+            {
+              "apiVersion": "v1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  "f:conditions": {
+                    "k:{\"type\":\"ContainersReady\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    },
+                    "k:{\"type\":\"Initialized\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    },
+                    "k:{\"type\":\"Ready\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    }
+                  },
+                  "f:containerStatuses": {},
+                  "f:hostIP": {},
+                  "f:initContainerStatuses": {},
+                  "f:phase": {},
+                  "f:podIP": {},
+                  "f:podIPs": {
+                    ".": {},
+                    "k:{\"ip\":\"172.17.0.4\"}": {
+                      ".": {},
+                      "f:ip": {}
+                    }
+                  },
+                  "f:startTime": {}
+                }
+              },
+              "manager": "kubelet",
+              "operation": "Update",
+              "time": "2021-02-18T07:24:14.000Z"
+            }
+          ],
+          "name": "workspaceeb55021d3cff42e0-77f7bd767f-tld2s",
+          "namespace": "che",
+          "ownerReferences": [
+            {
+              "apiVersion": "apps/v1",
+              "blockOwnerDeletion": true,
+              "controller": true,
+              "kind": "ReplicaSet",
+              "name": "workspaceeb55021d3cff42e0-77f7bd767f",
+              "uid": "3c7e3b78-0ae2-4d45-ac32-342f4664e5a1"
+            }
+          ],
+          "resourceVersion": "603279",
+          "selfLink": "/api/v1/namespaces/che/pods/workspaceeb55021d3cff42e0-77f7bd767f-tld2s",
+          "uid": "0ffe030a-9e1d-4871-a4e5-e805abdea940"
+        },
+        "spec": {
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "CHE_WORKSPACE_NAME",
+                  "value": "theia"
+                },
+                {
+                  "name": "CHE_WORKSPACE_ID",
+                  "value": "workspaceeb55021d3cff42e0"
+                },
+                {
+                  "name": "CHE_WORKSPACE_NAMESPACE",
+                  "value": "che"
+                },
+                {
+                  "name": "CHE_WORKSPACE_RUNTIME_JSON_PATH",
+                  "value": "/workspace/runtime.json"
+                },
+                {
+                  "name": "CHE_WORKSPACE_DEVFILE_YAML_PATH",
+                  "value": "/workspace/devfile.yaml"
+                },
+                {
+                  "name": "DEVWORKSPACE_NAMESPACE",
+                  "value": "che"
+                },
+                {
+                  "name": "DEVWORKSPACE_NAME",
+                  "value": "theia"
+                },
+                {
+                  "name": "DEVWORKSPACE_ID",
+                  "value": "workspaceeb55021d3cff42e0"
+                },
+                {
+                  "name": "DEVWORKSPACE_CREATOR"
+                },
+                {
+                  "name": "DEVWORKSPACE_IDLE_TIMEOUT",
+                  "value": "15m"
+                }
+              ],
+              "image": "quay.io/che-incubator/che-api-sidecar:next",
+              "imagePullPolicy": "Always",
+              "name": "che-rest-apis",
+              "ports": [
+                {
+                  "containerPort": 9999,
+                  "protocol": "TCP"
+                }
+              ],
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/workspace/",
+                  "name": "che-rest-apis-data",
+                  "readOnly": true
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "workspaceeb55021d3cff42e0-sa-token-8jzhh",
+                  "readOnly": true
+                }
+              ]
+            },
+            {
+              "args": [
+                "--url",
+                "0.0.0.0:4444",
+                "--pod-selector",
+                "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"
+              ],
+              "command": [
+                "/go/bin/che-machine-exec"
+              ],
+              "env": [
+                {
+                  "name": "PROJECTS_ROOT",
+                  "value": "/projects"
+                },
+                {
+                  "name": "PROJECTS_SOURCE",
+                  "value": "/projects"
+                },
+                {
+                  "name": "CHE_MACHINE_NAME",
+                  "value": "terminal"
+                },
+                {
+                  "name": "CHE_MACHINE_TOKEN"
+                },
+                {
+                  "name": "CHE_PROJECTS_ROOT",
+                  "value": "/projects"
+                },
+                {
+                  "name": "CHE_API",
+                  "value": "http://localhost:9999/api/"
+                },
+                {
+                  "name": "CHE_API_INTERNAL",
+                  "value": "http://localhost:9999/api/"
+                },
+                {
+                  "name": "CHE_API_EXTERNAL",
+                  "value": "http://localhost:9999/api/"
+                },
+                {
+                  "name": "CHE_WORKSPACE_NAME",
+                  "value": "theia"
+                },
+                {
+                  "name": "CHE_WORKSPACE_ID",
+                  "value": "workspaceeb55021d3cff42e0"
+                },
+                {
+                  "name": "CHE_AUTH_ENABLED",
+                  "value": "false"
+                },
+                {
+                  "name": "CHE_WORKSPACE_NAMESPACE",
+                  "value": "che"
+                },
+                {
+                  "name": "DEVWORKSPACE_NAMESPACE",
+                  "value": "che"
+                },
+                {
+                  "name": "DEVWORKSPACE_NAME",
+                  "value": "theia"
+                },
+                {
+                  "name": "DEVWORKSPACE_ID",
+                  "value": "workspaceeb55021d3cff42e0"
+                },
+                {
+                  "name": "DEVWORKSPACE_CREATOR"
+                },
+                {
+                  "name": "DEVWORKSPACE_IDLE_TIMEOUT",
+                  "value": "15m"
+                }
+              ],
+              "image": "quay.io/eclipse/che-machine-exec:nightly",
+              "imagePullPolicy": "Always",
+              "name": "terminal",
+              "ports": [
+                {
+                  "containerPort": 4444,
+                  "name": "4444-ws",
+                  "protocol": "TCP"
+                }
+              ],
+              "resources": {
+                "limits": {
+                  "memory": "128M"
+                },
+                "requests": {
+                  "memory": "128M"
+                }
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/projects",
+                  "name": "claim-devworkspace",
+                  "subPath": "workspaceeb55021d3cff42e0/projects"
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "workspaceeb55021d3cff42e0-sa-token-8jzhh",
+                  "readOnly": true
+                }
+              ]
+            },
+            {
+              "env": [
+                {
+                  "name": "THEIA_PLUGINS",
+                  "value": "local-dir:///plugins"
+                },
+                {
+                  "name": "HOSTED_PLUGIN_HOSTNAME",
+                  "value": "0.0.0.0"
+                },
+                {
+                  "name": "HOSTED_PLUGIN_PORT",
+                  "value": "3130"
+                },
+                {
+                  "name": "THEIA_HOST",
+                  "value": "0.0.0.0"
+                },
+                {
+                  "name": "PROJECTS_ROOT",
+                  "value": "/projects"
+                },
+                {
+                  "name": "PROJECTS_SOURCE",
+                  "value": "/projects"
+                },
+                {
+                  "name": "CHE_MACHINE_NAME",
+                  "value": "theia-ide"
+                },
+                {
+                  "name": "CHE_MACHINE_TOKEN"
+                },
+                {
+                  "name": "CHE_PROJECTS_ROOT",
+                  "value": "/projects"
+                },
+                {
+                  "name": "CHE_API",
+                  "value": "http://localhost:9999/api/"
+                },
+                {
+                  "name": "CHE_API_INTERNAL",
+                  "value": "http://localhost:9999/api/"
+                },
+                {
+                  "name": "CHE_API_EXTERNAL",
+                  "value": "http://localhost:9999/api/"
+                },
+                {
+                  "name": "CHE_WORKSPACE_NAME",
+                  "value": "theia"
+                },
+                {
+                  "name": "CHE_WORKSPACE_ID",
+                  "value": "workspaceeb55021d3cff42e0"
+                },
+                {
+                  "name": "CHE_AUTH_ENABLED",
+                  "value": "false"
+                },
+                {
+                  "name": "CHE_WORKSPACE_NAMESPACE",
+                  "value": "che"
+                },
+                {
+                  "name": "DEVWORKSPACE_NAMESPACE",
+                  "value": "che"
+                },
+                {
+                  "name": "DEVWORKSPACE_NAME",
+                  "value": "theia"
+                },
+                {
+                  "name": "DEVWORKSPACE_ID",
+                  "value": "workspaceeb55021d3cff42e0"
+                },
+                {
+                  "name": "DEVWORKSPACE_CREATOR"
+                },
+                {
+                  "name": "DEVWORKSPACE_IDLE_TIMEOUT",
+                  "value": "15m"
+                }
+              ],
+              "image": "quay.io/eclipse/che-theia:next",
+              "imagePullPolicy": "Always",
+              "name": "theia-ide",
+              "ports": [
+                {
+                  "containerPort": 3100,
+                  "name": "3100-http",
+                  "protocol": "TCP"
+                },
+                {
+                  "containerPort": 3130,
+                  "name": "3130-http",
+                  "protocol": "TCP"
+                },
+                {
+                  "containerPort": 13131,
+                  "name": "13131-http",
+                  "protocol": "TCP"
+                },
+                {
+                  "containerPort": 13132,
+                  "name": "13132-http",
+                  "protocol": "TCP"
+                },
+                {
+                  "containerPort": 13133,
+                  "name": "13133-http",
+                  "protocol": "TCP"
+                }
+              ],
+              "resources": {
+                "limits": {
+                  "memory": "512M"
+                },
+                "requests": {
+                  "memory": "512M"
+                }
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/plugins",
+                  "name": "claim-devworkspace",
+                  "subPath": "workspaceeb55021d3cff42e0/plugins"
+                },
+                {
+                  "mountPath": "/projects",
+                  "name": "claim-devworkspace",
+                  "subPath": "workspaceeb55021d3cff42e0/projects"
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "workspaceeb55021d3cff42e0-sa-token-8jzhh",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "enableServiceLinks": true,
+          "initContainers": [
+            {
+              "args": [
+                "/bin/sh",
+                "-c",
+                "echo \"kube api endpoint is https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}\" &&\\\nKUBE_API_ENDPOINT=\"https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}\" &&\\\nTOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) &&\\\necho \"calling curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H \"Authorization: Bearer ${TOKEN}\" $KUBE_API_ENDPOINT\" &&\\\nWORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H \"Authorization: Bearer ${TOKEN}\" $KUBE_API_ENDPOINT) &&\\\nfor container in $(echo $WORKSPACE | sed -e 's;[[,]\\({\"attributes\":{\"app.kubernetes.io\\);\\n\\1;g' | grep '\"che-theia.eclipse.org/vscode-extensions\":' | grep -e '^{\"attributes\".*'); do \\\n  dest=$(echo \"$container\" | sed 's;.*{\"name\":\"THEIA_PLUGINS\",\"value\":\"local-dir://\\([^\"][^\"]*\\)\"}.*;\\1;' - ) ;\\\n  urls=$(echo \"$container\" | sed 's;.*\"che-theia.eclipse.org/vscode-extensions\":\\[\\([^]][^]]*\\)\\]}.*;\\1;' - ) ;\\\n  mkdir -p $dest ;\\\n  for url in $(echo $urls | sed 's/[\",]/ /g' - ); do \\\n    echo; echo downloading $urls to $dest; curl -L $url > $dest/$(basename $url) ;\\\n  done \\\ndone \\\n"
+              ],
+              "env": [
+                {
+                  "name": "PROJECTS_ROOT",
+                  "value": "/projects"
+                },
+                {
+                  "name": "PROJECTS_SOURCE",
+                  "value": "/projects"
+                },
+                {
+                  "name": "CHE_MACHINE_NAME",
+                  "value": "vsx-installer"
+                },
+                {
+                  "name": "CHE_MACHINE_TOKEN"
+                },
+                {
+                  "name": "CHE_PROJECTS_ROOT",
+                  "value": "/projects"
+                },
+                {
+                  "name": "CHE_API",
+                  "value": "http://localhost:9999/api/"
+                },
+                {
+                  "name": "CHE_API_INTERNAL",
+                  "value": "http://localhost:9999/api/"
+                },
+                {
+                  "name": "CHE_API_EXTERNAL",
+                  "value": "http://localhost:9999/api/"
+                },
+                {
+                  "name": "CHE_WORKSPACE_NAME",
+                  "value": "theia"
+                },
+                {
+                  "name": "CHE_WORKSPACE_ID",
+                  "value": "workspaceeb55021d3cff42e0"
+                },
+                {
+                  "name": "CHE_AUTH_ENABLED",
+                  "value": "false"
+                },
+                {
+                  "name": "CHE_WORKSPACE_NAMESPACE",
+                  "value": "che"
+                },
+                {
+                  "name": "DEVWORKSPACE_NAMESPACE",
+                  "value": "che"
+                },
+                {
+                  "name": "DEVWORKSPACE_NAME",
+                  "value": "theia"
+                },
+                {
+                  "name": "DEVWORKSPACE_ID",
+                  "value": "workspaceeb55021d3cff42e0"
+                },
+                {
+                  "name": "DEVWORKSPACE_CREATOR"
+                },
+                {
+                  "name": "DEVWORKSPACE_IDLE_TIMEOUT",
+                  "value": "15m"
+                }
+              ],
+              "image": "quay.io/samsahai/curl:latest",
+              "imagePullPolicy": "Always",
+              "name": "vsx-installer",
+              "resources": {
+                "limits": {
+                  "memory": "128M"
+                },
+                "requests": {
+                  "memory": "128M"
+                }
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/tmp/workspace-storage",
+                  "name": "claim-devworkspace",
+                  "subPath": "workspaceeb55021d3cff42e0"
+                },
+                {
+                  "mountPath": "/plugins",
+                  "name": "claim-devworkspace",
+                  "subPath": "workspaceeb55021d3cff42e0/plugins"
+                },
+                {
+                  "mountPath": "/projects",
+                  "name": "claim-devworkspace",
+                  "subPath": "workspaceeb55021d3cff42e0/projects"
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "workspaceeb55021d3cff42e0-sa-token-8jzhh",
+                  "readOnly": true
+                }
+              ]
+            },
+            {
+              "env": [
+                {
+                  "name": "PLUGIN_REMOTE_ENDPOINT_EXECUTABLE",
+                  "value": "/remote-endpoint/plugin-remote-endpoint"
+                },
+                {
+                  "name": "REMOTE_ENDPOINT_VOLUME_NAME",
+                  "value": "remote-endpoint"
+                },
+                {
+                  "name": "PROJECTS_ROOT",
+                  "value": "/projects"
+                },
+                {
+                  "name": "PROJECTS_SOURCE",
+                  "value": "/projects"
+                },
+                {
+                  "name": "CHE_MACHINE_NAME",
+                  "value": "remote-runtime-injector"
+                },
+                {
+                  "name": "CHE_MACHINE_TOKEN"
+                },
+                {
+                  "name": "CHE_PROJECTS_ROOT",
+                  "value": "/projects"
+                },
+                {
+                  "name": "CHE_API",
+                  "value": "http://localhost:9999/api/"
+                },
+                {
+                  "name": "CHE_API_INTERNAL",
+                  "value": "http://localhost:9999/api/"
+                },
+                {
+                  "name": "CHE_API_EXTERNAL",
+                  "value": "http://localhost:9999/api/"
+                },
+                {
+                  "name": "CHE_WORKSPACE_NAME",
+                  "value": "theia"
+                },
+                {
+                  "name": "CHE_WORKSPACE_ID",
+                  "value": "workspaceeb55021d3cff42e0"
+                },
+                {
+                  "name": "CHE_AUTH_ENABLED",
+                  "value": "false"
+                },
+                {
+                  "name": "CHE_WORKSPACE_NAMESPACE",
+                  "value": "che"
+                },
+                {
+                  "name": "DEVWORKSPACE_NAMESPACE",
+                  "value": "che"
+                },
+                {
+                  "name": "DEVWORKSPACE_NAME",
+                  "value": "theia"
+                },
+                {
+                  "name": "DEVWORKSPACE_ID",
+                  "value": "workspaceeb55021d3cff42e0"
+                },
+                {
+                  "name": "DEVWORKSPACE_CREATOR"
+                },
+                {
+                  "name": "DEVWORKSPACE_IDLE_TIMEOUT",
+                  "value": "15m"
+                }
+              ],
+              "image": "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.20.0",
+              "imagePullPolicy": "Always",
+              "name": "remote-runtime-injector",
+              "resources": {
+                "limits": {
+                  "memory": "128M"
+                },
+                "requests": {
+                  "memory": "128M"
+                }
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/remote-endpoint",
+                  "name": "claim-devworkspace",
+                  "subPath": "workspaceeb55021d3cff42e0/remote-endpoint"
+                },
+                {
+                  "mountPath": "/projects",
+                  "name": "claim-devworkspace",
+                  "subPath": "workspaceeb55021d3cff42e0/projects"
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "workspaceeb55021d3cff42e0-sa-token-8jzhh",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "nodeName": "minikube",
+          "preemptionPolicy": "PreemptLowerPriority",
+          "priority": 0,
+          "restartPolicy": "Always",
+          "schedulerName": "default-scheduler",
+          "securityContext": {
+            "runAsGroup": 0,
+            "runAsNonRoot": true,
+            "runAsUser": 1234
+          },
+          "serviceAccount": "workspaceeb55021d3cff42e0-sa",
+          "serviceAccountName": "workspaceeb55021d3cff42e0-sa",
+          "terminationGracePeriodSeconds": 1,
+          "tolerations": [
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/not-ready",
+              "operator": "Exists",
+              "tolerationSeconds": 300
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/unreachable",
+              "operator": "Exists",
+              "tolerationSeconds": 300
+            }
+          ],
+          "volumes": [
+            {
+              "configMap": {
+                "defaultMode": 420,
+                "name": "workspaceeb55021d3cff42e0-che-rest-apis"
+              },
+              "name": "che-rest-apis-data"
+            },
+            {
+              "name": "claim-devworkspace",
+              "persistentVolumeClaim": {
+                "claimName": "claim-devworkspace"
+              }
+            },
+            {
+              "name": "workspaceeb55021d3cff42e0-sa-token-8jzhh",
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "workspaceeb55021d3cff42e0-sa-token-8jzhh"
+              }
+            }
+          ]
+        },
+        "status": {
+          "conditions": [
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2021-02-18T07:23:50.000Z",
+              "status": "True",
+              "type": "Initialized"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2021-02-18T07:24:14.000Z",
+              "status": "True",
+              "type": "Ready"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2021-02-18T07:24:14.000Z",
+              "status": "True",
+              "type": "ContainersReady"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2021-02-02T16:57:31.000Z",
+              "status": "True",
+              "type": "PodScheduled"
+            }
+          ],
+          "containerStatuses": [
+            {
+              "containerID": "docker://f591a4d24b44bc7650e06188761cf33666fcfb0f3c351e621a8edd114ea0709c",
+              "image": "quay.io/che-incubator/che-api-sidecar:next",
+              "imageID": "docker-pullable://quay.io/che-incubator/che-api-sidecar@sha256:8ab222c5d0468f8573055f57585a2ef8f9602168f1709836950dc70f8b95fbd2",
+              "lastState": {
+                "terminated": {
+                  "containerID": "docker://3e2d9b64adaca71d9b6b639a42af4dbd803d4d03310da7064b21cae9ce2ecea9",
+                  "exitCode": 255,
+                  "finishedAt": "2021-02-18T07:22:33.000Z",
+                  "reason": "Error",
+                  "startedAt": "2021-02-02T16:57:44.000Z"
+                }
+              },
+              "name": "che-rest-apis",
+              "ready": true,
+              "restartCount": 1,
+              "started": true,
+              "state": {
+                "running": {
+                  "startedAt": "2021-02-18T07:23:51.000Z"
+                }
+              }
+            },
+            {
+              "containerID": "docker://89e5be381999b89c3bdc4609661b56903d5b0b6636dd7f2c1993e3895e1b5ba2",
+              "image": "quay.io/eclipse/che-machine-exec:nightly",
+              "imageID": "docker-pullable://quay.io/eclipse/che-machine-exec@sha256:7e26ef7a6c7c111870d6b577f5e5ddbfea32d720986de68cf80dce9c1cf6090c",
+              "lastState": {
+                "terminated": {
+                  "containerID": "docker://685b1aa1a088b5973a648f597f0661ad44cdbf5cdc72e9830d2e09f70eb1e929",
+                  "exitCode": 255,
+                  "finishedAt": "2021-02-18T07:22:33.000Z",
+                  "reason": "Error",
+                  "startedAt": "2021-02-02T16:57:50.000Z"
+                }
+              },
+              "name": "terminal",
+              "ready": true,
+              "restartCount": 1,
+              "started": true,
+              "state": {
+                "running": {
+                  "startedAt": "2021-02-18T07:23:57.000Z"
+                }
+              }
+            },
+            {
+              "containerID": "docker://94dcc362d4f87b7b786360b6d3007dbc1ba4db97b80d38e38cc4005be3dd8bdc",
+              "image": "quay.io/eclipse/che-theia:next",
+              "imageID": "docker-pullable://quay.io/eclipse/che-theia@sha256:b8b8985dd1fe090eaea4fa4f7edba60c97f7e931ba5c39b9f7bf606cfbbe9bad",
+              "lastState": {
+                "terminated": {
+                  "containerID": "docker://d90461c10671f25ed0a92f8e2e965d6bf4708bcd2b057cbb13cbd0b6716794a9",
+                  "exitCode": 255,
+                  "finishedAt": "2021-02-18T07:22:33.000Z",
+                  "reason": "Error",
+                  "startedAt": "2021-02-02T16:58:07.000Z"
+                }
+              },
+              "name": "theia-ide",
+              "ready": true,
+              "restartCount": 1,
+              "started": true,
+              "state": {
+                "running": {
+                  "startedAt": "2021-02-18T07:24:14.000Z"
+                }
+              }
+            }
+          ],
+          "hostIP": "192.168.64.31",
+          "initContainerStatuses": [
+            {
+              "containerID": "docker://be11ae6618b5c09894ca35623c6d3ec97b08b8484b0b790642296fdedab5edf5",
+              "image": "quay.io/samsahai/curl:latest",
+              "imageID": "docker-pullable://quay.io/samsahai/curl@sha256:43b0e7ab54b8f20c987eed52c73ed30bb15f235a4d6ca93fcaf526239be0da05",
+              "lastState": {},
+              "name": "vsx-installer",
+              "ready": true,
+              "restartCount": 3,
+              "state": {
+                "terminated": {
+                  "containerID": "docker://be11ae6618b5c09894ca35623c6d3ec97b08b8484b0b790642296fdedab5edf5",
+                  "exitCode": 0,
+                  "finishedAt": "2021-02-18T07:23:46.000Z",
+                  "reason": "Completed",
+                  "startedAt": "2021-02-18T07:23:45.000Z"
+                }
+              }
+            },
+            {
+              "containerID": "docker://1ff3d0d394939eca5f32a0c999a10426614287d650e40055ff503887d5586d31",
+              "image": "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.20.0",
+              "imageID": "docker-pullable://quay.io/eclipse/che-theia-endpoint-runtime-binary@sha256:a618b628130b2f8cac00ea45f7a30da497ca1905699a884d9ed6b623109f702f",
+              "lastState": {},
+              "name": "remote-runtime-injector",
+              "ready": true,
+              "restartCount": 0,
+              "state": {
+                "terminated": {
+                  "containerID": "docker://1ff3d0d394939eca5f32a0c999a10426614287d650e40055ff503887d5586d31",
+                  "exitCode": 0,
+                  "finishedAt": "2021-02-18T07:23:49.000Z",
+                  "reason": "Completed",
+                  "startedAt": "2021-02-18T07:23:48.000Z"
+                }
+              }
+            }
+          ],
+          "phase": "Running",
+          "podIP": "172.17.0.4",
+          "podIPs": [
+            {
+              "ip": "172.17.0.4"
+            }
+          ],
+          "qosClass": "Burstable",
+          "startTime": "2021-02-02T16:57:31.000Z"
+        }
+      }
+    ],
+    "kind": "PodList",
+    "metadata": {
+      "resourceVersion": "677789",
+      "selfLink": "/api/v1/namespaces/che/pods"
+    }
+  }

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/get-workspaceroutings-for-a-workspace-id-body.json
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/get-workspaceroutings-for-a-workspace-id-body.json
@@ -1,0 +1,217 @@
+{
+    "apiVersion": "controller.devfile.io/v1alpha1",
+    "items": [
+      {
+        "apiVersion": "controller.devfile.io/v1alpha1",
+        "kind": "WorkspaceRouting",
+        "metadata": {
+          "creationTimestamp": "2021-02-02T16:57:30Z",
+          "generation": 1,
+          "labels": {
+            "controller.devfile.io/workspace_id": "workspaceeb55021d3cff42e0"
+          },
+          "managedFields": [
+            {
+              "apiVersion": "controller.devfile.io/v1alpha1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:labels": {
+                    ".": {},
+                    "f:controller.devfile.io/workspace_id": {}
+                  },
+                  "f:ownerReferences": {}
+                },
+                "f:spec": {
+                  ".": {},
+                  "f:endpoints": {
+                    ".": {},
+                    "f:che-rest-apis": {},
+                    "f:terminal": {},
+                    "f:theia-ide": {}
+                  },
+                  "f:podSelector": {
+                    ".": {},
+                    "f:controller.devfile.io/workspace_id": {}
+                  },
+                  "f:routingSuffix": {},
+                  "f:workspaceId": {}
+                },
+                "f:status": {
+                  ".": {},
+                  "f:exposedEndpoints": {
+                    ".": {},
+                    "f:terminal": {},
+                    "f:theia-ide": {}
+                  },
+                  "f:phase": {}
+                }
+              },
+              "manager": "devworkspace-controller",
+              "operation": "Update",
+              "time": "2021-02-02T16:57:31Z"
+            }
+          ],
+          "name": "routing-workspaceeb55021d3cff42e0",
+          "namespace": "che",
+          "ownerReferences": [
+            {
+              "apiVersion": "workspace.devfile.io/v1alpha2",
+              "blockOwnerDeletion": true,
+              "controller": true,
+              "kind": "DevWorkspace",
+              "name": "theia",
+              "uid": "eb55021d-3cff-42e0-b091-624708504bf7"
+            }
+          ],
+          "resourceVersion": "2754",
+          "selfLink": "/apis/controller.devfile.io/v1alpha1/namespaces/che/workspaceroutings/routing-workspaceeb55021d3cff42e0",
+          "uid": "40af1119-48e1-440a-ac55-9c279c526e2d"
+        },
+        "spec": {
+          "endpoints": {
+            "che-rest-apis": [
+              {
+                "exposure": "internal",
+                "name": "che-rest-apis",
+                "protocol": "tcp",
+                "targetPort": 9999
+              }
+            ],
+            "terminal": [
+              {
+                "attributes": {
+                  "cookiesAuthEnabled": "true",
+                  "type": "terminal"
+                },
+                "exposure": "public",
+                "name": "che-mach-exec",
+                "protocol": "ws",
+                "secure": true,
+                "targetPort": 4444
+              }
+            ],
+            "theia-ide": [
+              {
+                "attributes": {
+                  "cookiesAuthEnabled": "true",
+                  "type": "ide"
+                },
+                "exposure": "public",
+                "name": "theia",
+                "protocol": "http",
+                "secure": true,
+                "targetPort": 3100
+              },
+              {
+                "attributes": {
+                  "cookiesAuthEnabled": "true",
+                  "type": "webview",
+                  "unique": "true"
+                },
+                "exposure": "public",
+                "name": "webviews",
+                "protocol": "http",
+                "secure": true,
+                "targetPort": 3100
+              },
+              {
+                "attributes": {
+                  "type": "ide-dev"
+                },
+                "exposure": "public",
+                "name": "theia-dev",
+                "protocol": "http",
+                "targetPort": 3130
+              },
+              {
+                "exposure": "public",
+                "name": "theia-redir-1",
+                "protocol": "http",
+                "targetPort": 13131
+              },
+              {
+                "exposure": "public",
+                "name": "theia-redir-2",
+                "protocol": "http",
+                "targetPort": 13132
+              },
+              {
+                "exposure": "public",
+                "name": "theia-redir-3",
+                "protocol": "http",
+                "targetPort": 13133
+              }
+            ]
+          },
+          "podSelector": {
+            "controller.devfile.io/workspace_id": "workspaceeb55021d3cff42e0"
+          },
+          "routingSuffix": "192.168.64.31.nip.io",
+          "workspaceId": "workspaceeb55021d3cff42e0"
+        },
+        "status": {
+          "exposedEndpoints": {
+            "terminal": [
+              {
+                "attributes": {
+                  "cookiesAuthEnabled": "true",
+                  "type": "terminal"
+                },
+                "name": "che-mach-exec",
+                "url": "ws://workspaceeb55021d3cff42e0-che-mach-exec-4444.192.168.64.31.nip.io"
+              }
+            ],
+            "theia-ide": [
+              {
+                "attributes": {
+                  "cookiesAuthEnabled": "true",
+                  "type": "ide"
+                },
+                "name": "theia",
+                "url": "http://workspaceeb55021d3cff42e0-theia-3100.192.168.64.31.nip.io"
+              },
+              {
+                "attributes": {
+                  "cookiesAuthEnabled": "true",
+                  "type": "webview",
+                  "unique": "true"
+                },
+                "name": "webviews",
+                "url": "http://workspaceeb55021d3cff42e0-webviews-3100.192.168.64.31.nip.io"
+              },
+              {
+                "attributes": {
+                  "type": "ide-dev"
+                },
+                "name": "theia-dev",
+                "url": "http://workspaceeb55021d3cff42e0-theia-dev-3130.192.168.64.31.nip.io"
+              },
+              {
+                "attributes": {},
+                "name": "theia-redir-1",
+                "url": "http://workspaceeb55021d3cff42e0-theia-redir-1-13131.192.168.64.31.nip.io"
+              },
+              {
+                "attributes": {},
+                "name": "theia-redir-2",
+                "url": "http://workspaceeb55021d3cff42e0-theia-redir-2-13132.192.168.64.31.nip.io"
+              },
+              {
+                "attributes": {},
+                "name": "theia-redir-3",
+                "url": "http://workspaceeb55021d3cff42e0-theia-redir-3-13133.192.168.64.31.nip.io"
+              }
+            ]
+          },
+          "phase": "Ready"
+        }
+      }
+    ],
+    "kind": "WorkspaceRoutingList",
+    "metadata": {
+      "continue": "",
+      "resourceVersion": "659254",
+      "selfLink": "/apis/controller.devfile.io/v1alpha1/namespaces/che/workspaceroutings"
+    }
+  }

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/workspace-routing-object.json
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/workspace-routing-object.json
@@ -1,0 +1,206 @@
+    {
+        "apiVersion": "controller.devfile.io/v1alpha1",
+        "kind": "WorkspaceRouting",
+        "metadata": {
+            "creationTimestamp": "2021-02-02T16:57:30Z",
+            "generation": 1,
+            "labels": {
+                "controller.devfile.io/workspace_id": "workspaceeb55021d3cff42e0"
+            },
+            "managedFields": [
+                {
+                    "apiVersion": "controller.devfile.io/v1alpha1",
+                    "fieldsType": "FieldsV1",
+                    "fieldsV1": {
+                        "f:metadata": {
+                            "f:labels": {
+                                ".": {},
+                                "f:controller.devfile.io/workspace_id": {}
+                            },
+                            "f:ownerReferences": {}
+                        },
+                        "f:spec": {
+                            ".": {},
+                            "f:endpoints": {
+                                ".": {},
+                                "f:che-rest-apis": {},
+                                "f:terminal": {},
+                                "f:theia-ide": {}
+                            },
+                            "f:podSelector": {
+                                ".": {},
+                                "f:controller.devfile.io/workspace_id": {}
+                            },
+                            "f:routingSuffix": {},
+                            "f:workspaceId": {}
+                        },
+                        "f:status": {
+                            ".": {},
+                            "f:exposedEndpoints": {
+                                ".": {},
+                                "f:terminal": {},
+                                "f:theia-ide": {}
+                            },
+                            "f:phase": {}
+                        }
+                    },
+                    "manager": "devworkspace-controller",
+                    "operation": "Update",
+                    "time": "2021-02-02T16:57:31Z"
+                }
+            ],
+            "name": "routing-workspaceeb55021d3cff42e0",
+            "namespace": "che",
+            "ownerReferences": [
+                {
+                    "apiVersion": "workspace.devfile.io/v1alpha2",
+                    "blockOwnerDeletion": true,
+                    "controller": true,
+                    "kind": "DevWorkspace",
+                    "name": "theia",
+                    "uid": "eb55021d-3cff-42e0-b091-624708504bf7"
+                }
+            ],
+            "resourceVersion": "2754",
+            "selfLink": "/apis/controller.devfile.io/v1alpha1/namespaces/che/workspaceroutings/routing-workspaceeb55021d3cff42e0",
+            "uid": "40af1119-48e1-440a-ac55-9c279c526e2d"
+        },
+        "spec": {
+            "endpoints": {
+                "che-rest-apis": [
+                    {
+                        "exposure": "internal",
+                        "name": "che-rest-apis",
+                        "protocol": "tcp",
+                        "targetPort": 9999
+                    }
+                ],
+                "terminal": [
+                    {
+                        "attributes": {
+                            "cookiesAuthEnabled": "true",
+                            "type": "terminal"
+                        },
+                        "exposure": "public",
+                        "name": "che-mach-exec",
+                        "protocol": "ws",
+                        "secure": true,
+                        "targetPort": 4444
+                    }
+                ],
+                "theia-ide": [
+                    {
+                        "attributes": {
+                            "cookiesAuthEnabled": "true",
+                            "type": "ide"
+                        },
+                        "exposure": "public",
+                        "name": "theia",
+                        "protocol": "http",
+                        "secure": true,
+                        "targetPort": 3100
+                    },
+                    {
+                        "attributes": {
+                            "cookiesAuthEnabled": "true",
+                            "type": "webview",
+                            "unique": "true"
+                        },
+                        "exposure": "public",
+                        "name": "webviews",
+                        "protocol": "http",
+                        "secure": true,
+                        "targetPort": 3100
+                    },
+                    {
+                        "attributes": {
+                            "type": "ide-dev"
+                        },
+                        "exposure": "public",
+                        "name": "theia-dev",
+                        "protocol": "http",
+                        "targetPort": 3130
+                    },
+                    {
+                        "exposure": "public",
+                        "name": "theia-redir-1",
+                        "protocol": "http",
+                        "targetPort": 13131
+                    },
+                    {
+                        "exposure": "public",
+                        "name": "theia-redir-2",
+                        "protocol": "http",
+                        "targetPort": 13132
+                    },
+                    {
+                        "exposure": "public",
+                        "name": "theia-redir-3",
+                        "protocol": "http",
+                        "targetPort": 13133
+                    }
+                ]
+            },
+            "podSelector": {
+                "controller.devfile.io/workspace_id": "workspaceeb55021d3cff42e0"
+            },
+            "routingSuffix": "192.168.64.31.nip.io",
+            "workspaceId": "workspaceeb55021d3cff42e0"
+        },
+        "status": {
+            "exposedEndpoints": {
+                "terminal": [
+                    {
+                        "attributes": {
+                            "cookiesAuthEnabled": "true",
+                            "type": "terminal"
+                        },
+                        "name": "che-mach-exec",
+                        "url": "ws://workspaceeb55021d3cff42e0-che-mach-exec-4444.192.168.64.31.nip.io"
+                    }
+                ],
+                "theia-ide": [
+                    {
+                        "attributes": {
+                            "cookiesAuthEnabled": "true",
+                            "type": "ide"
+                        },
+                        "name": "theia",
+                        "url": "http://workspaceeb55021d3cff42e0-theia-3100.192.168.64.31.nip.io"
+                    },
+                    {
+                        "attributes": {
+                            "cookiesAuthEnabled": "true",
+                            "type": "webview",
+                            "unique": "true"
+                        },
+                        "name": "webviews",
+                        "url": "http://workspaceeb55021d3cff42e0-webviews-3100.192.168.64.31.nip.io"
+                    },
+                    {
+                        "attributes": {
+                            "type": "ide-dev"
+                        },
+                        "name": "theia-dev",
+                        "url": "http://workspaceeb55021d3cff42e0-theia-dev-3130.192.168.64.31.nip.io"
+                    },
+                    {
+                        "attributes": {},
+                        "name": "theia-redir-1",
+                        "url": "http://workspaceeb55021d3cff42e0-theia-redir-1-13131.192.168.64.31.nip.io"
+                    },
+                    {
+                        "attributes": {},
+                        "name": "theia-redir-2",
+                        "url": "http://workspaceeb55021d3cff42e0-theia-redir-2-13132.192.168.64.31.nip.io"
+                    },
+                    {
+                        "attributes": {},
+                        "name": "theia-redir-3",
+                        "url": "http://workspaceeb55021d3cff42e0-theia-redir-3-13133.192.168.64.31.nip.io"
+                    }
+                ]
+            },
+            "phase": "Ready"
+        }
+    }

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/node/k8s-devfile-service-impl.spec.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/node/k8s-devfile-service-impl.spec.ts
@@ -1,0 +1,164 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import 'reflect-metadata';
+
+import * as fs from 'fs-extra';
+import * as jsYaml from 'js-yaml';
+import * as path from 'path';
+
+import { Devfile, DevfileComponent, DevfileProject } from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
+
+import { Container } from 'inversify';
+import { K8SServiceImpl } from '../..//src/node/k8s-service-impl';
+import { K8sDevfileServiceImpl } from '../../src/node/k8s-devfile-service-impl';
+import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
+
+describe('Test K8sDevfileServiceImpl', () => {
+  let container: Container;
+
+  let k8sDevfileServiceImpl: K8sDevfileServiceImpl;
+
+  const k8sServiceMakeApiClientMethod = jest.fn();
+  const k8sServiceMock = {
+    makeApiClient: k8sServiceMakeApiClientMethod,
+  } as any;
+  const customObjectsApiMockGetNamespacedCustomObjectMethod = jest.fn();
+  const listNamespacedMockCustomObjectMethod = jest.fn();
+  const customObjectsApiMock = {
+    getNamespacedCustomObject: customObjectsApiMockGetNamespacedCustomObjectMethod,
+    listNamespacedCustomObject: listNamespacedMockCustomObjectMethod,
+  };
+
+  const workspaceServiceCurrentWorkspaceMethod = jest.fn();
+  const workspaceService = {
+    currentWorkspace: workspaceServiceCurrentWorkspaceMethod,
+  } as any;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(WorkspaceService).toConstantValue(workspaceService);
+    container.bind(K8sDevfileServiceImpl).toSelf().inSingletonScope();
+    container.bind(K8SServiceImpl).toConstantValue(k8sServiceMock);
+    k8sServiceMakeApiClientMethod.mockReturnValueOnce(customObjectsApiMock);
+    k8sDevfileServiceImpl = container.get(K8sDevfileServiceImpl);
+  });
+
+  test('get', async () => {
+    const devWorkspaceJsonPath = path.resolve(__dirname, '..', '_data', 'get-devworkspace-response-body.json');
+    const devWorkspaceJsonContent = await fs.readFile(devWorkspaceJsonPath, 'utf-8');
+    const devWorkspaceJson = JSON.parse(devWorkspaceJsonContent);
+    workspaceServiceCurrentWorkspaceMethod.mockResolvedValue({
+      name: 'fake-workspace-name',
+      namespace: 'fake-workspace-namespace',
+    });
+
+    customObjectsApiMockGetNamespacedCustomObjectMethod.mockReturnValue({ body: devWorkspaceJson });
+
+    const devfile = await k8sDevfileServiceImpl.get();
+    expect(devfile).toBeDefined();
+
+    expect(customObjectsApiMockGetNamespacedCustomObjectMethod).toBeCalledWith(
+      'workspace.devfile.io',
+      'v1alpha2',
+      'fake-workspace-namespace',
+      'devworkspaces',
+      'fake-workspace-name'
+    );
+
+    // check projects
+    expect(devfile.projects?.length).toBe(1);
+    let devfileProject: DevfileProject;
+    if (devfile.projects && devfile.projects.length > 0) {
+      devfileProject = devfile.projects[0];
+    } else {
+      fail('Did not found a project in the devfile');
+    }
+    expect(devfileProject.name).toBe('web-nodejs-sample');
+    expect(devfileProject.git).toStrictEqual({
+      remotes: { origin: 'https://github.com/che-samples/web-nodejs-sample.git' },
+    });
+
+    // check components
+    expect(devfile.components?.length).toBe(6);
+    let devfileComponent: DevfileComponent;
+    if (devfile.components && devfile.components.length > 0) {
+      devfileComponent = devfile.components[0];
+    } else {
+      fail('Did not found a component in the devfile');
+    }
+    expect(devfileComponent.name).toBe('terminal');
+    expect(devfileComponent.container).toBeDefined();
+    expect(devfileComponent.container?.image).toBe('quay.io/eclipse/che-machine-exec:nightly');
+  });
+
+  test('getRaw', async () => {
+    const devWorkspaceJsonPath = path.resolve(__dirname, '..', '_data', 'get-devworkspace-response-body.json');
+    const devWorkspaceJsonContent = await fs.readFile(devWorkspaceJsonPath, 'utf-8');
+    const devWorkspaceJson = JSON.parse(devWorkspaceJsonContent);
+    workspaceServiceCurrentWorkspaceMethod.mockResolvedValue({
+      name: 'fake-workspace-name',
+      namespace: 'fake-workspace-namespace',
+    });
+
+    customObjectsApiMockGetNamespacedCustomObjectMethod.mockReturnValue({ body: devWorkspaceJson });
+
+    const devfileYaml = await k8sDevfileServiceImpl.getRaw();
+    expect(devfileYaml).toBeDefined();
+    // able to convert result with jsYaml
+    const devfileObject = jsYaml.load(devfileYaml) as Devfile;
+
+    // ensure yaml was correct to be converted to be a devfile
+    expect(devfileObject.projects?.length).toBe(1);
+    expect(devfileObject.components?.length).toBe(6);
+  });
+
+  test('getComponentStatus', async () => {
+    // mock workspace routing
+    const workspaceRoutingJsonPath = path.resolve(
+      __dirname,
+      '..',
+      '_data',
+      'get-workspaceroutings-for-a-workspace-id-body.json'
+    );
+    const workspaceRoutingJsonContent = await fs.readFile(workspaceRoutingJsonPath, 'utf-8');
+    const workspaceRoutingJson = JSON.parse(workspaceRoutingJsonContent);
+    workspaceServiceCurrentWorkspaceMethod.mockResolvedValue({
+      name: 'fake-workspace-name',
+      namespace: 'fake-workspace-namespace',
+    });
+
+    listNamespacedMockCustomObjectMethod.mockReturnValue({ body: workspaceRoutingJson });
+
+    // mock pod
+    const listNamespacedPodMockMethod = jest.fn();
+    const coreV1ApiMock = {
+      listNamespacedPod: listNamespacedPodMockMethod,
+    };
+    k8sServiceMakeApiClientMethod.mockReturnValueOnce(coreV1ApiMock);
+    const workspacePodJsonPath = path.resolve(__dirname, '..', '_data', 'get-pod-response-body.json');
+    const workspacePodJsonContent = await fs.readFile(workspacePodJsonPath, 'utf-8');
+    const workspacePodJson = JSON.parse(workspacePodJsonContent);
+
+    listNamespacedPodMockMethod.mockReturnValueOnce({ body: workspacePodJson });
+
+    const componentStatuses = await k8sDevfileServiceImpl.getComponentStatuses();
+
+    expect(componentStatuses.length).toBe(3);
+
+    const theiaComponent = componentStatuses.find(component => component.name === 'theia-ide');
+    expect(theiaComponent).toBeDefined();
+    const theiaEndpoints = theiaComponent?.endpoints || {};
+    expect(theiaEndpoints['theia']?.url).toBe('http://workspaceeb55021d3cff42e0-theia-3100.192.168.64.31.nip.io');
+  });
+});

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/node/k8s-endpoint-service-impl.spec.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/node/k8s-endpoint-service-impl.spec.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import 'reflect-metadata';
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+import { Container } from 'inversify';
+import { K8sDevfileServiceImpl } from '../../src/node/k8s-devfile-service-impl';
+import { K8sEndpointServiceImpl } from '../../src/node/k8s-endpoint-service-impl';
+
+describe.only('Test K8sEndpointServiceImpl', () => {
+  let container: Container;
+
+  let k8sEndpointServiceImpl: K8sEndpointServiceImpl;
+
+  const getWorkspaceRoutingMethod = jest.fn();
+  const k8sDevfileServiceImplMock = {
+    getWorkspaceRouting: getWorkspaceRoutingMethod,
+  } as any;
+
+  beforeEach(async () => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(K8sEndpointServiceImpl).toSelf().inSingletonScope();
+    container.bind(K8sDevfileServiceImpl).toConstantValue(k8sDevfileServiceImplMock);
+    k8sEndpointServiceImpl = container.get(K8sEndpointServiceImpl);
+    const workspaceRoutingJsonPath = path.resolve(__dirname, '..', '_data', 'workspace-routing-object.json');
+    const workspaceRoutingJsonContent = await fs.readFile(workspaceRoutingJsonPath, 'utf-8');
+    const workspaceRoutingJson = JSON.parse(workspaceRoutingJsonContent);
+    getWorkspaceRoutingMethod.mockReturnValue(workspaceRoutingJson);
+  });
+
+  test('getEndpointsByType', async () => {
+    const ideEndpoints = await k8sEndpointServiceImpl.getEndpointsByType('ide');
+
+    expect(ideEndpoints).toBeDefined();
+    expect(ideEndpoints.length).toBe(1);
+    const ideEndpoint = ideEndpoints[0];
+
+    expect(ideEndpoint.name).toBe('theia');
+    expect(ideEndpoint.url).toBe('http://workspaceeb55021d3cff42e0-theia-3100.192.168.64.31.nip.io');
+    expect(ideEndpoint.component).toBe('theia-ide');
+  });
+
+  test('getEndpointsByName', async () => {
+    const ideEndpoints = await k8sEndpointServiceImpl.getEndpointsByName('theia');
+
+    expect(ideEndpoints).toBeDefined();
+    expect(ideEndpoints.length).toBe(1);
+    const ideEndpoint = ideEndpoints[0];
+
+    expect(ideEndpoint.name).toBe('theia');
+    expect(ideEndpoint.url).toBe('http://workspaceeb55021d3cff42e0-theia-3100.192.168.64.31.nip.io');
+    expect(ideEndpoint.component).toBe('theia-ide');
+  });
+});

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tsconfig.json
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../configs/base.tsconfig.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "lib": [
+      "es6",
+      "dom"
+    ],
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
### What does this PR do?
Introduce k8s implementation of service retrieval.
if DEVWORKSPACE_ID environment variable is set --> bind K8s service implementation
else: bind the che-server rest API implementation


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18874


### How to test this PR?
1. It shouldn't change anything if we use che-server REST api implementation.
2. Starts che with devworkspace engine  (chectl) or just use devworkspace operator deploy script (no che at all) and use theia next flattened example and replace theia image by the one built there.
 

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next

Change-Id: I94a62e17b2e986e7338bf4666c056bd0e46b735c
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
