### PR TITLE
Validate plugin registry in settings.json (#1002)

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-service-client.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-service-client.ts
@@ -37,6 +37,8 @@ export class ChePluginServiceClientImpl implements ChePluginServiceClient {
    ********************************************************************************/
 
   protected readonly pluginCachedEvent = new Emitter<number>();
+  protected readonly onInvalidRegistryFoundEmitter = new Emitter<ChePluginRegistry>();
+  readonly onInvalidRegistryFound = this.onInvalidRegistryFoundEmitter.event;
 
   get onPluginCached(): Event<number> {
     return this.pluginCachedEvent.event;
@@ -72,10 +74,11 @@ export class ChePluginServiceClientImpl implements ChePluginServiceClient {
    ********************************************************************************/
 
   async invalidRegistryFound(registry: ChePluginRegistry): Promise<void> {
+    this.onInvalidRegistryFoundEmitter.fire(registry);
     console.log('Unable to read plugin registry', registry.uri);
   }
 
-  async invaligPluginFound(pluginYaml: string): Promise<void> {
+  async invalidPluginFound(pluginYaml: string): Promise<void> {
     console.log('Unable to read plugin meta.yaml', pluginYaml);
   }
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-plugin-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-plugin-protocol.ts
@@ -132,5 +132,5 @@ export interface ChePluginServiceClient {
   /**
    * Called by Plugin Service when invalid plugin meta.yaml has been found while updating plugin cache.
    */
-  invaligPluginFound(pluginYaml: string): Promise<void>;
+  invalidPluginFound(pluginYaml: string): Promise<void>;
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -247,6 +247,10 @@ export class ChePluginServiceImpl implements ChePluginService {
       try {
         // Get list of ChePluginMetadataInternal from plugin registry
         const registryPlugins = await this.loadPluginList(registry);
+        if (!Array.isArray(registryPlugins)) {
+          await this.client.invalidRegistryFound(registry);
+          continue;
+        }
         availablePlugins += registryPlugins.length;
         await this.client.notifyPluginCacheSizeChanged(availablePlugins);
 
@@ -267,7 +271,7 @@ export class ChePluginServiceImpl implements ChePluginService {
             await this.client.notifyPluginCached(this.cachedPlugins.length);
           } catch (error) {
             console.log('Unable go get plugin metadata from ' + pluginYamlURI);
-            await this.client.invaligPluginFound(pluginYamlURI);
+            await this.client.invalidPluginFound(pluginYamlURI);
           }
         }
       } catch (error) {


### PR DESCRIPTION
Refresh the plugins view when a new plugin registry is added in the settings.json.
If the new plugin registry is not valid, show a notification about it.

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Refresh the `plugins` view when a new plugin registry is added in the `settings.json`.
* If the new plugin registry is not valid, show a notification about it.
![video-convert](https://user-images.githubusercontent.com/7668752/108871725-1b99ab80-7602-11eb-9601-0445e6eed6db.gif)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-1449
fixes https://github.com/eclipse/che/issues/17263

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Open a workspace from devfile:
```
apiVersion: 1.0.0
metadata:
  name: testnjz3q
components:
  - type: cheEditor
    reference: 'https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-1002/che_theia_meta.yaml'
  - id: github/vscode-pull-request-github/latest
    type: chePlugin
```
2. Open `Plugins` view.
3. Open `settings.json` file in the `.theia` directory in the user folder.
4. add a new value to the `chePlugins.repositories` field e.g.
```
{
    "chePlugins.repositories": { "test": "https://test.com" }
}
```
5. The `Plugins` panel must update the plugins list and a notification about the invalid plugin registry must appear.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
