### PR TITLE
Backport: Use plugin registry public URI for icons

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-plugin-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-plugin-protocol.ts
@@ -11,8 +11,14 @@
 import { JsonRpcServer } from '@theia/core';
 
 export interface ChePluginRegistry {
+  // Display name
   name: string;
+  // Registry URI
+  // For default registry it's internal URI, taken from workspace settings
   uri: string;
+  // Public URI to access the registry resources from browser
+  // If publicUri is not defined, internal ChePluginRegistry:uri is used
+  publicUri?: string;
 }
 
 export interface ChePlugin {

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -48,6 +48,18 @@ export interface ChePluginMetadataInternal {
   };
 }
 
+/**
+ * Workspace Settings :: Plugin Registry URI.
+ * Public URI to load registry resources, e.g. icons.
+ */
+const PLUGIN_REGISTRY_URL = 'cheWorkspacePluginRegistryUrl';
+
+/**
+ * Workspace Settings :: Plugin Registry internal URI.
+ * Is used for cross-container communication and mostly for getting plugins metadata.
+ */
+const PLUGIN_REGISTRY_INTERNAL_URL = 'cheWorkspacePluginRegistryInternalUrl';
+
 @injectable()
 export class ChePluginServiceImpl implements ChePluginService {
   private workspaceService: WorkspaceService;
@@ -74,6 +86,20 @@ export class ChePluginServiceImpl implements ChePluginService {
 
   dispose(): void {}
 
+  ensurePluginsURI(uri: string): string {
+    if (!uri.endsWith('/plugins/')) {
+      if (uri.endsWith('/')) {
+        uri = uri.substring(0, uri.length - 1);
+      }
+
+      if (!uri.endsWith('/plugins')) {
+        uri += '/plugins/';
+      }
+    }
+
+    return uri;
+  }
+
   async getDefaultRegistry(): Promise<ChePluginRegistry> {
     if (this.defaultRegistry) {
       return this.defaultRegistry;
@@ -81,22 +107,18 @@ export class ChePluginServiceImpl implements ChePluginService {
 
     try {
       const workspaceSettings: WorkspaceSettings = await this.workspaceService.getWorkspaceSettings();
-      if (workspaceSettings && workspaceSettings['cheWorkspacePluginRegistryInternalUrl']) {
-        let uri = workspaceSettings['cheWorkspacePluginRegistryInternalUrl'];
-        console.log('[INFO] Plugin registry url is: ' + uri);
+      if (workspaceSettings && workspaceSettings[PLUGIN_REGISTRY_INTERNAL_URL]) {
+        const uri = workspaceSettings[PLUGIN_REGISTRY_INTERNAL_URL];
 
-        if (!uri.endsWith('/plugins/')) {
-          if (uri.endsWith('/')) {
-            uri = uri.substring(0, uri.length - 1);
-          }
-
-          if (!uri.endsWith('/plugins')) {
-            uri += '/plugins/';
-          }
+        let publicUri: string | undefined;
+        if (workspaceSettings[PLUGIN_REGISTRY_URL]) {
+          publicUri = workspaceSettings[PLUGIN_REGISTRY_URL];
         }
+
         this.defaultRegistry = {
           name: 'Eclipse Che plugins',
-          uri: uri,
+          uri: this.ensurePluginsURI(uri),
+          publicUri: publicUri ? this.ensurePluginsURI(publicUri) : undefined,
         };
 
         return this.defaultRegistry;
@@ -262,7 +284,11 @@ export class ChePluginServiceImpl implements ChePluginService {
           const pluginYamlURI = this.getPluginYampURI(registry, metadataInternal);
 
           try {
-            const pluginMetadata = await this.loadPluginMetadata(pluginYamlURI, longKeyFormat);
+            const pluginMetadata = await this.loadPluginMetadata(
+              pluginYamlURI,
+              longKeyFormat,
+              registry.publicUri || registry.uri
+            );
             this.cachedPlugins.push(pluginMetadata);
             await this.client.notifyPluginCached(this.cachedPlugins.length);
           } catch (error) {
@@ -384,7 +410,11 @@ export class ChePluginServiceImpl implements ChePluginService {
     }
   }
 
-  private async loadPluginMetadata(yamlURI: string, longKeyFormat: boolean): Promise<ChePluginMetadata> {
+  private async loadPluginMetadata(
+    yamlURI: string,
+    longKeyFormat: boolean,
+    pluginRegistryURI?: string
+  ): Promise<ChePluginMetadata> {
     try {
       const props: ChePluginMetadata = await this.loadPluginYaml(yamlURI);
 
@@ -399,6 +429,12 @@ export class ChePluginServiceImpl implements ChePluginService {
         }
       }
 
+      let icon = props.icon;
+      if (pluginRegistryURI && props.icon && props.icon.startsWith('/')) {
+        const uri = new URI(pluginRegistryURI);
+        icon = `${uri.scheme}://${uri.authority}${icon}`;
+      }
+
       return {
         publisher: props.publisher,
         name: props.name,
@@ -407,7 +443,7 @@ export class ChePluginServiceImpl implements ChePluginService {
         displayName: props.displayName,
         title: props.title,
         description: props.description,
-        icon: props.icon,
+        icon: icon,
         url: props.url,
         repository: props.repository,
         firstPublicationDate: props.firstPublicationDate,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Backport of https://github.com/eclipse/che-theia/pull/997 to 7.26.x

Changes the URIs of icoins to be able to be properly displayed in Plugins panel.

For details see https://github.com/eclipse/che-theia/pull/997


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/18908

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next
