### PR TITLE
Add Github action for test coverage

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,12 +30,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       name: Checkout che-theia source code
+      with:
+        fetch-depth: "0"
     - uses: actions/setup-node@v1
       name: Configuring nodejs 10.x version
       with:
         node-version: '12.x'
     - name: build
       run: yarn
+    - name: Test Coverage
+      uses: codecov/codecov-action@v1
   docker-build:
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 <div id="badges" align="center">
 
   [![Build Status](https://github.com/eclipse/che-theia/workflows/Build%20&%20Publish%20%60next%60/badge.svg)](https://github.com/eclipse/che-theia/actions?query=workflow%3A%22Build+%26+Publish+%60next%60%22)
+  [![Test Coverage](https://img.shields.io/codecov/c/github/eclipse/che-theia)](https://codecov.io/gh/eclipse/che-theia)
   [![mattermost](https://img.shields.io/badge/chat-on%20mattermost-blue.svg)](https://mattermost.eclipse.org/eclipse/channels/eclipse-che)
   [![Open questions](https://img.shields.io/badge/Open-questions-blue.svg?style=flat-curved)](https://github.com/eclipse/che/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aarea%2Feditor%2Fche-theia+label%3Akind%2Fquestion+)
   [![Open bugs](https://img.shields.io/badge/Open-bugs-red.svg?style=flat-curved)](https://github.com/eclipse/che/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aarea%2Feditor%2Fche-theia+label%3Akind%2Fbug+)


### PR DESCRIPTION
### What does this PR do?
Provides an ability to generate test coverage report and upload it to https://codecov.io/gh

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### Screenshot/screencast of this PR

![Add Github action for test coverage by vzhukovs · Pull Request #1000 · eclipse:che-theia 2021-02-23 00-04-41](https://user-images.githubusercontent.com/1968177/108776234-cd859900-756a-11eb-91f3-5d4b73d4c6ce.jpg)


### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/18844


### How to test this PR?
There should be two new Github Actions that perform test coverage report generation.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
