### PR TITLE
Enable Che-Theia multi-root mode by default for all workspaces

### DIFF
--- a/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
+++ b/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
@@ -11,11 +11,11 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
-import { Workspace, WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
 import { inject, injectable } from 'inversify';
 
 import { DefaultWorkspaceServer } from '@theia/workspace/lib/node/default-workspace-server';
 import { FileUri } from '@theia/core/lib/node';
+import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
 
 interface TheiaWorkspace {
   folders: TheiaWorkspacePath[];
@@ -34,7 +34,7 @@ export class CheWorkspaceServer extends DefaultWorkspaceServer {
   // if not possible, use default method
   protected async getRoot(): Promise<string | undefined> {
     const workspace = await this.workspaceService.currentWorkspace();
-    if (!isMultiRoot(workspace)) {
+    if (workspace.devfile?.attributes?.multiRoot === 'off') {
       return super.getRoot();
     }
 
@@ -53,11 +53,4 @@ export class CheWorkspaceServer extends DefaultWorkspaceServer {
 
     return cheTheiaWorkspaceFileUri.toString();
   }
-}
-
-function isMultiRoot(workspace: Workspace): boolean {
-  // the multi-root mode is ON by default for DevWorkspace
-  // 'workspace.runtime' is 'undefined' in the case of DevWorkspace
-  // the check for 'workspace.runtime' will be removed soon as we are going to turn on multi-root mode by default
-  return !workspace.runtime || workspace.devfile?.attributes?.multiRoot === 'on';
 }

--- a/plugins/workspace-plugin/src/workspace-projects-manager.ts
+++ b/plugins/workspace-plugin/src/workspace-projects-manager.ts
@@ -51,12 +51,7 @@ export class WorkspaceProjectsManager {
 
     this.outputChannel.appendLine(`Clone commands are ${JSON.stringify(cloneCommandList, undefined, 2)}`);
 
-    const workspace = await che.workspace.getCurrentWorkspace();
-
-    // the multi-root mode is ON by default for DevWorkspace
-    // 'workspace.runtime' is 'undefined' in the case of DevWorkspace
-    // the check for 'workspace.runtime' will be removed soon as we are going to turn on multi-root mode by default
-    const isMultiRoot = !workspace.runtime || devfile.metadata?.attributes?.multiRoot === 'on';
+    const isMultiRoot = devfile.metadata?.attributes?.multiRoot !== 'off';
 
     this.outputChannel.appendLine(`multi root is ${isMultiRoot}`);
 


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

**Notice:** The changes should be merged together with https://github.com/eclipse/che/pull/19406

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
The changes turn on the Multi-root mode by default for all workspaces.
It's possible to turn off the Multi-root mode by providing the corresponding value for `multiRoot` attribute:

```
attributes:
  multiRoot: 'off'

 ```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
Multi-root is `off`:
![multi-root-off](https://user-images.githubusercontent.com/5676062/112598820-cb3b8680-8e17-11eb-8fcf-897c57e79bc3.png)

Multi-root is `on`:
![multi-root-on](https://user-images.githubusercontent.com/5676062/112598888-de4e5680-8e17-11eb-8573-fefdb345f37c.png)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19389

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Start a workspace and check that the workspace has started in `Multi-root` mode by default.
2. Add the following to your devfile:
```
attributes:
  multiRoot: 'off'

 ```
3. Start the workspace and check that the `Multi-root` mode is off.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next
