### PR TITLE
chore: initialize workspace properly if git repository does not contain .vscode/extensions.json

### DIFF
--- a/tools/devworkspace-handler/src/devfile/che-theia-plugins-devfile-resolver.ts
+++ b/tools/devworkspace-handler/src/devfile/che-theia-plugins-devfile-resolver.ts
@@ -58,8 +58,10 @@ export class CheTheiaPluginsDevfileResolver implements DevfileResolver {
       cheTheiaPluginsYamlContent = devfileContext.devfile.attributes?.['.che/che-theia-plugins.yaml'];
     }
 
-    // no content, skip
+    // no content
     if (!cheTheiaPluginsYamlContent && !vscodeExtensionJsonContent) {
+      // we have to update the workspace anyway, but without extensions
+      await this.devWorkspaceUpdater.update(devfileContext, [], [], { extensions: [] });
       return;
     }
 

--- a/tools/devworkspace-handler/tests/devfile/che-theia-plugins-devfile-resolver.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/che-theia-plugins-devfile-resolver.spec.ts
@@ -492,7 +492,7 @@ describe('Test CheTheiaPluginsDevfileResolver', () => {
     expect(cheTheiaPluginSidecarMergerMergeSpy).toBeCalledTimes(0);
     expect(cheTheiaPluginDevContainerMergerMergeSpy).toBeCalledTimes(0);
 
-    // no update
-    expect(devWorkspaceUpdaterUpdateMethod).toBeCalledTimes(0);
+    // devWorkspace should be updated
+    expect(devWorkspaceUpdaterUpdateMethod).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Initializes devWorkspace with empty extension list to be able to add extensions on demand.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Screenshot from 2022-06-08 18-17-29](https://user-images.githubusercontent.com/1655894/172653960-62d70ee8-42a9-4cd4-963c-f9bc581452de.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21422

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

Following flow to test on local minikube deployment:

- clone `che-theia`, run `yarn`
- clone `che-dashboard`, run `yarn` to install dependencies
- overwrite `che-dashboard/node_modules/@eclipse-che/che-theia-devworkspace-handler/lib` with `che-theia/tools/devworkspace-handler/lib`
- go to `che-dashboard/packages/dashboard-frontend`, run `yarn build`
- go to `che-dashboard`, run
```
yarn start:prepare
yarn start
```
- open browser, navigate to http://localhost:8080/
- use factory to create workspace with https://github.com/crw-samples/web-nodejs-sample/tree/che-qe-no-extensions
- go to Plugins view, install few plugins
- apply changes

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
