### PR TITLE
feat(resource-monitor-plugin): Update to latest devfile 2 API

### DIFF
--- a/plugins/resource-monitor-plugin/__mocks__/@eclipse-che/plugin.ts
+++ b/plugins/resource-monitor-plugin/__mocks__/@eclipse-che/plugin.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2020-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@
  * @author Valerii Svydenko
  */
 const che: any = {};
-che.workspace = {};
+che.devfile = {};
+che.devfile.metadata = {};
 che.k8s = {};
 module.exports = che;

--- a/plugins/resource-monitor-plugin/src/resource-monitor-plugin.ts
+++ b/plugins/resource-monitor-plugin/src/resource-monitor-plugin.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2018-2020 Red Hat, Inc.
+ * Copyright (c) 2018-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -193,6 +193,6 @@ export class ResMon {
 }
 
 export async function getNamespace(): Promise<string> {
-  const workspace = await che.workspace.getCurrentWorkspace();
-  return workspace.attributes ? workspace.attributes.infrastructureNamespace : '';
+  const devfile = await che.devfile.get();
+  return devfile.metadata?.attributes ? devfile.metadata.attributes.infrastructureNamespace : '';
 }

--- a/plugins/resource-monitor-plugin/tests/resource-monitor.spec.ts
+++ b/plugins/resource-monitor-plugin/tests/resource-monitor.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2020-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,10 +20,9 @@ import * as theia from '@theia/plugin';
 import { Container } from '../src/objects';
 import { ResMon } from '../src/resource-monitor-plugin';
 import { SHOW_WARNING_MESSAGE_COMMAND } from '../src/constants';
-import { che as cheApi } from '@eclipse-che/api';
 
 describe('Test Resource Monitor Plugin', () => {
-  const getCurrentWorkspace = jest.fn();
+  const devfileMock = jest.fn();
   const sendRawQuery = jest.fn();
   const createStatusBar = jest.fn();
   process.env.HOSTNAME = 'workspace';
@@ -75,12 +74,14 @@ describe('Test Resource Monitor Plugin', () => {
     che.k8s.sendRawQuery = sendRawQuery;
 
     // Prepare Namespace
-    che.workspace.getCurrentWorkspace = getCurrentWorkspace;
+    che.devfile.get = devfileMock;
     const attributes = { infrastructureNamespace: 'che-namespace' };
-    const workspace: cheApi.workspace.Workspace = {
-      attributes,
+    const devfile = {
+      metadata: {
+        attributes,
+      },
     };
-    getCurrentWorkspace.mockReturnValue(workspace);
+    devfileMock.mockReturnValue(devfile);
 
     // Prepare StatusBarItem
     theia.window.createStatusBarItem = createStatusBar;


### PR DESCRIPTION
### What does this PR do?
Switch API call to get devfile attributes.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19188

### How to test this PR?
Should work as before for the resource monitor plug-in

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next


Change-Id: Ia532b973e081ae9801cd28008521bd07db9411fa
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
