### PR TITLE
feat(terminal): Use collocated terminal instead of terminal

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/tests/plugin/che-api.spec.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/tests/plugin/che-api.spec.ts
@@ -73,8 +73,8 @@ describe('che-api', () => {
     cheApiFactory = createAPIFactory(rpcClient);
     const apiImpl = cheApiFactory(plugin);
     const getEndpointsByTypeSpy = jest.spyOn(endpointServiceMock, 'getEndpointsByType');
-    const terminalEndpoints = await apiImpl.endpoint.getEndpointsByType('terminal');
-    expect(getEndpointsByTypeSpy).toBeCalledWith('terminal');
+    const terminalEndpoints = await apiImpl.endpoint.getEndpointsByType('collocated-terminal');
+    expect(getEndpointsByTypeSpy).toBeCalledWith('collocated-terminal');
     expect(terminalEndpoints.length).toBe(1);
     expect(terminalEndpoints[0].name).toBe('machine-exec');
   });

--- a/extensions/eclipse-che-theia-remote-impl-k8s/package.json
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/package.json
@@ -16,7 +16,7 @@
     "@eclipse-che/theia-remote-api": "^0.0.1"
   },
   "scripts": {
-    "prepare": "yarn clean && yarn build",
+    "prepare": "yarn clean && yarn build && yarn test",
     "clean": "rimraf lib",
     "format": "if-env SKIP_FORMAT=true && echo 'skip format check' || prettier --check '{src,tests}/**/*.ts' package.json",
     "format:fix": "prettier --write '{src,tests}/**/*.ts' package.json",

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/get-devworkspace-response-body.json
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/get-devworkspace-response-body.json
@@ -143,7 +143,7 @@
                 {
                   "attributes": {
                     "cookiesAuthEnabled": "true",
-                    "type": "terminal"
+                    "type": "collocated-terminal"
                   },
                   "exposure": "public",
                   "name": "che-mach-exec",

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/node/k8s-devfile-service-impl.spec.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/node/k8s-devfile-service-impl.spec.ts
@@ -154,6 +154,6 @@ describe('Test K8sDevfileServiceImpl', () => {
     const theiaComponent = componentStatuses.find(component => component.name === 'theia-ide');
     expect(theiaComponent).toBeDefined();
     const theiaEndpoints = theiaComponent?.endpoints || {};
-    expect(theiaEndpoints['theia']?.url).toBe('http://workspaceeb55021d3cff42e0-theia-3100.192.168.64.31.nip.io');
+    expect(theiaEndpoints['theia']?.url).toBe('http://workspace79f69b51a4e24714-theia-3100.192.168.64.46.nip.io');
   });
 });

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/node/k8s-endpoint-service-impl.spec.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/node/k8s-endpoint-service-impl.spec.ts
@@ -49,7 +49,7 @@ describe.only('Test K8sEndpointServiceImpl', () => {
     const ideEndpoint = ideEndpoints[0];
 
     expect(ideEndpoint.name).toBe('theia');
-    expect(ideEndpoint.url).toBe('http://workspaceeb55021d3cff42e0-theia-3100.192.168.64.31.nip.io');
+    expect(ideEndpoint.url).toBe('http://workspace79f69b51a4e24714-theia-3100.192.168.64.46.nip.io');
     expect(ideEndpoint.component).toBe('theia-ide');
   });
 
@@ -61,7 +61,7 @@ describe.only('Test K8sEndpointServiceImpl', () => {
     const ideEndpoint = ideEndpoints[0];
 
     expect(ideEndpoint.name).toBe('theia');
-    expect(ideEndpoint.url).toBe('http://workspaceeb55021d3cff42e0-theia-3100.192.168.64.31.nip.io');
+    expect(ideEndpoint.url).toBe('http://workspace79f69b51a4e24714-theia-3100.192.168.64.46.nip.io');
     expect(ideEndpoint.component).toBe('theia-ide');
   });
 });

--- a/extensions/eclipse-che-theia-terminal/src/browser/server-definition/remote-terminal-protocol.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/server-definition/remote-terminal-protocol.ts
@@ -13,7 +13,7 @@ import { Emitter, Event } from '@theia/core/lib/common/event';
 import { JsonRpcProxy } from '@theia/core';
 import { injectable } from 'inversify';
 
-export const TERMINAL_SERVER_TYPE = 'terminal';
+export const TERMINAL_SERVER_TYPE = 'collocated-terminal';
 export const CONNECT_TERMINAL_SEGMENT = 'connect';
 export const ATTACH_TERMINAL_SEGMENT = 'attach';
 

--- a/extensions/eclipse-che-theia-terminal/src/browser/terminal-frontend-module.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/terminal-frontend-module.ts
@@ -103,7 +103,7 @@ export default new ContainerModule(
 
         const endpointService = context.container.get<EndpointService>(EndpointService);
         const envServer = context.container.get<EnvVariablesServer>(EnvVariablesServer);
-        const terminalComponents = await endpointService.getEndpointsByType('terminal');
+        const terminalComponents = await endpointService.getEndpointsByType('collocated-terminal');
         if (terminalComponents.length !== 1) {
           console.error(
             'Failed to get remote terminal server api end point url. Cause: Found ${terminalComponents} components (should only have one)'

--- a/plugins/task-plugin/src/che-workspace-client.ts
+++ b/plugins/task-plugin/src/che-workspace-client.ts
@@ -13,7 +13,7 @@ import * as che from '@eclipse-che/plugin';
 import { che as cheApi } from '@eclipse-che/api';
 import { injectable } from 'inversify';
 
-const TERMINAL_SERVER_TYPE = 'terminal';
+const TERMINAL_SERVER_TYPE = 'collocated-terminal';
 
 export interface WorkspaceContainer extends che.devfile.DevfileComponentStatus {}
 

--- a/plugins/task-plugin/tests/che-workspace-client.spec.ts
+++ b/plugins/task-plugin/tests/che-workspace-client.spec.ts
@@ -42,7 +42,7 @@ describe('Test containers service', () => {
         name: 'che-machine-exec',
         component: 'machine-exec',
         attributes: {
-          type: 'terminal',
+          type: 'collocated-terminal',
           discoverable: 'false',
           cookiesAuthEnabled: 'true',
           port: '4444',


### PR DESCRIPTION
### What does this PR do?
Use the collocated-terminal definition (machine-exec component provided in che-theia component definition) instead of terminal that is currently provided by default by che-server property

on a side note, I noticed that the tests were not executed on this module, so I turn it on in package.json.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19215

### How to test this PR?
Check terminal and tasks are working as before
in che it's more difficult to remove default terminal to see what is happening when default machine-exec is not there
in devworkspace mode, update flattened-theia-next.yaml (or see it doesn't work in that mode)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next


Change-Id: I31f58bb9400e6c3b25d0a428ad38c0f0be7733a0
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
