### PR TITLE
fix(task-plugin): task plugin should not have to connect to an extern…

### DIFF
--- a/plugins/task-plugin/src/che-workspace-client.ts
+++ b/plugins/task-plugin/src/che-workspace-client.ts
@@ -109,7 +109,10 @@ export class CheWorkspaceClient {
     if (!machineExecServer) {
       throw new Error(`No server with type ${TERMINAL_SERVER_TYPE} found.`);
     }
-    return machineExecServer.url!;
+    if (!machineExecServer.attributes!.port) {
+      throw new Error('No machine-exec-server attributes.port found');
+    }
+    return `ws://127.0.0.1:${machineExecServer.attributes!.port}`;
   }
 
   protected async getMachineExecServer(): Promise<cheApi.workspace.Server | undefined> {


### PR DESCRIPTION
…al route and should avoid dealing with https, tls issues.

Signed-off-by: Sun Tan <sutan@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Replacing connection to machine-exec through external route with a connection to localhost. Should work as these are all running in the same pod. Also fixing certificate issues, simplifying code, avoid any other issues with proxy and certificates.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18957


### How to test this PR?
Make sure that che commands are working with the provided maven or nodejs generated devfile.

(optional) Setup https://che-incubator.github.io/2021/02/01/@mario.loriedo-using-mkcert-to-locally-trust-eclipse-che-tls-certificates-ffaafe76e5d0.html, make sure to have the problem described in https://github.com/eclipse/che/issues/18957. Then run the maven or nodejs devfile provided and make sure that tasks are working.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
