### PR TITLE
Don't use cached url in the local storage to connect to the terminal server

### DIFF
--- a/extensions/eclipse-che-theia-terminal/src/browser/server-definition/terminal-proxy-creator.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/server-definition/terminal-proxy-creator.ts
@@ -43,4 +43,8 @@ export class TerminalProxyCreator {
     }
     return this.remoteTermServer;
   }
+
+  getApiEndPointUrl(): URI | undefined {
+    return this.apiEndPoint;
+  }
 }


### PR DESCRIPTION
### What does this PR do?
Don't use cached url in the local storage to connect to the terminal server

### Referenced issues:
https://github.com/eclipse/che/issues/16593
https://github.com/eclipse/che/issues/19201

### Screenshot/screencast of this PR


### How to test this PR?
On the minikube:
  - start any workspace
  - open new terminal
  - stop workspace
  - start workspace again
Expected result: che-theia should restore previously opened terminal.
Fixed bug: che-theia opened empty terminal and refresh browser page doesn't help. Helps only clean up local storage of the browser page...

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
