### PR TITLE
Multi-root by default for Dev Workspaces

### DIFF
--- a/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
+++ b/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
@@ -56,6 +56,8 @@ export class CheWorkspaceServer extends DefaultWorkspaceServer {
 }
 
 function isMultiRoot(workspace: Workspace): boolean {
-  const devfile = workspace.devfile;
-  return !!devfile && !!devfile.attributes && !!devfile.attributes.multiRoot && devfile.attributes.multiRoot === 'on';
+  // the multi-root mode is ON by default for DevWorkspace
+  // 'workspace.runtime' is 'undefined' in the case of DevWorkspace
+  // the check for 'workspace.runtime' will be removed soon as we are going to turn on multi-root mode by default
+  return !workspace.runtime || workspace.devfile?.attributes?.multiRoot === 'on';
 }

--- a/plugins/workspace-plugin/src/workspace-projects-manager.ts
+++ b/plugins/workspace-plugin/src/workspace-projects-manager.ts
@@ -44,11 +44,22 @@ export class WorkspaceProjectsManager {
 
   async run(): Promise<void> {
     const devfile = await che.devfile.get();
+
     this.outputChannel.appendLine(`Found devfile ${JSON.stringify(devfile, undefined, 2)}`);
+
     const cloneCommandList = await this.buildCloneCommands(devfile.projects || []);
+
     this.outputChannel.appendLine(`Clone commands are ${JSON.stringify(cloneCommandList, undefined, 2)}`);
-    const isMultiRoot = devfile.metadata?.attributes?.multiRoot === 'on';
+
+    const workspace = await che.workspace.getCurrentWorkspace();
+
+    // the multi-root mode is ON by default for DevWorkspace
+    // 'workspace.runtime' is 'undefined' in the case of DevWorkspace
+    // the check for 'workspace.runtime' will be removed soon as we are going to turn on multi-root mode by default
+    const isMultiRoot = !workspace.runtime || devfile.metadata?.attributes?.multiRoot === 'on';
+
     this.outputChannel.appendLine(`multi root is ${isMultiRoot}`);
+
     const cloningPromise = this.executeCloneCommands(cloneCommandList, isMultiRoot);
     theia.window.withProgress({ location: { viewId: 'explorer' } }, () => cloningPromise);
     await cloningPromise;


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Enable multi-root by default for Dev Workspaces

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19191

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
