### PR TITLE
feat(endpoints): Expose endpoint service for plug-ins

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-api-provider.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-api-provider.ts
@@ -11,6 +11,7 @@
 import { injectable, interfaces } from 'inversify';
 
 import { CheDevfileMainImpl } from './che-devfile-main';
+import { CheEndpointMainImpl } from './che-endpoint-main';
 import { CheGithubMainImpl } from './che-github-main';
 import { CheK8SMainImpl } from './che-k8s-main';
 import { CheLanguagesTestAPIImpl } from './che-languages-test-api';
@@ -34,6 +35,7 @@ export class CheApiProvider implements MainPluginApiProvider {
   initialize(rpc: RPCProtocol, container: interfaces.Container): void {
     rpc.set(PLUGIN_RPC_CONTEXT.CHE_WORKSPACE_MAIN, new CheWorkspaceMainImpl(container));
     rpc.set(PLUGIN_RPC_CONTEXT.CHE_DEVFILE_MAIN, new CheDevfileMainImpl(container));
+    rpc.set(PLUGIN_RPC_CONTEXT.CHE_ENDPOINT_MAIN, new CheEndpointMainImpl(container));
     rpc.set(PLUGIN_RPC_CONTEXT.CHE_TELEMETRY_MAIN, new CheTelemetryMainImpl(container, rpc));
     rpc.set(PLUGIN_RPC_CONTEXT.CHE_VARIABLES_MAIN, new CheVariablesMainImpl(container, rpc));
     rpc.set(PLUGIN_RPC_CONTEXT.CHE_TASK_MAIN, new CheTaskMainImpl(container, rpc));

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-endpoint-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-endpoint-main.ts
@@ -1,0 +1,33 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { ComponentExposedEndpoint, ExposedEndpoint } from '@eclipse-che/theia-remote-api/lib/common/endpoint-service';
+
+import { CheEndpointMain } from '../common/che-protocol';
+import { EndpointService } from '@eclipse-che/theia-remote-api/lib/common/endpoint-service';
+import { interfaces } from 'inversify';
+
+export class CheEndpointMainImpl implements CheEndpointMain {
+  private readonly endpointService: EndpointService;
+
+  constructor(container: interfaces.Container) {
+    this.endpointService = container.get(EndpointService);
+  }
+
+  async $getEndpoints(): Promise<ComponentExposedEndpoint[]> {
+    return this.endpointService.getEndpoints();
+  }
+  async $getEndpointsByName(...names: string[]): Promise<ExposedEndpoint[]> {
+    return this.endpointService.getEndpointsByName(...names);
+  }
+  async $getEndpointsByType(type: string): Promise<ExposedEndpoint[]> {
+    return this.endpointService.getEndpointsByType(type);
+  }
+}

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -51,6 +51,14 @@ export interface CheDevfileMain {
   $update(updatedDevfile: che.devfile.Devfile): Promise<void>;
 }
 
+export interface CheEndpoint {}
+
+export interface CheEndpointMain {
+  $getEndpoints(): Promise<che.endpoint.ComponentExposedEndpoint[]>;
+  $getEndpointsByName(...names: string[]): Promise<che.endpoint.ExposedEndpoint[]>;
+  $getEndpointsByType(type: string): Promise<che.endpoint.ExposedEndpoint[]>;
+}
+
 export interface CheSsh {}
 
 export interface CheSshMain {
@@ -415,6 +423,9 @@ export const PLUGIN_RPC_CONTEXT = {
 
   CHE_DEVFILE: createProxyIdentifier<CheDevfile>('CheDevfile'),
   CHE_DEVFILE_MAIN: createProxyIdentifier<CheDevfileMain>('CheDevfileMain'),
+
+  CHE_ENDPOINT: createProxyIdentifier<CheEndpoint>('CheEndpoint'),
+  CHE_ENDPOINT_MAIN: createProxyIdentifier<CheEndpointMain>('CheEndpointMain'),
 
   CHE_TELEMETRY: createProxyIdentifier<CheTelemetry>('CheTelemetry'),
   CHE_TELEMETRY_MAIN: createProxyIdentifier<CheTelemetryMain>('CheTelemetryMain'),

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
@@ -14,6 +14,7 @@ import * as theia from '@theia/plugin';
 import { CheTaskImpl, TaskStatus, TaskTerminallKind } from './che-task-impl';
 
 import { CheDevfileImpl } from './che-devfile';
+import { CheEndpointImpl } from './che-endpoint';
 import { CheGithubImpl } from './che-github';
 import { CheK8SImpl } from './che-k8s';
 import { CheOauthImpl } from './che-oauth';
@@ -41,6 +42,7 @@ export interface CheApiFactory {
 export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
   const cheWorkspaceImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_WORKSPACE, new CheWorkspaceImpl(rpc));
   const cheDevfileImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_DEVFILE, new CheDevfileImpl(rpc));
+  const cheEndpointImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_DEVFILE, new CheEndpointImpl(rpc));
   const cheVariablesImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_VARIABLES, new CheVariablesImpl(rpc));
   const cheTaskImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_TASK, new CheTaskImpl(rpc));
   const cheSshImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_SSH, new CheSshImpl(rpc));
@@ -115,6 +117,18 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
       },
       createWorkspace(devfilePath: string): Promise<void> {
         return cheDevfileImpl.createWorkspace(devfilePath);
+      },
+    };
+
+    const endpoint: typeof che.endpoint = {
+      getEndpoints(): Promise<che.endpoint.ComponentExposedEndpoint[]> {
+        return cheEndpointImpl.getEndpoints();
+      },
+      getEndpointsByName(...names: string[]): Promise<che.endpoint.ExposedEndpoint[]> {
+        return cheEndpointImpl.getEndpointsByName(...names);
+      },
+      getEndpointsByType(type: string): Promise<che.endpoint.ExposedEndpoint[]> {
+        return cheEndpointImpl.getEndpointsByType(type);
       },
     };
 
@@ -424,6 +438,7 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
     return <typeof che>{
       workspace,
       devfile,
+      endpoint,
       variables,
       task,
       ssh,

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-endpoint.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-endpoint.ts
@@ -1,0 +1,33 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { CheEndpoint, CheEndpointMain, PLUGIN_RPC_CONTEXT } from '../common/che-protocol';
+
+import { RPCProtocol } from '@theia/plugin-ext/lib/common/rpc-protocol';
+import { endpoint } from '@eclipse-che/plugin';
+
+export class CheEndpointImpl implements CheEndpoint {
+  private readonly endpointMain: CheEndpointMain;
+
+  constructor(rpc: RPCProtocol) {
+    this.endpointMain = rpc.getProxy(PLUGIN_RPC_CONTEXT.CHE_ENDPOINT_MAIN);
+  }
+
+  async getEndpoints(): Promise<endpoint.ComponentExposedEndpoint[]> {
+    return this.endpointMain.$getEndpoints();
+  }
+  async getEndpointsByName(...names: string[]): Promise<endpoint.ExposedEndpoint[]> {
+    return this.endpointMain.$getEndpointsByName(...names);
+  }
+
+  async getEndpointsByType(type: string): Promise<endpoint.ExposedEndpoint[]> {
+    return this.endpointMain.$getEndpointsByType(type);
+  }
+}

--- a/extensions/eclipse-che-theia-plugin-ext/tests/plugin/che-api.spec.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/tests/plugin/che-api.spec.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { CheApiFactory, createAPIFactory } from '../../src/plugin/che-api';
+import { CheProductService, PLUGIN_RPC_CONTEXT } from '../../src/common/che-protocol';
+import { RPCProtocol, RPCProtocolImpl } from '@theia/plugin-ext/lib/common/rpc-protocol';
+
+import { CheEndpointMainImpl } from '../../src/browser/che-endpoint-main';
+import { CheProductMainImpl } from '../../src/browser/che-product-main';
+import { Container } from 'inversify';
+import { Emitter } from '@theia/core';
+import { EndpointService } from '@eclipse-che/theia-remote-api/lib/common/endpoint-service';
+
+describe('che-api', () => {
+  let rpcClient: RPCProtocol;
+  let rpcServer: RPCProtocol;
+  let cheApiFactory: CheApiFactory;
+  let container: Container;
+  let endpointServiceMock: any;
+  beforeAll(() => {
+    const emitterServer = new Emitter<any>();
+    const emitterClient = new Emitter<any>();
+
+    rpcServer = new RPCProtocolImpl({
+      onMessage: emitterServer.event,
+      send: (message: any) => emitterClient.fire(message),
+    });
+
+    rpcClient = new RPCProtocolImpl({
+      onMessage: emitterClient.event,
+      send: (message: any) => emitterServer.fire(message),
+    });
+
+    endpointServiceMock = {
+      getEndpoints: jest.fn(),
+      getEndpointsByName: jest.fn(),
+      getEndpointsByType: () => [
+        {
+          name: 'machine-exec',
+          component: 'foo',
+        },
+      ],
+    };
+
+    const productServiceMock: CheProductService = {
+      getProduct: jest.fn(),
+    };
+    container = new Container();
+    container.bind(CheProductService).toConstantValue(productServiceMock);
+
+    rpcServer.set(PLUGIN_RPC_CONTEXT.CHE_PRODUCT_MAIN, new CheProductMainImpl(container, rpcServer));
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it('endpoint tests', async () => {
+    const plugin: any = {};
+    container.bind(EndpointService).toConstantValue(endpointServiceMock);
+    rpcServer.set(PLUGIN_RPC_CONTEXT.CHE_ENDPOINT_MAIN, new CheEndpointMainImpl(container));
+    cheApiFactory = createAPIFactory(rpcClient);
+    const apiImpl = cheApiFactory(plugin);
+    const getEndpointsByTypeSpy = jest.spyOn(endpointServiceMock, 'getEndpointsByType');
+    const terminalEndpoints = await apiImpl.endpoint.getEndpointsByType('terminal');
+    expect(getEndpointsByTypeSpy).toBeCalledWith('terminal');
+    expect(terminalEndpoints.length).toBe(1);
+    expect(terminalEndpoints[0].name).toBe('machine-exec');
+  });
+});

--- a/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
+++ b/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
@@ -216,6 +216,25 @@ declare module '@eclipse-che/plugin' {
         export function createWorkspace(devfilePath: string): Promise<void>;
     }
 
+    export namespace endpoint {
+
+        export interface ExposedEndpoint {
+            attributes?: { [key: string]: string };
+            url?: string;
+            name: string;
+            component: string;
+          }
+
+          export interface ComponentExposedEndpoint {
+            name: string;
+            endpoints: ExposedEndpoint[];
+          }
+
+         export function getEndpoints(): Promise<ComponentExposedEndpoint[]>;
+         export function getEndpointsByName(...names: string[]): Promise<ExposedEndpoint[]>;
+         export function getEndpointsByType(type: string): Promise<ExposedEndpoint[]>;
+    }
+
     export interface GithubUser {
         login: string,
         id: number,


### PR DESCRIPTION
### What does this PR do?
Endpoint service was available to extensions but not to plug-ins
Add support for plug-ins

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18874

### How to test this PR?
Add a plug-in using this extension 
FYI I have an example in this PR: https://github.com/eclipse/che-theia/pull/1024

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next
