### PR TITLE
fix(package.json): Should use the yarn workspace version of @eclipse-che/plugin

### DIFF
--- a/plugins/ports-plugin/package.json
+++ b/plugins/ports-plugin/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@eclipse-che/plugin": "latest",
+    "@eclipse-che/plugin": "0.0.1",
     "@theia/plugin": "next",
     "@theia/plugin-packager": "latest"
   },


### PR DESCRIPTION
### What does this PR do?
package @eclipse-che/plugin is inside the current yarn workspace, then it's this version that should be used instead of the remote one.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
May lead to not having the correct API when building the plug-in.

### How to test this PR?
Modify .d.ts of `@eclipse-che/plugin` and try to use that in ports-plugin: it will fail without this fix.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next


Change-Id: I8b0d5b30a2f11f891faa613488459bbe5fcb1576
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
