### PR TITLE
Apply default certificate when downloading ZIP projects

### DIFF
--- a/plugins/workspace-plugin/src/ca-cert.ts
+++ b/plugins/workspace-plugin/src/ca-cert.ts
@@ -16,8 +16,36 @@ const SS_CRT_PATH = '/tmp/che/secret/ca.crt';
 
 const CA_BUNDLE_PATH = '/tmp/ca-bundle.crt';
 
+/**
+ * Possible locations of default system certificates.
+ */
+const systemCerts = [
+  // Debian, Ubuntu, Gentoo
+  '/etc/ssl/certs/ca-certificates.crt',
+  // Fedora, RHEL 6
+  '/etc/pki/tls/certs/ca-bundle.crt',
+  // OpenSUSE
+  '/etc/ssl/ca-bundle.pem',
+  // OpenELEC
+  '/etc/pki/tls/cacert.pem',
+  // CentOS, RHEL 7
+  '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem',
+  // Alpine
+  '/etc/ssl/cert.pem',
+];
+
 export const getCertificate = new Promise<string | undefined>(async resolve => {
   const certificates: Buffer[] = [];
+
+  // Look for default certificate.
+  // Stop iterating when finding one.
+  for (const cert of systemCerts) {
+    if (await fs.pathExists(cert)) {
+      // read the certificate
+      certificates.push(await fs.readFile(cert));
+      break;
+    }
+  }
 
   if (await fs.pathExists(SS_CRT_PATH)) {
     certificates.push(await fs.readFile(SS_CRT_PATH));

--- a/plugins/workspace-plugin/src/ca-cert.ts
+++ b/plugins/workspace-plugin/src/ca-cert.ts
@@ -19,18 +19,10 @@ const CA_BUNDLE_PATH = '/tmp/ca-bundle.crt';
 /**
  * Possible locations of default system certificates.
  */
-const systemCerts = [
-  // Debian, Ubuntu, Gentoo
+const SYSTEM_CERTS = [
   '/etc/ssl/certs/ca-certificates.crt',
-  // Fedora, RHEL 6
   '/etc/pki/tls/certs/ca-bundle.crt',
-  // OpenSUSE
-  '/etc/ssl/ca-bundle.pem',
-  // OpenELEC
-  '/etc/pki/tls/cacert.pem',
-  // CentOS, RHEL 7
   '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem',
-  // Alpine
   '/etc/ssl/cert.pem',
 ];
 
@@ -39,7 +31,7 @@ export const getCertificate = new Promise<string | undefined>(async resolve => {
 
   // Look for default certificate.
   // Stop iterating when finding one.
-  for (const cert of systemCerts) {
+  for (const cert of SYSTEM_CERTS) {
     if (await fs.pathExists(cert)) {
       // read the certificate
       certificates.push(await fs.readFile(cert));


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes downloading of zipped projects when creating a workspace.
Now the default system certificate is used when downloading zip with curl.

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19120

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Devfile
```
---
apiVersion: 1.0.0
metadata:
  name: test-import-zip
projects:
  -
    name: theia-master
    source:
      type: zip
      location: "https://github.com/eclipse-theia/theia/archive/master.zip"
components:
  - type: cheEditor
    alias: che-theia
    reference: https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-1014/che_theia_meta.yaml
    memoryLimit: 1G
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
