### PR TITLE
Remove unnecessary delay in workspace plugin

### DIFF
--- a/plugins/workspace-plugin/src/theia-commands.ts
+++ b/plugins/workspace-plugin/src/theia-commands.ts
@@ -207,17 +207,10 @@ export class TheiaGitCloneCommand implements TheiaImportCommand {
         return Promise.reject(new Error(message));
       }
 
-      // pause will be removed after debugging this method
-      await this.pause(100);
+      break;
     }
 
     return this.clone();
-  }
-
-  private async pause(miliseconds: number): Promise<void> {
-    return new Promise(resolve => {
-      setTimeout(resolve, miliseconds);
-    });
   }
 
   // Clones git repository


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Removes redundant delay in workspace plugin.

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
No issue, just code cleanup.

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Devfile to test
```
---
apiVersion: 1.0.0
metadata:
  generateName: clone-ssh-
projects:
  -
    name: greeting-extension
    source:
      type: git
      location: "git@github.com:vitaliy-guliy/greeting-extension.git"
      # location: "https://github.com/vitaliy-guliy/greeting-extension.git"
  -
    name: atlascode
    source:
      type: git
      location: "git@bitbucket.org:atlassianlabs/atlascode.git"
      # location: "https://bitbucket.org/atlassianlabs/atlascode.git"
components:
  - type: cheEditor
    alias: che-theia
    reference: https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-1006/che_theia_meta.yaml
    memoryLimit: 2G
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
