### PR TITLE
feat(task-plugin): bump to devfile 2.0 API

### DIFF
--- a/plugins/task-plugin/.gitignore
+++ b/plugins/task-plugin/.gitignore
@@ -2,3 +2,4 @@ dist/
 lib/
 node_modules/
 *.theia
+coverage

--- a/plugins/task-plugin/__mocks__/@eclipse-che/plugin.ts
+++ b/plugins/task-plugin/__mocks__/@eclipse-che/plugin.ts
@@ -8,6 +8,15 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-describe('no-op', function () {
-  it('no-op', function () {});
-});
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const chePlugin: any = {};
+chePlugin.devfile = {
+    get: jest.fn(),
+    getComponentStatuses: jest.fn(),
+};
+
+chePlugin.endpoint = {
+    getEndpointsByType: jest.fn(),
+};
+
+module.exports = chePlugin;

--- a/plugins/task-plugin/__mocks__/@theia/plugin.ts
+++ b/plugins/task-plugin/__mocks__/@theia/plugin.ts
@@ -1,0 +1,17 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const theiaPlugin: any = {};
+
+theiaPlugin.window = {
+  createOutputChannel: jest.fn()
+};
+module.exports = theiaPlugin;

--- a/plugins/task-plugin/src/che-workspace-client.ts
+++ b/plugins/task-plugin/src/che-workspace-client.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,12 +15,7 @@ import { injectable } from 'inversify';
 
 const TERMINAL_SERVER_TYPE = 'terminal';
 
-export const RECIPE_CONTAINER_SOURCE = 'recipe';
-export const CONTAINER_SOURCE_ATTRIBUTE = 'source';
-
-export interface WorkspaceContainer extends cheApi.workspace.Machine {
-  name: string;
-}
+export interface WorkspaceContainer extends che.devfile.DevfileComponentStatus {}
 
 @injectable()
 export class CheWorkspaceClient {
@@ -30,57 +25,8 @@ export class CheWorkspaceClient {
     return workspace.links;
   }
 
-  /** Returns array of containers' names for the current workspace. */
-  async getContainersNames(): Promise<string[]> {
-    const containerNames: string[] = [];
-
-    try {
-      const containers = await this.getMachines();
-      for (const containerName in containers) {
-        if (containers.hasOwnProperty(containerName)) {
-          containerNames.push(containerName);
-        }
-      }
-    } catch (error) {
-    } finally {
-      return containerNames;
-    }
-  }
-
-  async getMachines(): Promise<{ [attrName: string]: cheApi.workspace.Machine }> {
-    const workspace = await this.getCurrentWorkspace();
-    const runtime = workspace.runtime;
-    if (!runtime) {
-      throw new Error('Workspace is not running.');
-    }
-
-    const machines = runtime.machines;
-    if (!machines) {
-      throw new Error('No machines for current workspace is found.');
-    }
-    return machines;
-  }
-
-  async getContainers(): Promise<WorkspaceContainer[]> {
-    const containers: WorkspaceContainer[] = [];
-    try {
-      const workspace = await this.getCurrentWorkspace();
-
-      if (workspace.runtime && workspace.runtime.machines) {
-        const machines = workspace.runtime.machines;
-        for (const machineName in machines) {
-          if (!machines.hasOwnProperty(machineName)) {
-            continue;
-          }
-          const container: WorkspaceContainer = { name: machineName, ...machines[machineName] };
-          containers.push(container);
-        }
-      }
-    } catch (e) {
-      throw new Error('Unable to get list workspace containers. Cause: ' + e);
-    }
-
-    return containers;
+  async getComponentStatuses(): Promise<che.devfile.DevfileComponentStatus[]> {
+    return che.devfile.getComponentStatuses();
   }
 
   async getCommands(): Promise<cheApi.workspace.Command[]> {
@@ -105,34 +51,16 @@ export class CheWorkspaceClient {
   }
 
   async getMachineExecServerURL(): Promise<string> {
-    const machineExecServer = await this.getMachineExecServer();
-    if (!machineExecServer) {
-      throw new Error(`No server with type ${TERMINAL_SERVER_TYPE} found.`);
-    }
-    if (!machineExecServer.attributes!.port) {
-      throw new Error('No machine-exec-server attributes.port found');
-    }
-    return `ws://127.0.0.1:${machineExecServer.attributes!.port}`;
+    const machineExecEndpoint = await this.getMachineExecEndpoint();
+    const port = machineExecEndpoint.attributes?.port || machineExecEndpoint.attributes?.targetPort;
+    return `ws://127.0.0.1:${port}`;
   }
 
-  protected async getMachineExecServer(): Promise<cheApi.workspace.Server | undefined> {
-    const machines = await this.getMachines();
-    for (const machineName in machines) {
-      if (!machines.hasOwnProperty(machineName)) {
-        continue;
-      }
-      const servers = machines[machineName].servers!;
-      for (const serverName in servers) {
-        if (!servers.hasOwnProperty(serverName)) {
-          continue;
-        }
-
-        const serverAttributes = servers[serverName].attributes;
-        if (serverAttributes && serverAttributes['type'] === TERMINAL_SERVER_TYPE) {
-          return servers[serverName];
-        }
-      }
+  protected async getMachineExecEndpoint(): Promise<che.endpoint.ExposedEndpoint> {
+    const terminalEndpoints = await che.endpoint.getEndpointsByType(TERMINAL_SERVER_TYPE);
+    if (terminalEndpoints.length === 1) {
+      return terminalEndpoints[0];
     }
-    return undefined;
+    throw new Error(`Unable to find terminal with type ${TERMINAL_SERVER_TYPE}: Found: ${terminalEndpoints}`);
   }
 }

--- a/plugins/task-plugin/src/che-workspace-client.ts
+++ b/plugins/task-plugin/src/che-workspace-client.ts
@@ -29,16 +29,9 @@ export class CheWorkspaceClient {
     return che.devfile.getComponentStatuses();
   }
 
-  async getCommands(): Promise<cheApi.workspace.Command[]> {
-    const workspace: cheApi.workspace.Workspace = await this.getCurrentWorkspace();
-
-    const runtime: cheApi.workspace.Runtime | undefined = workspace.runtime;
-    if (!runtime) {
-      return [];
-    }
-
-    const commands = runtime.commands;
-    return commands ? commands : [];
+  async getCommands(): Promise<che.devfile.DevfileCommand[]> {
+    const devfile = await che.devfile.get();
+    return devfile.commands || [];
   }
 
   getCurrentWorkspace(): Promise<cheApi.workspace.Workspace> {

--- a/plugins/task-plugin/src/export/export-configs-manager.ts
+++ b/plugins/task-plugin/src/export/export-configs-manager.ts
@@ -8,11 +8,12 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+import * as che from '@eclipse-che/plugin';
+
 import { inject, injectable, multiInject } from 'inversify';
 
 import { CheWorkspaceClient } from '../che-workspace-client';
 import { LaunchConfigurationsExporter } from './launch-configs-exporter';
-import { che as cheApi } from '@eclipse-che/api';
 
 export const ConfigurationsExporter = Symbol('ConfigurationsExporter');
 
@@ -23,7 +24,7 @@ export interface ConfigurationsExporter {
    * @param workspaceFolder workspace folder for exporting configs in the config file
    * @param commands commands with configurations for export
    */
-  export(commands: cheApi.workspace.Command[]): Promise<void>;
+  export(commands: che.devfile.DevfileCommand[]): Promise<void>;
 }
 /** Contains configurations as array of object and as raw content and is used at getting configurations from config file for example */
 export interface Configurations<T> {
@@ -46,7 +47,7 @@ export class ExportConfigurationsManager {
   @inject(LaunchConfigurationsExporter)
   protected readonly launchConfigurationsExporter: LaunchConfigurationsExporter;
 
-  protected cheCommands: cheApi.workspace.Command[] = [];
+  protected cheCommands: che.devfile.DevfileCommand[] = [];
 
   async init(): Promise<void> {
     this.cheCommands = await this.cheWorkspaceClient.getCommands();
@@ -63,7 +64,7 @@ export class ExportConfigurationsManager {
     await Promise.all(exportPromises);
   }
 
-  private async doExport(cheCommands: cheApi.workspace.Command[], exporter: ConfigurationsExporter): Promise<void> {
+  private async doExport(cheCommands: che.devfile.DevfileCommand[], exporter: ConfigurationsExporter): Promise<void> {
     return exporter.export(cheCommands);
   }
 }

--- a/plugins/task-plugin/src/export/launch-configs-exporter.ts
+++ b/plugins/task-plugin/src/export/launch-configs-exporter.ts
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+import * as che from '@eclipse-che/plugin';
 import * as startPoint from '../task-plugin-backend';
 import * as theia from '@theia/plugin';
 
@@ -17,7 +18,6 @@ import { inject, injectable } from 'inversify';
 import { ConfigFileLaunchConfigsExtractor } from '../extract/config-file-launch-configs-extractor';
 import { ConfigurationsExporter } from './export-configs-manager';
 import { VsCodeLaunchConfigsExtractor } from '../extract/vscode-launch-configs-extractor';
-import { che as cheApi } from '@eclipse-che/api';
 import { resolve } from 'path';
 
 const CONFIG_DIR = '.theia';
@@ -33,7 +33,7 @@ export class LaunchConfigurationsExporter implements ConfigurationsExporter {
   @inject(VsCodeLaunchConfigsExtractor)
   protected readonly vsCodeLaunchConfigsExtractor: VsCodeLaunchConfigsExtractor;
 
-  async init(commands: cheApi.workspace.Command[]): Promise<void> {
+  async init(commands: che.devfile.DevfileCommand[]): Promise<void> {
     theia.workspace.onDidChangeWorkspaceFolders(
       event => {
         const workspaceFolders: theia.WorkspaceFolder[] | undefined = event.added;
@@ -46,7 +46,7 @@ export class LaunchConfigurationsExporter implements ConfigurationsExporter {
     );
   }
 
-  async export(commands: cheApi.workspace.Command[], workspaceFolders?: theia.WorkspaceFolder[]): Promise<void> {
+  async export(commands: che.devfile.DevfileCommand[], workspaceFolders?: theia.WorkspaceFolder[]): Promise<void> {
     workspaceFolders = workspaceFolders ? workspaceFolders : theia.workspace.workspaceFolders;
     if (!workspaceFolders) {
       return;
@@ -60,7 +60,7 @@ export class LaunchConfigurationsExporter implements ConfigurationsExporter {
     await Promise.all(exportConfigsPromises);
   }
 
-  async doExport(workspaceFolder: theia.WorkspaceFolder, commands: cheApi.workspace.Command[]): Promise<void> {
+  async doExport(workspaceFolder: theia.WorkspaceFolder, commands: che.devfile.DevfileCommand[]): Promise<void> {
     const workspaceFolderPath = workspaceFolder.uri.path;
     const launchConfigFilePath = resolve(workspaceFolderPath, CONFIG_DIR, LAUNCH_CONFIG_FILE);
     const configFileConfigs = await this.configFileLaunchConfigsExtractor.extract(launchConfigFilePath);

--- a/plugins/task-plugin/src/export/task-configs-exporter.ts
+++ b/plugins/task-plugin/src/export/task-configs-exporter.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+import * as che from '@eclipse-che/plugin';
 import * as startPoint from '../task-plugin-backend';
 
 import { inject, injectable } from 'inversify';
@@ -19,7 +20,6 @@ import { ConfigFileTasksExtractor } from '../extract/config-file-task-configs-ex
 import { ConfigurationsExporter } from './export-configs-manager';
 import { TaskConfiguration } from '@eclipse-che/plugin';
 import { VsCodeTaskConfigsExtractor } from '../extract/vscode-task-configs-extractor';
-import { che as cheApi } from '@eclipse-che/api';
 import { homedir } from 'os';
 import { resolve } from 'path';
 
@@ -48,7 +48,7 @@ export class TaskConfigurationsExporter implements ConfigurationsExporter {
   @inject(BackwardCompatibilityResolver)
   protected readonly backwardCompatibilityResolver: BackwardCompatibilityResolver;
 
-  async export(commands: cheApi.workspace.Command[]): Promise<void> {
+  async export(commands: che.devfile.DevfileCommand[]): Promise<void> {
     const configFileTasks = await this.configFileTasksExtractor.extract(THEIA_USER_TASKS_PATH);
 
     const cheTasks = this.cheTaskConfigsExtractor.extract(commands);

--- a/plugins/task-plugin/src/extract/che-task-configs-extractor.ts
+++ b/plugins/task-plugin/src/extract/che-task-configs-extractor.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,21 +8,18 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+import * as che from '@eclipse-che/plugin';
+
 import { TaskConfiguration } from '@eclipse-che/plugin';
-import { VSCODE_LAUNCH_TYPE } from './vscode-launch-configs-extractor';
-import { VSCODE_TASK_TYPE } from './vscode-task-configs-extractor';
-import { che as cheApi } from '@eclipse-che/api';
 import { injectable } from 'inversify';
 import { toTaskConfiguration } from '../task/converter';
 
 /** Extracts CHE configurations of tasks. */
 @injectable()
 export class CheTaskConfigsExtractor {
-  extract(commands: cheApi.workspace.Command[]): TaskConfiguration[] {
+  extract(commands: che.devfile.DevfileCommand[]): TaskConfiguration[] {
     // TODO filter should be changed according to task type after resolving https://github.com/eclipse/che/issues/12710
-    const filteredCommands = commands.filter(
-      command => command.type !== VSCODE_TASK_TYPE && command.type !== VSCODE_LAUNCH_TYPE
-    );
+    const filteredCommands = commands.filter(command => command.exec);
 
     if (filteredCommands.length === 0) {
       return [];

--- a/plugins/task-plugin/src/extract/vscode-launch-configs-extractor.ts
+++ b/plugins/task-plugin/src/extract/vscode-launch-configs-extractor.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,36 +8,34 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+import * as che from '@eclipse-che/plugin';
 import * as theia from '@theia/plugin';
 
 import { Configurations } from '../export/export-configs-manager';
-import { che as cheApi } from '@eclipse-che/api';
 import { injectable } from 'inversify';
 import { parse } from '../utils';
-
-export const VSCODE_LAUNCH_TYPE = 'vscode-launch';
 
 /** Extracts vscode launch configurations. */
 @injectable()
 export class VsCodeLaunchConfigsExtractor {
-  extract(commands: cheApi.workspace.Command[]): Configurations<theia.DebugConfiguration> {
+  extract(commands: che.devfile.DevfileCommand[]): Configurations<theia.DebugConfiguration> {
     const emptyContent: Configurations<theia.DebugConfiguration> = { content: '', configs: [] };
 
-    const configCommands = commands.filter(command => command.type === VSCODE_LAUNCH_TYPE);
+    const configCommands = commands.filter(command => command.vscodeLaunch);
     if (configCommands.length === 0) {
       return emptyContent;
     }
 
     if (configCommands.length > 1) {
-      console.warn(`Found duplicate entry with configurations for type ${VSCODE_LAUNCH_TYPE}`);
+      console.warn(`Found duplicate entry with configurations for type vscodeLaunch`);
     }
 
     const configCommand = configCommands[0];
-    if (!configCommand || !configCommand.attributes || !configCommand.attributes.actionReferenceContent) {
+    if (!configCommand || !configCommand.vscodeLaunch?.inline) {
       return emptyContent;
     }
 
-    const launchConfigsContent = configCommand.attributes.actionReferenceContent;
+    const launchConfigsContent = configCommand.vscodeLaunch.inline;
     const configsJson = parse(launchConfigsContent);
     if (!configsJson || !configsJson.configurations) {
       return emptyContent;

--- a/plugins/task-plugin/src/extract/vscode-task-configs-extractor.ts
+++ b/plugins/task-plugin/src/extract/vscode-task-configs-extractor.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,35 +8,34 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+import * as che from '@eclipse-che/plugin';
+
 import { Configurations } from '../export/export-configs-manager';
 import { TaskConfiguration } from '@eclipse-che/plugin';
-import { che as cheApi } from '@eclipse-che/api';
 import { injectable } from 'inversify';
 import { parse } from '../utils';
-
-export const VSCODE_TASK_TYPE = 'vscode-task';
 
 /** Extracts vscode configurations of tasks. */
 @injectable()
 export class VsCodeTaskConfigsExtractor {
-  extract(commands: cheApi.workspace.Command[]): Configurations<TaskConfiguration> {
+  extract(commands: che.devfile.DevfileCommand[]): Configurations<TaskConfiguration> {
     const emptyContent = { content: '', configs: [] } as Configurations<TaskConfiguration>;
 
-    const configCommands = commands.filter(command => command.type === VSCODE_TASK_TYPE);
+    const configCommands = commands.filter(command => command.vscodeTask);
     if (configCommands.length === 0) {
       return emptyContent;
     }
 
     if (configCommands.length > 1) {
-      console.warn(`Found duplicate entry with configurations for type ${VSCODE_TASK_TYPE}`);
+      console.warn(`Found duplicate entry with configurations for type vscodeTask`);
     }
 
     const configCommand = configCommands[0];
-    if (!configCommand || !configCommand.attributes || !configCommand.attributes.actionReferenceContent) {
+    if (!configCommand || !configCommand.vscodeTask?.inline) {
       return emptyContent;
     }
 
-    const tasksContent = configCommand.attributes.actionReferenceContent;
+    const tasksContent = configCommand.vscodeTask.inline;
     const tasksJson = parse(tasksContent);
     if (!tasksJson || !tasksJson.tasks) {
       return emptyContent;

--- a/plugins/task-plugin/src/machine/machines-picker.ts
+++ b/plugins/task-plugin/src/machine/machines-picker.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,12 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-import {
-  CONTAINER_SOURCE_ATTRIBUTE,
-  CheWorkspaceClient,
-  RECIPE_CONTAINER_SOURCE,
-  WorkspaceContainer,
-} from '../che-workspace-client';
+import { CheWorkspaceClient, WorkspaceContainer } from '../che-workspace-client';
 import { QuickPickItem, window } from '@theia/plugin';
 import { inject, injectable } from 'inversify';
 
@@ -60,7 +55,7 @@ export class MachinesPicker {
   }
 
   private async pickContainerFromClient(): Promise<string> {
-    const containers = await this.cheWorkspaceClient.getContainers();
+    const containers = await this.cheWorkspaceClient.getComponentStatuses();
 
     if (containers.length === 1) {
       return Promise.resolve(containers[0].name);
@@ -74,8 +69,8 @@ export class MachinesPicker {
   private toQuickPickItems(containers: WorkspaceContainer[]): QuickPickItem[] {
     const items: QuickPickItem[] = [];
 
-    const devContainers = containers.filter(container => this.isDevContainer(container));
-    const toolingContainers = containers.filter(container => !this.isDevContainer(container));
+    const devContainers = containers.filter(container => container.isUser);
+    const toolingContainers = containers.filter(container => !container.isUser);
 
     items.push(
       ...devContainers.map(
@@ -108,13 +103,5 @@ export class MachinesPicker {
     );
 
     return items;
-  }
-
-  private isDevContainer(container: WorkspaceContainer): boolean {
-    return (
-      container.attributes !== undefined &&
-      (!container.attributes[CONTAINER_SOURCE_ATTRIBUTE] ||
-        container.attributes[CONTAINER_SOURCE_ATTRIBUTE] === RECIPE_CONTAINER_SOURCE)
-    );
   }
 }

--- a/plugins/task-plugin/src/task/backward-compatibility.ts
+++ b/plugins/task-plugin/src/task/backward-compatibility.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,9 +13,7 @@ import * as che from '@eclipse-che/plugin';
 import { inject, injectable } from 'inversify';
 
 import { CHE_TASK_TYPE } from './task-protocol';
-import { COMPONENT_ATTRIBUTE } from '../machine/machines-picker';
 import { CheWorkspaceClient } from '../che-workspace-client';
-import { getAttribute } from '../utils';
 
 /** Contains logic to provide backward compatibility. */
 @injectable()
@@ -61,7 +59,7 @@ export class BackwardCompatibilityResolver {
       return configs;
     }
 
-    const containers = await this.cheWorkspaceClient.getMachines();
+    const containers = await this.cheWorkspaceClient.getComponentStatuses();
     for (const config of configs) {
       if (config.type !== CHE_TASK_TYPE) {
         continue;
@@ -76,14 +74,11 @@ export class BackwardCompatibilityResolver {
       target.containerName = undefined;
       target.component = '';
 
-      if (!containers.hasOwnProperty(containerName)) {
+      const matchingComponent = containers.find(component => component.name === containerName);
+      if (!matchingComponent) {
         continue;
-      }
-
-      const container = containers[containerName];
-      const component = getAttribute(COMPONENT_ATTRIBUTE, container.attributes);
-      if (component) {
-        target.component = component;
+      } else {
+        target.component = matchingComponent.name;
       }
     }
     return configs;

--- a/plugins/task-plugin/src/task/converter.ts
+++ b/plugins/task-plugin/src/task/converter.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,28 +8,23 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-import {
-  CHE_TASK_TYPE,
-  COMPONENT_ALIAS_ATTRIBUTE,
-  PREVIEW_URL_ATTRIBUTE,
-  WORKING_DIR_ATTRIBUTE,
-} from './task-protocol';
+import * as che from '@eclipse-che/plugin';
 
-import { Task } from '@theia/plugin';
+import { CHE_TASK_TYPE, PREVIEW_URL_ATTRIBUTE } from './task-protocol';
+
 import { TaskConfiguration } from '@eclipse-che/plugin';
-import { che as cheApi } from '@eclipse-che/api';
 import { getAttribute } from '../utils';
 
 /** Converts the Che command to Theia Task Configuration */
-export function toTaskConfiguration(command: cheApi.workspace.Command): TaskConfiguration {
+export function toTaskConfiguration(command: che.devfile.DevfileCommand): TaskConfiguration {
   const taskConfig: TaskConfiguration = {
     type: CHE_TASK_TYPE,
-    label: command.name!,
-    command: command.commandLine,
+    label: command.id,
+    command: command.exec?.commandLine,
     _scope: '', // not to put into tasks.json
     target: {
-      workingDir: getAttribute(WORKING_DIR_ATTRIBUTE, command.attributes),
-      component: getAttribute(COMPONENT_ALIAS_ATTRIBUTE, command.attributes),
+      workingDir: command.exec?.workingDir,
+      component: command.exec?.component,
     },
     previewUrl: getAttribute(PREVIEW_URL_ATTRIBUTE, command.attributes),
     problemMatcher: [],
@@ -38,24 +33,7 @@ export function toTaskConfiguration(command: cheApi.workspace.Command): TaskConf
   return taskConfig;
 }
 
-/** Converts the Che command to Task API object */
-export function toTask(command: cheApi.workspace.Command): Task {
-  return {
-    definition: {
-      type: CHE_TASK_TYPE,
-      command: command.commandLine,
-      target: {
-        workingDir: getAttribute(WORKING_DIR_ATTRIBUTE, command.attributes),
-        component: getAttribute(COMPONENT_ALIAS_ATTRIBUTE, command.attributes),
-      },
-      previewUrl: getAttribute(PREVIEW_URL_ATTRIBUTE, command.attributes),
-    },
-    name: `${command.name}`,
-    source: CHE_TASK_TYPE,
-  };
-}
-
-export function getCommandAttribute(command: cheApi.workspace.Command, attrName: string): string | undefined {
+export function getCommandAttribute(command: che.devfile.DevfileCommand, attrName: string): string | undefined {
   if (!command.attributes) {
     return undefined;
   }

--- a/plugins/task-plugin/src/task/task-protocol.ts
+++ b/plugins/task-plugin/src/task/task-protocol.ts
@@ -13,8 +13,6 @@ import { TaskDefinition } from '@theia/plugin';
 export const CHE_TASK_TYPE: string = 'che';
 export const MACHINE_NAME_ATTRIBUTE: string = 'machineName';
 export const PREVIEW_URL_ATTRIBUTE: string = 'previewUrl';
-export const WORKING_DIR_ATTRIBUTE: string = 'workingDir';
-export const COMPONENT_ALIAS_ATTRIBUTE: string = 'componentAlias';
 
 export interface CheTaskDefinition extends TaskDefinition {
   readonly target?: Target;

--- a/plugins/task-plugin/tests/che-workspace-client.spec.ts
+++ b/plugins/task-plugin/tests/che-workspace-client.spec.ts
@@ -1,0 +1,57 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import 'reflect-metadata';
+
+import * as che from '@eclipse-che/plugin';
+import * as theia from '@theia/plugin';
+
+import { CheWorkspaceClient } from '../src/che-workspace-client';
+import { Container } from 'inversify';
+
+describe('Test containers service', () => {
+  const getEndpointsByTypeSpy = jest.spyOn(che.endpoint, 'getEndpointsByType');
+  const createOutputChannelSpy = jest.spyOn(theia.window, 'createOutputChannel');
+
+  let workspaceClient: CheWorkspaceClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+    const outputChannelMock = {
+      appendLine: jest.fn(),
+    };
+    createOutputChannelSpy.mockReturnValue(outputChannelMock as any);
+    const container = new Container();
+    container.bind(CheWorkspaceClient).toSelf().inSingletonScope();
+    workspaceClient = container.get(CheWorkspaceClient);
+  });
+
+  test('Check getMachineExecServerURL', async () => {
+    const exposedEndpoints: che.endpoint.ExposedEndpoint[] = [
+      {
+        name: 'che-machine-exec',
+        component: 'machine-exec',
+        attributes: {
+          type: 'terminal',
+          discoverable: 'false',
+          cookiesAuthEnabled: 'true',
+          port: '4444',
+        },
+      },
+    ];
+    getEndpointsByTypeSpy.mockResolvedValue(exposedEndpoints);
+    const url = await workspaceClient.getMachineExecServerURL();
+    expect(url).toBe('ws://127.0.0.1:4444');
+    expect(getEndpointsByTypeSpy).toBeCalled();
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Switch to devfile 2.0 API instead of using old workspace attributes

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19188

### How to test this PR?
Check tasks are working as expected


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next

Change-Id: Ib64a9a1b8e4f15ffba869e79bfe7aa1aa0a87b00
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
