### PR TITLE
Add a doc on how to include an upstream Theia patch into the Che-Theia release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ To make another bugfix release of Che-Theia with the upstream Theia patch includ
 - create a new branch
 - cherry-pick the required commit sha to the created branch and push the changes
 - update the `build.include` file:
-  - `THEIA_GITHUB_REPO="redhat-developer/codeready-workspaces-theia"`
+  - `THEIA_GITHUB_REPO="redhat-developer/eclipse-theia"`
   - `THEIA_BRANCH="<created-branch-name>"`
   - `THEIA_COMMIT_SHA="<commit-sha>"`
 - push the changes

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,29 @@
-# Eclipse Che-Theia release process
+## Eclipse Che-Theia release process
+See [Release Che-Theia](./.github/workflows/release.yml) workflow.
 
-See [Release Che Theia](./.github/workflows/release.yml) workflow.
+## Bugfix release with the upstream Theia commit included
+To make another bugfix release of Che-Theia with the upstream Theia patch included, there're several options available.
+
+### To include all the commits made before the required patch
+- update the `build.include` file for an interested Che-Theia tag:
+  - `THEIA_COMMIT_SHA="<commit-sha>"`
+- continue the release process as usual
+
+### To include only the required upstream commit
+- clone the Theia fork https://github.com/redhat-developer/codeready-workspaces-theia
+- sync the `master` branch of the forked repository with the origin one and push the changes
+- take the Theia commit sha which was used for an interested Che-Theia release, e.g. for 7.27.x it's [`1110f990`](https://github.com/eclipse/che-theia/blob/7.27.x/build.include#L17)
+- create a branch
+- cherry-pick the required commit sha to the created branch and push the changes
+- update the `build.include` file for an interested Che-Theia tag:
+  - `THEIA_GITHUB_REPO="redhat-developer/codeready-workspaces-theia"`
+  - `THEIA_BRANCH="<created-branch-name>"`
+  - `THEIA_COMMIT_SHA="<commit-sha>"`
+- push the changes
+- continue the release process as usual
+
+### Include a diff file
+It's also possible to use a diff file to patch the Theia while releasing Che-Theia:
+- prepare a `*.patch` file
+- put it into the [`patches`](https://github.com/eclipse/che-theia/tree/master/dockerfiles/theia/src/patches) folder and a sub-folder which name corresponds to the [`THEIA_VERSION`](https://github.com/eclipse/che-theia/blob/7.27.x/build.include#L15) value, e.g. `master`
+- continue the release process as usual

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ To make another bugfix release of Che-Theia with the upstream Theia patch includ
 - continue the release process as usual
 
 ### To include only the required upstream commit
-- clone the Theia fork https://github.com/redhat-developer/codeready-workspaces-theia
+- clone the Theia fork https://github.com/redhat-developer/eclipse-theia
 - sync the `master` branch of the forked repository with the origin one and push the changes
 - take the Theia commit sha which was used for an interested Che-Theia release, e.g. for 7.27.x it's [`1110f990`](https://github.com/eclipse/che-theia/blob/7.27.x/build.include#L17)
 - create a branch

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@ See [Release Che-Theia](./.github/workflows/release.yml) workflow.
 To make another bugfix release of Che-Theia with the upstream Theia patch included, there're several options available.
 
 ### To include all the commits made before the required patch
-- update the `build.include` file for an interested Che-Theia tag:
+- update the `build.include` file to match upstream Eclipse Theia revision:
   - `THEIA_COMMIT_SHA="<commit-sha>"`
 - continue the release process as usual
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@ See [Release Che-Theia](./.github/workflows/release.yml) workflow.
 To make another bugfix release of Che-Theia with the upstream Theia patch included, there're several options available.
 
 ### To include all the commits made before the required patch
+- switch to the required Che-Theia tag, e.g. [7.27.x](https://github.com/eclipse/che-theia/blob/7.27.x)
 - update the `build.include` file to match upstream Eclipse Theia revision:
   - `THEIA_COMMIT_SHA="<commit-sha>"`
 - continue the release process as usual
@@ -12,10 +13,10 @@ To make another bugfix release of Che-Theia with the upstream Theia patch includ
 ### To include only the required upstream commit
 - clone the Theia fork https://github.com/redhat-developer/eclipse-theia
 - sync the `master` branch of the forked repository with the origin one and push the changes
-- take the Theia commit sha which was used for an interested Che-Theia release, e.g. for 7.27.x it's [`1110f990`](https://github.com/eclipse/che-theia/blob/7.27.x/build.include#L17)
-- create a branch
+- take the Theia commit sha which was used for a Che-Theia release, e.g. for 7.27.x it's [`1110f990`](https://github.com/eclipse/che-theia/blob/7.27.x/build.include#L17)
+- create a new branch
 - cherry-pick the required commit sha to the created branch and push the changes
-- update the `build.include` file for an interested Che-Theia tag:
+- update the `build.include` file:
   - `THEIA_GITHUB_REPO="redhat-developer/codeready-workspaces-theia"`
   - `THEIA_BRANCH="<created-branch-name>"`
   - `THEIA_COMMIT_SHA="<commit-sha>"`


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds a doc on how to include an upstream Theia patch into the Che-Theia release.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
closes https://github.com/eclipse/che/issues/19141, https://issues.redhat.com/browse/RHDEVDOCS-2741

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
