### PR TITLE
Filter items when reading /public-certs directory

### DIFF
--- a/plugins/workspace-plugin/src/ca-cert.ts
+++ b/plugins/workspace-plugin/src/ca-cert.ts
@@ -47,7 +47,9 @@ export const getCertificate = new Promise<string | undefined>(async resolve => {
     const publicCertificates = await fs.readdir(PUBLIC_CRT_PATH);
     for (const publicCertificate of publicCertificates) {
       const certPath = path.join(PUBLIC_CRT_PATH, publicCertificate);
-      certificates.push(await fs.readFile(certPath));
+      if ((await fs.pathExists(certPath)) && (await fs.stat(certPath)).isFile()) {
+        certificates.push(await fs.readFile(certPath));
+      }
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
When workspace plugin reads items from `/public-certs` directory, it gets not only files, but directories as well.
It was working before, because names of items checked for `.crt` suffix. The verification was removed by https://github.com/eclipse/che-theia/pull/1038 to operate with certificates, that have any extension (not only `.crt`, `.pem`, ...).

This PR adds a check to take into account only files.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Screenshot from 2021-03-24 12-35-31](https://user-images.githubusercontent.com/1655894/112297427-8f30e600-8c9e-11eb-88d0-810ef1f6630d.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
- https://github.com/eclipse/che/issues/19377
- https://github.com/eclipse/che/issues/19309

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. On `Get Started Page` switch to `Custom Workspace`, select a devfile template (e.g. Go)
2. Add following editor to the components to replace the default one
```
  - type: cheEditor
    alias: che-theia
    reference: https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-1046/che_theia_meta.yaml
    memoryLimit: 1Gi
```
3. Create a workspace and check for projects

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
