### PR TITLE
Add tests for 'WorkspaceFolderUpdater'

### DIFF
--- a/plugins/workspace-plugin/tests/workspace-folder-updater.spec.ts
+++ b/plugins/workspace-plugin/tests/workspace-folder-updater.spec.ts
@@ -1,0 +1,194 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as theia from '@theia/plugin';
+
+import { WorkspaceFolderUpdater } from '../src/workspace-folder-updater';
+
+interface WorkspaceFolder {
+  readonly uri: theia.Uri;
+}
+
+const PROJECT_1_PATH = '/projects/theia';
+const PROJECT_2_PATH = '/projects/che-theia';
+const PROJECT_3_PATH = '/projects/test-plugin';
+const WRONG_PROJECT_PATH = '/projects/theia/';
+const CORRECT_FOLDER_PATH = '/projects/theia';
+
+let actualWorkspaceFolders: string[] = [];
+let addedFoldersForEvent: WorkspaceFolder[] = [];
+
+const onDidChangeWorkspaceFolders = jest.fn();
+onDidChangeWorkspaceFolders.mockImplementation(onDidChangeWorkspaceFoldersTestImpl);
+
+const workspace = { onDidChangeWorkspaceFolders };
+Object.assign(theia, { workspace });
+
+Object.assign(theia, { Uri: {} });
+const fileFunc = jest.fn();
+theia.Uri.file = fileFunc;
+fileFunc.mockImplementation(uriStub);
+
+const updateWorkspaceFolders = jest.fn();
+
+const dispose = jest.fn();
+const disposable = { dispose };
+
+theia.workspace.updateWorkspaceFolders = updateWorkspaceFolders;
+
+describe('Test Workspace Folder Updater', () => {
+  const workspaceFolderUpdater: WorkspaceFolderUpdater = new WorkspaceFolderUpdater(200);
+
+  beforeEach(() => {
+    actualWorkspaceFolders = [];
+    addedFoldersForEvent = [];
+    updateWorkspaceFolders.mockReset();
+    updateWorkspaceFolders.mockRestore();
+    dispose.mockReset();
+
+    updateWorkspaceFolders.mockImplementation(updateWorkspaceFoldersTestImpl);
+    theia.workspace.workspaceFolders = [];
+  });
+
+  test('request update Workspace Folders using API', async () => {
+    const workspaceFolder = { uri: uriStub(PROJECT_1_PATH) };
+    addedFoldersForEvent = [workspaceFolder];
+
+    await workspaceFolderUpdater.addWorkspaceFolder(PROJECT_1_PATH);
+
+    expect(actualWorkspaceFolders).toStrictEqual([PROJECT_1_PATH]);
+    expect(updateWorkspaceFolders).toBeCalledTimes(1);
+    expect(dispose).toBeCalledTimes(1);
+  });
+
+  test('it shoud skip a request if there is pending request for the same folder', async () => {
+    const workspaceFolder_1 = { uri: uriStub(PROJECT_1_PATH) };
+    const workspaceFolder_2 = { uri: uriStub(PROJECT_2_PATH) };
+    addedFoldersForEvent = [workspaceFolder_1, workspaceFolder_2];
+
+    workspaceFolderUpdater.addWorkspaceFolder(PROJECT_1_PATH);
+    workspaceFolderUpdater.addWorkspaceFolder(PROJECT_2_PATH);
+    await workspaceFolderUpdater.addWorkspaceFolder(PROJECT_2_PATH);
+    await waitUpdateFolders(500);
+
+    expect(actualWorkspaceFolders).toStrictEqual([PROJECT_1_PATH, PROJECT_2_PATH]);
+    expect(updateWorkspaceFolders).toBeCalledTimes(2);
+    expect(dispose).toBeCalledTimes(2);
+  });
+
+  test('it shoud skip adding Workspace Folders duplicates', async () => {
+    const workspaceFolder = { uri: uriStub(PROJECT_1_PATH) };
+    addedFoldersForEvent = [workspaceFolder];
+
+    await workspaceFolderUpdater.addWorkspaceFolder(PROJECT_1_PATH);
+
+    theia.workspace.workspaceFolders = [{ name: '', index: 0, uri: workspaceFolder.uri }];
+
+    await workspaceFolderUpdater.addWorkspaceFolder(PROJECT_1_PATH);
+    await waitUpdateFolders(150);
+
+    expect(actualWorkspaceFolders).toStrictEqual([PROJECT_1_PATH]);
+    expect(updateWorkspaceFolders).toBeCalledTimes(1);
+    expect(dispose).toBeCalledTimes(1);
+  });
+
+  test('it shoud reject adding a Workspace Folder by timeout', async () => {
+    await workspaceFolderUpdater.addWorkspaceFolder(PROJECT_1_PATH);
+
+    expect(actualWorkspaceFolders).toStrictEqual([]);
+    expect(updateWorkspaceFolders).toBeCalledTimes(1);
+    expect(dispose).toBeCalledTimes(1);
+  });
+
+  test('it shoud add the next folder after rejecting adding a Workspace Folder by timeout', async () => {
+    // add PROJECT_1_PATH
+    // add PROJECT_2_PATH
+    // case: there is no an event that PROJECT_1_PATH was added ==> the first request should be rejected by timeout
+    // then the second request should be handled
+    // The expected behavior = PROJECT_2_PATH is added as a workspace folder
+
+    const workspaceFolder = { uri: uriStub(PROJECT_2_PATH) };
+    addedFoldersForEvent = [workspaceFolder];
+
+    workspaceFolderUpdater.addWorkspaceFolder(PROJECT_1_PATH);
+    await workspaceFolderUpdater.addWorkspaceFolder(PROJECT_2_PATH);
+    await waitUpdateFolders(500);
+
+    expect(actualWorkspaceFolders).toStrictEqual([PROJECT_2_PATH]);
+    expect(updateWorkspaceFolders).toBeCalledTimes(2);
+    expect(dispose).toBeCalledTimes(2);
+  });
+
+  test('it shoud add Workspace Folders in turn', async () => {
+    const workspaceFolder_1 = { uri: uriStub(PROJECT_1_PATH) };
+    const workspaceFolder_2 = { uri: uriStub(PROJECT_2_PATH) };
+    const workspaceFolder_3 = { uri: uriStub(PROJECT_3_PATH) };
+    addedFoldersForEvent = [workspaceFolder_1, workspaceFolder_2, workspaceFolder_3];
+
+    workspaceFolderUpdater.addWorkspaceFolder(PROJECT_1_PATH);
+    workspaceFolderUpdater.addWorkspaceFolder(PROJECT_2_PATH);
+    await workspaceFolderUpdater.addWorkspaceFolder(PROJECT_3_PATH);
+    await waitUpdateFolders(500);
+
+    expect(actualWorkspaceFolders).toStrictEqual([PROJECT_1_PATH, PROJECT_2_PATH, PROJECT_3_PATH]);
+    expect(updateWorkspaceFolders).toBeCalledTimes(3);
+    expect(dispose).toBeCalledTimes(3);
+  });
+
+  test('it should correct a project path to the valid Workspace Folder path ', async () => {
+    const workspaceFolder = { uri: uriStub(CORRECT_FOLDER_PATH) };
+    addedFoldersForEvent = [workspaceFolder];
+
+    await workspaceFolderUpdater.addWorkspaceFolder(WRONG_PROJECT_PATH);
+
+    expect(actualWorkspaceFolders).toStrictEqual([CORRECT_FOLDER_PATH]);
+  });
+});
+
+function updateWorkspaceFoldersTestImpl(
+  start: number,
+  deleteCount: number | undefined | null,
+  workspaceFolderToAdd: { uri: theia.Uri; name?: string }
+): boolean {
+  const projectPath = workspaceFolderToAdd.uri.path;
+  if (projectPath && addedFoldersForEvent.some(folder => folder.uri.path === projectPath)) {
+    actualWorkspaceFolders.push(projectPath);
+    return true;
+  }
+  return false;
+}
+
+function onDidChangeWorkspaceFoldersTestImpl(listener: (event: {}) => {}): { dispose(): void } {
+  setTimeout(() => {
+    const addWorkspaceFolderEvent = {
+      added: addedFoldersForEvent,
+      removed: [],
+    };
+    listener(addWorkspaceFolderEvent);
+  }, 100);
+  return disposable;
+}
+
+function uriStub(path: string): theia.Uri {
+  return {
+    path,
+    authority: '',
+    query: '',
+    fsPath: '',
+    scheme: '',
+    fragment: '',
+    with: jest.fn(),
+    toJSON: jest.fn(),
+  };
+}
+
+function waitUpdateFolders(ms: number): Promise<void> {
+  return new Promise<void>(resolve => setTimeout(() => resolve(), ms));
+}


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Add tests for 'WorkspaceFolderUpdater'

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
It's related to multi-root workspaces support logic https://github.com/eclipse/che/issues/17212

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
The tests should be happy.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
